### PR TITLE
remove commas from struct tags

### DIFF
--- a/server/models/api.go
+++ b/server/models/api.go
@@ -30,7 +30,7 @@ const ApiEntityName = "Api"
 
 // Api is the storage-side representation of an API.
 type Api struct {
-	Key                string    `datastore:"-", gorm:"primaryKey"`
+	Key                string    `datastore:"-" gorm:"primaryKey"`
 	ProjectID          string    // Uniquely identifies a project.
 	ApiID              string    // Uniquely identifies an api within a project.
 	DisplayName        string    // A human-friendly name.

--- a/server/models/blob.go
+++ b/server/models/blob.go
@@ -21,7 +21,7 @@ const BlobEntityName = "Blob"
 
 // Blob is the storage-side representation of a blob.
 type Blob struct {
-	Key         string    `datastore:"-", gorm:"primaryKey"`
+	Key         string    `datastore:"-" gorm:"primaryKey"`
 	ProjectID   string    // Uniquely identifies a project.
 	ApiID       string    // Uniquely identifies an api within a project.
 	VersionID   string    // Uniquely identifies a version within a api.

--- a/server/models/label.go
+++ b/server/models/label.go
@@ -29,7 +29,7 @@ const LabelEntityName = "Label"
 
 // Label is the storage-side representation of a label.
 type Label struct {
-	Key        string    `datastore:"-", gorm:"primaryKey"`
+	Key        string    `datastore:"-" gorm:"primaryKey"`
 	ProjectID  string    // Project associated with label (required).
 	ApiID      string    // Api associated with label (if appropriate).
 	VersionID  string    // Version associated with label (if appropriate).

--- a/server/models/project.go
+++ b/server/models/project.go
@@ -29,7 +29,7 @@ const ProjectEntityName = "Project"
 
 // Project is the storage-side representation of a project.
 type Project struct {
-	Key         string    `datastore:"-", gorm:"primaryKey"`
+	Key         string    `datastore:"-" gorm:"primaryKey"`
 	ProjectID   string    // Uniquely identifies a project.
 	DisplayName string    // A human-friendly name.
 	Description string    // A detailed description.

--- a/server/models/property.go
+++ b/server/models/property.go
@@ -48,7 +48,7 @@ const (
 
 // Property is the storage-side representation of a property.
 type Property struct {
-	Key         string            `datastore:"-", gorm:"primaryKey"`
+	Key         string            `datastore:"-" gorm:"primaryKey"`
 	ProjectID   string            // Project associated with property (required).
 	ApiID       string            // Api associated with property (if appropriate).
 	VersionID   string            // Version associated with property (if appropriate).

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -46,7 +46,7 @@ const (
 
 // Spec is the storage-side representation of a spec.
 type Spec struct {
-	Key         string    `datastore:"-", gorm:"primaryKey"`
+	Key         string    `datastore:"-" gorm:"primaryKey"`
 	Currency    int32     // IsCurrent for the current revision of the spec.
 	ProjectID   string    // Uniquely identifies a project.
 	ApiID       string    // Uniquely identifies an api within a project.
@@ -240,7 +240,7 @@ func hashForBytes(b []byte) string {
 
 // SpecRevisionTag is the storage-side representation of a spec revision tag.
 type SpecRevisionTag struct {
-	Key        string    `datastore:"-", gorm:"primaryKey"`
+	Key        string    `datastore:"-" gorm:"primaryKey"`
 	ProjectID  string    // Uniquely identifies a project.
 	ApiID      string    // Uniquely identifies an api within a project.
 	VersionID  string    // Uniquely identifies a version within a api.

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -30,7 +30,7 @@ const VersionEntityName = "Version"
 
 // Version is the storage-side representation of a version.
 type Version struct {
-	Key         string    `datastore:"-", gorm:"primaryKey"`
+	Key         string    `datastore:"-" gorm:"primaryKey"`
 	ProjectID   string    // Uniquely identifies a project.
 	ApiID       string    // Uniquely identifies an api within a project.
 	VersionID   string    // Uniquely identifies a version wihtin a api.


### PR DESCRIPTION
According to https://golang.org/pkg/reflect/#StructTag, struct tags are space-separated key-value pairs. For some reason, I thought these should be comma-separated, and recently noticed that these commas were preventing gorm from recognizing the primaryKey tags added to identify the primary keys in registry models.