### PR TITLE
Add support to deploy on GKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,26 @@ build:
 ifndef REGISTRY_PROJECT_IDENTIFIER
 	@echo "Error! REGISTRY_PROJECT_IDENTIFIER must be set."; exit 1
 endif
-	gcloud builds submit --tag gcr.io/${REGISTRY_PROJECT_IDENTIFIER}/registry-backend
+ifndef DB_CONFIG
+	$(eval DB_CONFIG := registry) # default to use config/registry.yaml
+endif
+	gcloud builds submit . --substitutions _REGISTRY_PROJECT_IDENTIFIER="${REGISTRY_PROJECT_IDENTIFIER}",_DB_CONFIG=$(DB_CONFIG)
 
 deploy:
 ifndef REGISTRY_PROJECT_IDENTIFIER
 	@echo "Error! REGISTRY_PROJECT_IDENTIFIER must be set."; exit 1
 endif
 	gcloud run deploy registry-backend --image gcr.io/${REGISTRY_PROJECT_IDENTIFIER}/registry-backend --platform managed
+
+deploy-gke:
+ifndef REGISTRY_PROJECT_IDENTIFIER
+	@echo "Error! REGISTRY_PROJECT_IDENTIFIER must be set."; exit 1
+endif
+ifeq ($(LB),internal)
+	./deployments/gke/DEPLOY-TO-GKE.sh deployments/gke/service-internal.yaml
+else
+	./deployments/gke/DEPLOY-TO-GKE.sh
+endif
 
 index:
 	gcloud datastore indexes create index.yaml

--- a/README.md
+++ b/README.md
@@ -256,6 +256,28 @@ message like this:
 `rpc error: code = Unauthenticated desc = Unauthorized: HTTP status code 401`.
 To generate a new token, rerun `source auth/CLOUDRUN.sh`.
 
+## Running the Registry API server on GKE
+
+The [Makefile](Makefile) contains targets that build a Docker image
+(`make build`) and that deploy it to GKE (`make deploy-gke`).
+
+Requirements:
+
+- Ensure you have [gcloud](https://cloud.google.com/sdk/gcloud) and
+  [kubectl](https://cloud.google.com/kubernetes-engine/docs/quickstart)
+  installed.
+
+- If not already done, `gcloud auth login` gets user credentials for subsequent
+  `gcloud` operations and `gcloud config set project PROJECT_ID` can be used to
+  set your project ID to the one where you plan to host your servce.
+
+- The Makefile gets your project ID from the `REGISTRY_PROJECT_IDENTIFIER`
+  environment variable. This can be set automatically by running
+  `source auth/GKE.sh`.
+
+For detailed steps on how to deploy to GKE, please refer to
+[deployments/gke/README.md](deployments/gke/README.md).
+
 ## License
 
 This software is licensed under the Apache License, Version 2.0. See

--- a/auth/GKE.sh
+++ b/auth/GKE.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Configure an environment to access the Registry server running on GKE.
+#
+
+if ! [ -x "$(command -v kubectl)" ] || ! [ -x "$(command -v gcloud)" ]; then
+  echo 'ERROR: This script requires `kubectl` and `gcloud`. Please install to continue.' >&2; return
+fi
+
+### SERVER CONFIGURATION
+
+# These steps are needed to enable local calls to the GKE service.
+
+# Optionally run this to update your application-default credentials.
+#gcloud auth application-default login
+
+# This assumes that the current gcloud project is the one where data is stored.
+export REGISTRY_PROJECT_IDENTIFIER=$(gcloud config list --format 'value(core.project)')
+
+### CLIENT CONFIGURATION
+# Below configuration assumes the server is running on the GKE cluter
+# `registry-backend` under zone `us-central1-a`, and is exposed by the
+# service `registry-backend`. Ensure the cluster, service and zone are
+# correct.
+gcloud container clusters get-credentials registry-backend --zone us-central1-a || return
+
+ingress_ip=$(kubectl get service registry-backend -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+service_port=$(kubectl get service registry-backend -o jsonpath="{.spec.ports[0].port}")
+if [ -z "${ingress_ip}" ]; then
+  echo "External IP not found for service 'registry-backend'. Pleasee try later."
+  return
+fi
+
+export APG_REGISTRY_ADDRESS="${ingress_ip}:${service_port}"
+export APG_REGISTRY_AUDIENCES="http://${APG_REGISTRY_ADDRESS}"
+
+# The auth token is generated for the gcloud logged-in user.
+export APG_REGISTRY_CLIENT_EMAIL=$(gcloud config list account --format "value(core.account)")
+export APG_REGISTRY_TOKEN=$(gcloud auth print-identity-token ${APG_REGISTRY_CLIENT_EMAIL})
+
+# Calls don't use an API key.
+unset APG_REGISTRY_API_KEY
+unset APG_REGISTRY_INSECURE
+

--- a/auth/README.md
+++ b/auth/README.md
@@ -12,3 +12,6 @@ the `registry-server`.
   from the top-level [Makefile](../Makefile).
 - [ENVOY.sh](ENVOY.sh) configures clients to work with a locally-running
   `registry-server` that is proxied behind a local Envoy instance.
+- [GKE.sh](GKE.sh) configures clients to work with a `registry-server` deployed
+  to GKE. For more details about GKE deployments, please refer to
+  [deployments/gke/README.md](../deployments/gke/README.md).

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '--build-arg', 'DB_CONFIG=${_DB_CONFIG}', '-t', 'gcr.io/${_REGISTRY_PROJECT_IDENTIFIER}/registry-backend', '.']
+images: ['gcr.io/${_REGISTRY_PROJECT_IDENTIFIER}/registry-backend']

--- a/deployments/container/Dockerfile.envoy
+++ b/deployments/container/Dockerfile.envoy
@@ -33,6 +33,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o authz-server ./cmd/authz-server
 # Use an Envoy release image to get envoy in the image.
 FROM envoyproxy/envoy:v1.14.4
 
+ARG DB_CONFIG=registry
+
 COPY deployments/container/RUN-WITH-ENVOY.sh /RUN-WITH-ENVOY.sh
 COPY deployments/envoy/envoy.yaml /etc/envoy/envoy.yaml
 COPY deployments/envoy/proto.pb /proto.pb
@@ -44,7 +46,7 @@ COPY --from=builder /app/registry-server /registry-server
 COPY --from=builder /app/authz-server /authz-server
 
 # Copy configuration files to the production image.
-COPY config/registry.yaml /registry.yaml
+COPY config/${DB_CONFIG}.yaml /registry.yaml
 COPY cmd/authz-server/authz.yaml /authz.yaml
 
 # Run the web service on container startup.

--- a/deployments/gke/DEPLOY-TO-GKE.sh
+++ b/deployments/gke/DEPLOY-TO-GKE.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if ! [ -x "$(command -v kubectl)" ] || ! [ -x "$(command -v gcloud)" ]; then
+  echo 'ERROR: This script requires `kubectl` and `gcloud`. Please install to continue.' >&2; return
+fi
+
+# Uses deployments/gke/service.yaml to create an external load balancer if no
+# service configuration file is specified.
+SERVICE_CONFIG=$1
+if [ -z "${SERVICE_CONFIG}" ]; then
+  SERVICE_CONFIG=deployments/gke/service.yaml
+fi
+
+gcloud config set project ${REGISTRY_PROJECT_IDENTIFIER}
+
+# Enables Kubernetes Engine API.
+gcloud services enable container.googleapis.com
+
+# Creates the cluster `registry-backend` if not exists.
+if [[ $(gcloud container clusters list --zone=us-central1-a --filter name=registry-backend --uri) ]]; then
+  echo "Cluster 'registry-backend' exists. "
+else
+  gcloud container clusters create registry-backend --zone us-central1-a --scopes=datastore,sql-admin,gke-default
+fi
+
+# Authenticates to the cluster.
+gcloud container clusters get-credentials registry-backend --zone us-central1-a
+
+# Creates a deployment.
+envsubst < deployments/gke/deployment.yaml | kubectl apply -f -
+
+# Creates a service to expose the deployment.
+kubectl apply -f "${SERVICE_CONFIG}"

--- a/deployments/gke/README.md
+++ b/deployments/gke/README.md
@@ -1,0 +1,50 @@
+# gke
+
+This directory contains configuration tools and other support files for running
+`registry-server` on GKE with envoy setup.
+
+## Instructions
+
+Following steps assume you're in the root directory.
+
+1. Run `make build` to build the docker image and upload to GCR. The default
+   database configuration is
+   [config/registry.yaml](../../config/registry.yaml). You can specify a
+   different config file by using `DB_CONFIG`, e.g.
+   `make build DB_CONFIG=cloudsql-postgres` will use
+   [config/cloudsql-postgres.yaml](../../config/cloudsql-postgres.yaml)
+   instead.
+
+1. Create a GKE deployment and expose the backend server through a load
+   balancer:
+
+   - To create an external LB, run `make deploy-gke`
+   - To create an internal LB, run `make deploy-gke LB=internal`
+
+1. Setup the client authentication. This step differs based on the load
+   balancer type you chose in the previous step:
+   - External LB: run `source auth/GKE.sh`.
+   - Internal LB: Usually you can't access services that are behind the
+     internal LB from your local. For more details, please check
+     [here](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#inspect).
+     1. Find the ingress IP:
+        `kubectl get service registry-backend -o jsonpath="{.status.loadBalancer.ingress[0].ip}"`.
+     1. Find the service port:
+        `kubectl get service registry-backend -o jsonpath="{.spec.ports[0].port}"`
+     1. SSH into a VM.
+     1. Run the following commands with `ingress_ip` found in the first step
+        and `service_port` found in the second step:
+        ```shell script
+        export APG_REGISTRY_ADDRESS="<ingress_ip>:<service_port>"
+        export APG_REGISTRY_AUDIENCES="http://${APG_REGISTRY_ADDRESS}"
+        export APG_REGISTRY_CLIENT_EMAIL=$(gcloud config list account --format "value(core.account)")
+        export APG_REGISTRY_TOKEN=$(gcloud auth print-identity-token ${APG_REGISTRY_CLIENT_EMAIL})
+        ```
+1. Verify the server. The GKE deployment uses
+   `<PROJECT_NUMBER>-compute@developer.gserviceaccount.com` by default. Please
+   ensure the service account has sufficient permissions to access the database
+   you configured. Below is a sample curl call to access your GKE deployment:
+
+   ```shell script
+   curl $APG_REGISTRY_AUDIENCES/v1alpha1/status -i -H "Authorization: Bearer $APG_REGISTRY_TOKEN"
+   ```

--- a/deployments/gke/deployment.yaml
+++ b/deployments/gke/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-backend
+spec:
+  selector:
+    matchLabels:
+      app: registry-backend
+  template:
+    metadata:
+      labels:
+        app: registry-backend
+    spec:
+      containers:
+      - name: registry-backend-gke
+        image: gcr.io/${REGISTRY_PROJECT_IDENTIFIER}/registry-backend:latest
+        imagePullPolicy: Always
+        env:
+        - name: PORT
+          value: "8080"
+        ports:
+        - containerPort: 8080

--- a/deployments/gke/service-internal.yaml
+++ b/deployments/gke/service-internal.yaml
@@ -1,0 +1,19 @@
+#  This configuration exposes the Registry backend through an internal load
+#  balancer. With an internal load balancer, you can only access the Registry
+#  service if you're within the same VPC network and GCP region as your GKE
+#  cluster. For more details, please refer to
+#  https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing.
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-backend
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  selector:
+    app: registry-backend
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080

--- a/deployments/gke/service.yaml
+++ b/deployments/gke/service.yaml
@@ -1,0 +1,13 @@
+#  This configuration exposes the Registry backend through an external load balancer.
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry-backend
+spec:
+  type: LoadBalancer
+  selector:
+    app: registry-backend
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080


### PR DESCRIPTION
This change contains helper functionalities to deploy the registry server to GKE. Changes include:
- Generalize `make build` so database is configurable while building the container image.
- Add scripts to create and expose services on GKE.
- Add scripts to setup authentication of local clients.
- Add instructions in README