### PR TITLE
Fix the patching in tools/COMPILE-PROTOS.sh for recent protoc versions

### DIFF
--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -86,6 +86,9 @@ protoc --proto_path=. --proto_path=${ANNOTATIONS} \
 sed -i -e 's/anypb.Property_MessageValue/rpcpb.Property_MessageValue/g' \
 	cmd/apg/create-property.go \
 	cmd/apg/update-property.go
+sed -i -e 's/anypbpb.Property_MessageValue/rpcpb.Property_MessageValue/g' \
+	cmd/apg/create-property.go \
+	cmd/apg/update-property.go
 
 echo "Generating descriptor set for Envoy gRPC-JSON Transcoding."
 protoc --proto_path=. --proto_path=${ANNOTATIONS} \


### PR DESCRIPTION
This fixes a problem observed with recent versions of protoc (3.14.0
and possibly 3.13.X). Code in tools/COMPILE-PROTOS.sh "manually"
patches generated code to fix a problem in the automatic CLI generator.

This should be removed when that problem is fixed. We'll need
to file an issue on github.com/googleapis/gapic-generator-go.