### PR TITLE
Increase portability of proto compilation script

### DIFF
--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -27,6 +27,9 @@ go get -u github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
 go get -u github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_cli
 go get -u github.com/googleapis/api-linter/cmd/api-linter
 
+# add installed dependencies to PATH in case they aren't already
+export PATH=$PATH:$(go env GOBIN):$(go env GOPATH)/bin
+
 echo "Clearing any previously-generated files."
 rm -rf rpc/*.go gapic/*.go cmd/apg/*.go
 mkdir -p rpc gapic cmd/apg
@@ -83,12 +86,13 @@ protoc --proto_path=. --proto_path=${ANNOTATIONS} \
   	--go_cli_opt "gapic=github.com/apigee/registry/gapic"
 
 # fix a problem in a couple of generated CLI files
-sed -i -e 's/anypb.Property_MessageValue/rpcpb.Property_MessageValue/g' \
+sed -i.bk -e 's/anypb.Property_MessageValue/rpcpb.Property_MessageValue/g' \
 	cmd/apg/create-property.go \
 	cmd/apg/update-property.go
-sed -i -e 's/anypbpb.Property_MessageValue/rpcpb.Property_MessageValue/g' \
+sed -i.bk -e 's/anypbpb.Property_MessageValue/rpcpb.Property_MessageValue/g' \
 	cmd/apg/create-property.go \
 	cmd/apg/update-property.go
+rm cmd/apg/create-property.go.bk cmd/apg/update-property.go.bk
 
 echo "Generating descriptor set for Envoy gRPC-JSON Transcoding."
 protoc --proto_path=. --proto_path=${ANNOTATIONS} \


### PR DESCRIPTION
The COMPILE-PROTOS.sh setup script fails when dependencies are installed
to a Go bin directory that isn't accessible by the script (and the
programs it calls). This commit gives the script access to either the
custom or default Go bin directory in case it isn't already accessible.

The script also uses `sed` for string replacement in some files, but the
command behaves differently on the BSD and GNU versions of `sed`. When
the BSD version is used (e.g. on MacOS), then `sed -i -e ...` is
equivalent to `sed -i=-e ...`. When the GNU version is used, then `sed
-i -e ...` considers `-i` and `-e` as separate flags. This commit
updates the `sed` commands to have consistent behavior on BSD and GNU
versions of `sed`.