### PR TITLE
Create isolated test environment for server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,10 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.3
 	github.com/google/cel-go v0.6.0
+	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.1.2
-	github.com/googleapis/api-linter v1.14.0 // indirect
-	github.com/googleapis/gapic-generator-go v0.18.1 // indirect
+	github.com/googleapis/api-linter v1.16.0 // indirect
+	github.com/googleapis/gapic-generator-go v0.18.4 // indirect
 	github.com/googleapis/gax-go v1.0.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/googleapis/gnostic v0.5.3
@@ -34,12 +35,12 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/yoheimuta/go-protoparser/v4 v4.2.1
 	gitlab.com/golang-commonmark/linkify v0.0.0-20200225224916-64bca66f6ad3 // indirect
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
-	golang.org/x/sys v0.0.0-20210216224549-f992740a1bac // indirect
+	golang.org/x/sys v0.0.0-20210223212115-eede4237b368 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/api v0.36.0
-	google.golang.org/genproto v0.0.0-20210212180131-e7f2df4ecc2d
+	google.golang.org/genproto v0.0.0-20210224155714-063164c882e6
 	google.golang.org/grpc v1.35.0
 	google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -278,10 +278,14 @@ github.com/googleapis/api-linter v1.8.0 h1:2Phc6zdmTcQGgARgJiAHq55Mr7AhiiKMVVgR3
 github.com/googleapis/api-linter v1.8.0/go.mod h1:MgC7tj4mzZviplbcqPY+o6Sm1zWft5ygMk33Hz0COhM=
 github.com/googleapis/api-linter v1.14.0 h1:cUjoH+UBAZAAHUYo1sQA129Ziv42ThD46Sy2YqC0K34=
 github.com/googleapis/api-linter v1.14.0/go.mod h1:UKvDCDRemG5E4ELnJ+qdFXN2zmRtQWiFLD7UpYFe59Q=
+github.com/googleapis/api-linter v1.16.0 h1:WAKxWrOsTVmm5thUlhrFI3yVh8QDvwHd3XXdFFyijvk=
+github.com/googleapis/api-linter v1.16.0/go.mod h1:UKvDCDRemG5E4ELnJ+qdFXN2zmRtQWiFLD7UpYFe59Q=
 github.com/googleapis/gapic-generator-go v0.16.0 h1:S1XVOuROJERt6zj1VZOO85dRoGE+5//FjZ1+SWbYzIg=
 github.com/googleapis/gapic-generator-go v0.16.0/go.mod h1:yl/RVCI7Yp1eLhTTZ7q1xSI+Jy0sCmrD7otRcch4RHM=
 github.com/googleapis/gapic-generator-go v0.18.1 h1:VHRU7rr68F+fDrFyPeeikA940cNRocRQm7kWrxIvRmw=
 github.com/googleapis/gapic-generator-go v0.18.1/go.mod h1:H6N/ARdZZD4mo4+iOh438AEbvXFikXHjo5CwYVbgKrY=
+github.com/googleapis/gapic-generator-go v0.18.4 h1:jkDbmauSOiaGMc7Ih7quA2jO/zwh5egRof4YS4JpUn0=
+github.com/googleapis/gapic-generator-go v0.18.4/go.mod h1:q51Tz1Xx0dbp69606eZlk0YUc1FfujYaXTmGxb3awJw=
 github.com/googleapis/gax-go v1.0.3 h1:9dMLqhaibYONnDRcnHdUs9P8Mw64jLlZTYlDe3leBtQ=
 github.com/googleapis/gax-go v1.0.3/go.mod h1:QyXYajJFdARxGzjwUfbDFIse7Spkw81SJ4LrBJXtlQ8=
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
@@ -756,6 +760,8 @@ golang.org/x/net v0.0.0-20201207224615-747e23833adb h1:xj2oMIbduz83x7tzglytWT7sp
 golang.org/x/net v0.0.0-20201207224615-747e23833adb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 h1:OgUuv8lsRpBibGNbSizVwKWlysjaNzmC9gYMhPVfqFM=
+golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -830,6 +836,8 @@ golang.org/x/sys v0.0.0-20210216163648-f7da38b97c65 h1:pTMjDVnP5eVRRlWO76rEWJ8Jo
 golang.org/x/sys v0.0.0-20210216163648-f7da38b97c65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210216224549-f992740a1bac h1:9glrpwtNjBYgRpb67AZJKHfzj1stG/8BL5H7In2oTC4=
 golang.org/x/sys v0.0.0-20210216224549-f992740a1bac/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368 h1:fDE3p0qf2V1co1vfj3/o87Ps8Hq6QTGNxJ5Xe7xSp80=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
@@ -992,6 +1000,9 @@ google.golang.org/genproto v0.0.0-20201207150747-9ee31aac76e7/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210207032614-bba0dbe2a9ea/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210212180131-e7f2df4ecc2d h1:Edhcm0CKDPLQIecHCp5Iz57Lo7MfT6zUFBAlocmOjcY=
 google.golang.org/genproto v0.0.0-20210212180131-e7f2df4ecc2d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210222212404-3e1e516060db/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210224155714-063164c882e6 h1:bXUwz2WkXXrXgiLxww3vWmoSHLOGv4ipdPdTvKymcKw=
+google.golang.org/genproto v0.0.0-20210224155714-063164c882e6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/server/actions_status_test.go
+++ b/server/actions_status_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestGetStatus(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+
+	req := &empty.Empty{}
+	want := &rpc.Status{
+		Message: "running",
+	}
+
+	got, err := server.GetStatus(ctx, req)
+	if err != nil {
+		t.Fatalf("GetStatus(%+v) returned error: %s", req, err)
+	}
+
+	if !cmp.Equal(want, got, protocmp.Transform()) {
+		t.Errorf("GetStatus(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(want, got, protocmp.Transform()))
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,29 +15,15 @@
 package server
 
 import (
-	"context"
+	"fmt"
 	"testing"
-
-	"github.com/apigee/registry/connection"
-	"github.com/golang/protobuf/ptypes/empty"
 )
 
-func TestServerIsRunning(t *testing.T) {
-	// Create a registry client.
-	ctx := context.Background()
-	registryClient, err := connection.NewClient(ctx)
-	if err != nil {
-		t.Logf("Failed to create client: %+v", err)
-		t.FailNow()
-	}
-	defer registryClient.Close()
-	// Get the server status.
-	response, err := registryClient.GetStatus(ctx, &empty.Empty{})
-	if err != nil {
-		t.Logf("Failed to get status: %+v", err)
-		t.FailNow()
-	}
-	if response.Message != "running" {
-		t.Errorf("Invalid status response: %s", response.Message)
+func defaultTestServer(t *testing.T) *RegistryServer {
+	t.Helper()
+	return &RegistryServer{
+		database:     "sqlite3",
+		dbConfig:     fmt.Sprintf("%s/registry.db", t.TempDir()),
+		loggingLevel: loggingError,
 	}
 }


### PR DESCRIPTION
This change establishes a pattern that can be used for testing all
functionality of the server package. It also restricts the scope of
tests to cover only the server RPC handler functionality.

Tests for the full server stack including gRPC and gapic client behavior
can be found in the `tests/` directory.