### PR TITLE
Experimental support for filtering APIs by label

### DIFF
--- a/server/filters.go
+++ b/server/filters.go
@@ -25,9 +25,10 @@ import (
 type filterArgType int
 
 const (
-	filterArgTypeString    filterArgType = iota
-	filterArgTypeInt                     = iota
-	filterArgTypeTimestamp               = iota
+	filterArgTypeString      filterArgType = iota
+	filterArgTypeInt                       = iota
+	filterArgTypeTimestamp                 = iota
+	filterArgTypeStringArray               = iota
 )
 
 type filterArg struct {
@@ -48,6 +49,8 @@ func createFilterOperator(filter string, args []filterArg) (cel.Program, error) 
 			dd = append(dd, decls.NewIdent(pair.argName, decls.Int, nil))
 		case filterArgTypeTimestamp:
 			dd = append(dd, decls.NewIdent(pair.argName, decls.Timestamp, nil))
+		case filterArgTypeStringArray:
+			dd = append(dd, decls.NewIdent(pair.argName, decls.NewListType(decls.String), nil))
 		default:
 			log.Fatalf("unknown filter argument type")
 		}


### PR DESCRIPTION
This adds experimental code that adds a "labels" list to filtered objects when the "in labels" string is included in the CEL filter passd to a ListApis call. This allows label values to be used in filter strings, e.g.

```
registry list projects/$PROJECTID/apis --filter '$LABEL' in labels"
```

WARNING: this implementation is very slow so this feature should only be used on small API collections.