### PR TITLE
base64-encode cursors for gorm-based pagination

### DIFF
--- a/server/gorm/iterator.go
+++ b/server/gorm/iterator.go
@@ -15,6 +15,7 @@
 package gorm
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/apigee/registry/server/models"
@@ -32,7 +33,8 @@ type Iterator struct {
 
 // GetCursor gets the cursor for the next page of results.
 func (it *Iterator) GetCursor(l int) (string, error) {
-	return it.Cursor, nil
+	encodedCursor := base64.StdEncoding.EncodeToString([]byte(it.Cursor))
+	return encodedCursor, nil
 }
 
 // Next gets the next value from the iterator.

--- a/server/gorm/query.go
+++ b/server/gorm/query.go
@@ -15,6 +15,7 @@
 package gorm
 
 import (
+	"encoding/base64"
 	"log"
 
 	"github.com/apigee/registry/server/storage"
@@ -86,7 +87,11 @@ func (q *Query) Order(value string) storage.Query {
 }
 
 // ApplyCursor configures a query to start from a specified cursor.
-func (q *Query) ApplyCursor(cursorStr string) (storage.Query, error) {
-	q.Cursor = cursorStr
+func (q *Query) ApplyCursor(encodedCursor string) (storage.Query, error) {
+	decodedCursor, err := base64.StdEncoding.DecodeString(encodedCursor)
+	if err != nil {
+		return q, err
+	}
+	q.Cursor = string(decodedCursor)
 	return q, nil
 }


### PR DESCRIPTION
gorm cursors are object primary keys, which are currently the objects' resource names.

here we obscure this by base64-encoding cursors outside of the gorm package.