### PR TITLE
Add support for the Spectral linter and more generalized linting.

### DIFF
--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -84,7 +84,11 @@ type computeLintTask struct {
 }
 
 func (task *computeLintTask) Name() string {
-	return "compute " + task.specName + "/lint-" + task.linter
+	return fmt.Sprintf("compute %s/lint-%s", task.specName, task.linter)
+}
+
+func lintRelation(linter string) string {
+	return "lint-" + linter
 }
 
 func (task *computeLintTask) Run() error {
@@ -103,7 +107,7 @@ func (task *computeLintTask) Run() error {
 		if task.linter == "" {
 			task.linter = "gnostic"
 		}
-		relation = "lint-" + task.linter
+		relation = lintRelation(task.linter)
 		log.Printf("computing %s/properties/%s", spec.Name, relation)
 		lint, err = core.NewLintFromOpenAPI(spec.Name, spec.GetContents(), task.linter)
 		if err != nil {
@@ -116,7 +120,7 @@ func (task *computeLintTask) Run() error {
 		if task.linter == "" {
 			task.linter = "aip"
 		}
-		relation = "lint-" + task.linter
+		relation = lintRelation(task.linter)
 		log.Printf("computing %s/properties/%s", spec.Name, relation)
 		lint, err = core.NewLintFromZippedProtos(spec.Name, spec.GetContents())
 		if err != nil {

--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -84,7 +84,7 @@ type computeLintTask struct {
 }
 
 func (task *computeLintTask) Name() string {
-	return "compute " + task.linter + " lint" + task.specName
+	return "compute " + task.specName + "/lint-" + task.linter
 }
 
 func (task *computeLintTask) Run() error {

--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -31,7 +31,7 @@ import (
 
 func init() {
 	computeCmd.AddCommand(computeLintCmd)
-	computeLintCmd.Flags().String("linter", "", "name of linter to use (api-linter, spectral, gnostic)")
+	computeLintCmd.Flags().String("linter", "", "name of linter to use (aip, spectral, gnostic)")
 }
 
 var computeLintCmd = &cobra.Command{

--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -31,6 +31,7 @@ import (
 
 func init() {
 	computeCmd.AddCommand(computeLintCmd)
+	computeLintCmd.Flags().String("linter", "", "name of linter to use (api-linter, spectral, gnostic)")
 }
 
 var computeLintCmd = &cobra.Command{
@@ -38,6 +39,10 @@ var computeLintCmd = &cobra.Command{
 	Short: "Compute lint results for API specs",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		linter, err := cmd.LocalFlags().GetString("linter")
+		if err != nil { // ifnore errors
+			linter = ""
+		}
 		ctx := context.TODO()
 		client, err := connection.NewClient(ctx)
 		if err != nil {
@@ -59,6 +64,7 @@ var computeLintCmd = &cobra.Command{
 					ctx:      ctx,
 					client:   client,
 					specName: spec.Name,
+					linter:   linter,
 				}
 			})
 			if err != nil {
@@ -74,10 +80,11 @@ type computeLintTask struct {
 	ctx      context.Context
 	client   connection.Client
 	specName string
+	linter   string
 }
 
 func (task *computeLintTask) Name() string {
-	return "compute lint " + task.specName
+	return "compute " + task.linter + " lint" + task.specName
 }
 
 func (task *computeLintTask) Run() error {
@@ -89,17 +96,28 @@ func (task *computeLintTask) Run() error {
 	if err != nil {
 		return err
 	}
-	relation := "lint"
-	log.Printf("computing %s/properties/%s", spec.Name, relation)
+	var relation string
 	var lint *rpc.Lint
 	if strings.HasPrefix(spec.GetStyle(), "openapi") {
-		lint, err = core.NewLintFromOpenAPI(spec.Name, spec.GetContents())
+		// the default openapi linter is gnostic
+		if task.linter == "" {
+			task.linter = "gnostic"
+		}
+		relation = "lint-" + task.linter
+		log.Printf("computing %s/properties/%s", spec.Name, relation)
+		lint, err = core.NewLintFromOpenAPI(spec.Name, spec.GetContents(), task.linter)
 		if err != nil {
 			return fmt.Errorf("error processing OpenAPI: %s (%s)", spec.Name, err.Error())
 		}
 	} else if strings.HasPrefix(spec.GetStyle(), "discovery") {
 		return fmt.Errorf("unsupported Discovery document: %s", spec.Name)
 	} else if spec.GetStyle() == "proto+zip" {
+		// the default proto linter is the aip linter
+		if task.linter == "" {
+			task.linter = "aip"
+		}
+		relation = "lint-" + task.linter
+		log.Printf("computing %s/properties/%s", spec.Name, relation)
 		lint, err = core.NewLintFromZippedProtos(spec.Name, spec.GetContents())
 		if err != nil {
 			return fmt.Errorf("error processing protos: %s (%s)", spec.Name, err.Error())

--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -40,7 +40,7 @@ var computeLintCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		linter, err := cmd.LocalFlags().GetString("linter")
-		if err != nil { // ifnore errors
+		if err != nil { // ignore errors
 			linter = ""
 		}
 		ctx := context.TODO()

--- a/cmd/registry/cmd/compute-lintstats.go
+++ b/cmd/registry/cmd/compute-lintstats.go
@@ -34,19 +34,20 @@ func init() {
 	computeLintStatsCmd.Flags().String("linter", "", "name of linter associated with these lintstats (aip, spectral, gnostic)")
 }
 
+func lintStatsRelation(linter string) string {
+	return "lintstats-" + linter
+}
+
 var computeLintStatsCmd = &cobra.Command{
 	Use:   "lintstats",
 	Short: "Compute summaries of linter runs",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		linter, err := cmd.LocalFlags().GetString("linter")
-		if err != nil { // ignore errors
-			linter = ""
-		}
-		if linter == "" {
+		if err != nil || linter == "" {
 			log.Fatalf("Please specify a linter with the --linter flag")
 		}
-		linterSuffix := "-" + linter
+
 		ctx := context.TODO()
 		client, err := connection.NewClient(ctx)
 		if err != nil {
@@ -61,7 +62,7 @@ var computeLintStatsCmd = &cobra.Command{
 				fmt.Printf("%s\n", spec.Name)
 				// get the lint results
 				request := rpc.GetPropertyRequest{
-					Name: spec.Name + "/properties/lint" + linterSuffix,
+					Name: spec.Name + "/properties/" + lintRelation(linter),
 					View: rpc.View_FULL,
 				}
 				property, err := client.GetProperty(ctx, &request)
@@ -86,7 +87,7 @@ var computeLintStatsCmd = &cobra.Command{
 				{
 					// store the lintstats property
 					subject := spec.GetName()
-					relation := "lintstats" + linterSuffix
+					relation := lintStatsRelation(linter)
 					messageData, err := proto.Marshal(lintStats)
 					property := &rpc.Property{
 						Subject:  subject,
@@ -116,7 +117,7 @@ var computeLintStatsCmd = &cobra.Command{
 				// Create a top-level list of problem counts for the project
 				problemCounts := make([]*rpc.LintProblemCount, 0)
 				// get the lintstats for each spec in the project
-				pattern := project.Name + "/apis/-/versions/-/specs/-/properties/lintstats" + linterSuffix
+				pattern := project.Name + "/apis/-/versions/-/specs/-/properties/" + lintStatsRelation(linter)
 				if m2 := names.PropertyRegexp().FindStringSubmatch(pattern); m2 != nil {
 					err = core.ListProperties(ctx, client, m2, "", true, func(property *rpc.Property) {
 						log.Printf("%+v", property.Name)
@@ -147,7 +148,7 @@ var computeLintStatsCmd = &cobra.Command{
 				{
 					// store the lintstats property
 					subject := project.GetName()
-					relation := "lintstats" + linterSuffix
+					relation := lintStatsRelation(linter)
 					messageData, err := proto.Marshal(lintstats)
 					property := &rpc.Property{
 						Subject:  subject,

--- a/cmd/registry/core/lint-openapi-gnostic.go
+++ b/cmd/registry/core/lint-openapi-gnostic.go
@@ -1,0 +1,121 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/apigee/registry/rpc"
+	linter "github.com/googleapis/gnostic/metrics/lint"
+	"google.golang.org/protobuf/proto"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func lintFileForOpenAPIWithGnostic(path string, root string) (*rpc.LintFile, error) {
+	cmd := exec.Command("gnostic", path, "--linter-out=.")
+	cmd.Dir = root
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadFile(filepath.Join(root, "/linter.pb"))
+	if err != nil {
+		return nil, err
+	}
+	output := &linter.Linter{}
+	if err := proto.Unmarshal(b, output); err != nil {
+		return nil, err
+	}
+	nodeFinder, err := newNodeFinder(filepath.Join(root, path))
+	if err != nil {
+		return nil, err
+	}
+	problems := make([]*rpc.LintProblem, 0)
+	for _, message := range output.Messages {
+		problem := &rpc.LintProblem{
+			Message:    message.Message,
+			Suggestion: message.Suggestion,
+		}
+		node, err := nodeFinder.findNode(message.Keys)
+		if err == nil {
+			l := int32(node.Line)
+			c := int32(node.Column)
+			problem.Location = &rpc.LintLocation{
+				StartPosition: &rpc.LintPosition{
+					LineNumber:   l,
+					ColumnNumber: c,
+				},
+				EndPosition: &rpc.LintPosition{
+					LineNumber:   l,
+					ColumnNumber: c + int32(len(node.Value)-1),
+				},
+			}
+		}
+		problems = append(problems, problem)
+	}
+	result := &rpc.LintFile{Problems: problems}
+	return result, nil
+}
+
+type nodeFinder struct {
+	node *yaml.Node
+}
+
+func newNodeFinder(filename string) (*nodeFinder, error) {
+	data, _ := ioutil.ReadFile(filename)
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return nil, err
+	}
+	return &nodeFinder{node: &node}, nil
+}
+
+// FindNode returns a node object pointing to the given token in a yaml file. The node contains
+// information such as the string value, line number, bordering commments, etc.
+func (nf *nodeFinder) findNode(keys []string) (*yaml.Node, error) {
+	return findNode(nf.node.Content[0], 0, len(keys)-1, keys)
+}
+
+// findNode recursively iterates through the yaml file using the node feature. The function
+// will continue until the token is found at the max depth. If the token is not found, an
+// empty node is returned.
+func findNode(node *yaml.Node, keyIndex, maxDepth int, keys []string) (*yaml.Node, error) {
+	if keyIndex > maxDepth {
+		return node, nil
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i]
+		val := node.Content[i+1]
+		if keyIndex+1 == maxDepth && val.Value == keys[maxDepth] {
+			return val, nil
+		}
+		if key.Value == keys[keyIndex] {
+			switch val.Kind {
+			case yaml.SequenceNode:
+				nextKeyIndex, err := strconv.Atoi(keys[keyIndex+1])
+				if err != nil {
+					return nil, err
+				}
+				return findNode(val.Content[nextKeyIndex], keyIndex+2, maxDepth, keys)
+			default:
+				return findNode(val, keyIndex+1, maxDepth, keys)
+			}
+		}
+	}
+	return &yaml.Node{}, nil
+}

--- a/cmd/registry/core/lint-openapi-spectral.go
+++ b/cmd/registry/core/lint-openapi-spectral.go
@@ -59,8 +59,9 @@ func lintFileForOpenAPIWithSpectral(path string, root string) (*rpc.LintFile, er
 	problems := make([]*rpc.LintProblem, 0)
 	for _, result := range lintResults {
 		problem := &rpc.LintProblem{
-			Message: result.Message,
-			RuleId:  result.Code,
+			Message:    result.Message,
+			RuleId:     result.Code,
+			RuleDocUri: "https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#" + result.Code,
 			Location: &rpc.LintLocation{
 				StartPosition: &rpc.LintPosition{
 					LineNumber:   result.Range.Start.Line + 1,

--- a/cmd/registry/core/lint-openapi-spectral.go
+++ b/cmd/registry/core/lint-openapi-spectral.go
@@ -1,0 +1,83 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/apigee/registry/rpc"
+)
+
+type SpectralLintResult struct {
+	Code     string            `json:"code"`
+	Path     []string          `json:"path"`
+	Message  string            `json:"message"`
+	Severity int32             `json:"severity"`
+	Range    SpectralLintRange `json:"range"`
+	Source   string            `json:"source"`
+}
+
+type SpectralLintRange struct {
+	Start SpectralLintLocation `json:"start"`
+	End   SpectralLintLocation `json:"end"`
+}
+
+type SpectralLintLocation struct {
+	Line      int32 `json:"line"`
+	Character int32 `json:"character"`
+}
+
+func lintFileForOpenAPIWithSpectral(path string, root string) (*rpc.LintFile, error) {
+	cmd := exec.Command("spectral", "lint", path, "--f", "json", "--output", "spectral.json")
+	cmd.Dir = root
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadFile(filepath.Join(root, "/spectral.json"))
+	if err != nil {
+		return nil, err
+	}
+	var lintResults []*SpectralLintResult
+
+	err = json.Unmarshal(b, &lintResults)
+	if err != nil {
+		return nil, err
+	}
+
+	problems := make([]*rpc.LintProblem, 0)
+	for _, result := range lintResults {
+		problem := &rpc.LintProblem{
+			Message: result.Message,
+			RuleId:  result.Code,
+			Location: &rpc.LintLocation{
+				StartPosition: &rpc.LintPosition{
+					LineNumber:   result.Range.Start.Line + 1,
+					ColumnNumber: result.Range.Start.Character + 1,
+				},
+				EndPosition: &rpc.LintPosition{
+					LineNumber:   result.Range.End.Line + 1,
+					ColumnNumber: result.Range.End.Character,
+				},
+			},
+		}
+		problems = append(problems, problem)
+	}
+	result := &rpc.LintFile{Problems: problems}
+	return result, nil
+}

--- a/cmd/registry/core/lint-openapi-spectral.go
+++ b/cmd/registry/core/lint-openapi-spectral.go
@@ -43,23 +43,19 @@ type SpectralLintLocation struct {
 }
 
 func lintFileForOpenAPIWithSpectral(path string, root string) (*rpc.LintFile, error) {
-	cmd := exec.Command("spectral", "lint", path, "--f", "json", "--output", "spectral.json")
+	cmd := exec.Command("spectral", "lint", path, "--f", "json", "--output", "spectral-lint.json")
 	cmd.Dir = root
-	_, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, err
-	}
-	b, err := ioutil.ReadFile(filepath.Join(root, "/spectral.json"))
+	// ignore errors from Spectral because Spectral returns an error result when APIs have errors.
+	cmd.Run()
+	b, err := ioutil.ReadFile(filepath.Join(root, "/spectral-lint.json"))
 	if err != nil {
 		return nil, err
 	}
 	var lintResults []*SpectralLintResult
-
 	err = json.Unmarshal(b, &lintResults)
 	if err != nil {
 		return nil, err
 	}
-
 	problems := make([]*rpc.LintProblem, 0)
 	for _, result := range lintResults {
 		problem := &rpc.LintProblem{

--- a/cmd/registry/core/lint-openapi.go
+++ b/cmd/registry/core/lint-openapi.go
@@ -15,20 +15,16 @@
 package core
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 
 	"github.com/apigee/registry/rpc"
-	linter "github.com/googleapis/gnostic/metrics/lint"
-	"google.golang.org/protobuf/proto"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // NewLintFromOpenAPI runs the API linter and returns the results.
-func NewLintFromOpenAPI(name string, b []byte) (*rpc.Lint, error) {
+func NewLintFromOpenAPI(name string, b []byte, linter string) (*rpc.Lint, error) {
 	// create a tmp directory
 	root, err := ioutil.TempDir("", "registry-openapi-")
 	if err != nil {
@@ -47,7 +43,17 @@ func NewLintFromOpenAPI(name string, b []byte) (*rpc.Lint, error) {
 		return nil, err
 	}
 	// run the linter on the spec
-	lintFile, err := lintFileForOpenAPI(name, root)
+	var lintFile *rpc.LintFile
+	switch linter {
+	case "":
+		err = errors.New("unspecified linter")
+	case "gnostic":
+		lintFile, err = lintFileForOpenAPIWithGnostic(name, root)
+	case "spectral":
+		lintFile, err = lintFileForOpenAPIWithSpectral(name, root)
+	default:
+		err = errors.New("unknown linter: " + linter)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -56,98 +62,4 @@ func NewLintFromOpenAPI(name string, b []byte) (*rpc.Lint, error) {
 		Files: []*rpc.LintFile{lintFile},
 	}
 	return lint, nil
-}
-
-func lintFileForOpenAPI(path string, root string) (*rpc.LintFile, error) {
-	cmd := exec.Command("gnostic", path, "--linter-out=.")
-	cmd.Dir = root
-	_, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, err
-	}
-	b, err := ioutil.ReadFile(filepath.Join(root, "/linter.pb"))
-	if err != nil {
-		return nil, err
-	}
-	output := &linter.Linter{}
-	if err := proto.Unmarshal(b, output); err != nil {
-		return nil, err
-	}
-	nodeFinder, err := newNodeFinder(filepath.Join(root, path))
-	if err != nil {
-		return nil, err
-	}
-	problems := make([]*rpc.LintProblem, 0)
-	for _, message := range output.Messages {
-		problem := &rpc.LintProblem{
-			Message:    message.Message,
-			Suggestion: message.Suggestion,
-		}
-		node, err := nodeFinder.findNode(message.Keys)
-		if err == nil {
-			l := int32(node.Line)
-			c := int32(node.Column)
-			problem.Location = &rpc.LintLocation{
-				StartPosition: &rpc.LintPosition{
-					LineNumber:   l,
-					ColumnNumber: c,
-				},
-				EndPosition: &rpc.LintPosition{
-					LineNumber:   l,
-					ColumnNumber: c + int32(len(node.Value)-1),
-				},
-			}
-		}
-		problems = append(problems, problem)
-	}
-	result := &rpc.LintFile{Problems: problems}
-	return result, nil
-}
-
-type nodeFinder struct {
-	node *yaml.Node
-}
-
-func newNodeFinder(filename string) (*nodeFinder, error) {
-	data, _ := ioutil.ReadFile(filename)
-	var node yaml.Node
-	if err := yaml.Unmarshal(data, &node); err != nil {
-		return nil, err
-	}
-	return &nodeFinder{node: &node}, nil
-}
-
-// FindNode returns a node object pointing to the given token in a yaml file. The node contains
-// information such as the string value, line number, bordering commments, etc.
-func (nf *nodeFinder) findNode(keys []string) (*yaml.Node, error) {
-	return findNode(nf.node.Content[0], 0, len(keys)-1, keys)
-}
-
-// findNode recursively iterates through the yaml file using the node feature. The function
-// will continue until the token is found at the max depth. If the token is not found, an
-// empty node is returned.
-func findNode(node *yaml.Node, keyIndex, maxDepth int, keys []string) (*yaml.Node, error) {
-	if keyIndex > maxDepth {
-		return node, nil
-	}
-	for i := 0; i < len(node.Content); i += 2 {
-		key := node.Content[i]
-		val := node.Content[i+1]
-		if keyIndex+1 == maxDepth && val.Value == keys[maxDepth] {
-			return val, nil
-		}
-		if key.Value == keys[keyIndex] {
-			switch val.Kind {
-			case yaml.SequenceNode:
-				nextKeyIndex, err := strconv.Atoi(keys[keyIndex+1])
-				if err != nil {
-					return nil, err
-				}
-				return findNode(val.Content[nextKeyIndex], keyIndex+2, maxDepth, keys)
-			default:
-				return findNode(val, keyIndex+1, maxDepth, keys)
-			}
-		}
-	}
-	return &yaml.Node{}, nil
 }


### PR DESCRIPTION
This PR allows results from [Spectral](https://github.com/stoplightio/spectral) to be stored and displayed alongside other linting results. (Probably not ready for merging at least until the "lintstats" summarization is updated)