### PR TITLE
Fix a bug and an inconsistency in the "registry get" command

### DIFF
--- a/cmd/registry/cmd/compute-details.go
+++ b/cmd/registry/cmd/compute-details.go
@@ -176,7 +176,7 @@ func (task *computeDetailsTask) Run() error {
 				Description: description,
 			},
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{"owner", "display_name", "description"},
+				Paths: []string{"display_name", "description"},
 			},
 		}
 

--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
@@ -101,7 +100,7 @@ func (task *computeLintTask) Run() error {
 	}
 	var relation string
 	var lint *rpc.Lint
-	if strings.HasPrefix(spec.GetMimeType(), "openapi") {
+	if core.IsOpenAPIv2(spec.GetMimeType()) || core.IsOpenAPIv3(spec.GetMimeType()) {
 		// the default openapi linter is gnostic
 		if task.linter == "" {
 			task.linter = "gnostic"

--- a/cmd/registry/cmd/export-sheet.go
+++ b/cmd/registry/cmd/export-sheet.go
@@ -94,7 +94,7 @@ var exportSheetCmd = &cobra.Command{
 			saveSheetPath(ctx, client, path, sheetArtifactName)
 		} else if messageType == "gnostic.metrics.Complexity" {
 			path, err = core.ExportComplexityToSheet("Complexity", inputs)
-			log.Printf("exported complexity %+v to %s", inputs, path)
+			log.Printf("exported complexity to %s", path)
 			saveSheetPath(ctx, client, path, sheetArtifactName)
 		} else if messageType == "google.cloud.apigee.registry.applications.v1alpha1.Index" {
 			if len(inputs) != 1 {

--- a/cmd/registry/cmd/get.go
+++ b/cmd/registry/cmd/get.go
@@ -61,7 +61,11 @@ var getCmd = &cobra.Command{
 				_, err = core.GetSpec(ctx, client, m, getContents, core.PrintSpecDetail)
 			}
 		} else if m := names.ArtifactRegexp().FindStringSubmatch(name); m != nil {
-			_, err = core.GetArtifact(ctx, client, m, true, core.PrintArtifactDetail)
+			if getContents {
+				_, err = core.GetArtifact(ctx, client, m, getContents, core.PrintArtifactContents)
+			} else {
+				_, err = core.GetArtifact(ctx, client, m, getContents, core.PrintArtifactDetail)
+			}
 		} else {
 			log.Printf("Unsupported entity %+v", args)
 		}

--- a/cmd/registry/cmd/upload-bulk-openapi.go
+++ b/cmd/registry/cmd/upload-bulk-openapi.go
@@ -129,7 +129,6 @@ type uploadOpenAPITask struct {
 	version   string
 	projectID string
 	apiID     string // computed at runtime
-	apiOwner  string // computed at runtime
 	versionID string // computed at runtime
 	specID    string // computed at runtime
 }
@@ -166,8 +165,6 @@ func (task *uploadOpenAPITask) populateFields() error {
 	if len(parts) < 3 {
 		return fmt.Errorf("invalid API path: %s", task.apiPath())
 	}
-
-	task.apiOwner = parts[0]
 
 	apiParts := parts[0 : len(parts)-2]
 	apiPart := strings.ReplaceAll(strings.Join(apiParts, "-"), "/", "-")

--- a/cmd/registry/cmd/upload-bulk-protos.go
+++ b/cmd/registry/cmd/upload-bulk-protos.go
@@ -112,7 +112,6 @@ type uploadProtoTask struct {
 	path      string
 	directory string
 	apiID     string // computed at runtime
-	apiOwner  string // computed at runtime
 	versionID string // computed at runtime
 	specID    string // computed at runtime
 }
@@ -147,7 +146,6 @@ func (task *uploadProtoTask) populateFields() {
 	apiParts := parts[0 : len(parts)-1]
 
 	task.apiID = strings.ReplaceAll(strings.Join(apiParts, "-"), "/", "-")
-	task.apiOwner = strings.ReplaceAll(task.apiID, "-", "/")
 	task.versionID = parts[len(parts)-1]
 	task.specID = task.fileName()
 }

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -61,7 +61,7 @@ func PrintSpecDetail(message *rpc.ApiSpec) {
 
 func PrintSpecContents(message *rpc.ApiSpec) {
 	contents := message.GetContents()
-	if strings.HasSuffix(message.GetMimeType(), "+gzip") {
+	if strings.Contains(message.GetMimeType(), "+gzip") {
 		contents, _ = GUnzippedBytes(contents)
 	}
 	os.Stdout.Write(contents)
@@ -72,6 +72,14 @@ func PrintArtifact(artifact *rpc.Artifact) {
 }
 
 func PrintArtifactDetail(artifact *rpc.Artifact) {
+	PrintMessage(artifact)
+}
+
+func PrintArtifactContents(artifact *rpc.Artifact) {
+	if artifact.GetMimeType() == "text/plain" {
+		fmt.Printf("%s\n", string(artifact.GetContents()))
+		return
+	}
 	messageType, err := MessageTypeForMimeType(artifact.GetMimeType())
 	if err != nil {
 		fmt.Println(artifact.Name)
@@ -92,10 +100,6 @@ func PrintArtifactDetail(artifact *rpc.Artifact) {
 	default:
 		fmt.Printf("%+v", artifact.GetContents())
 	}
-}
-
-func PrintArtifactContents(message *rpc.Artifact) {
-	PrintArtifactDetail(message)
 }
 
 func PrintMessage(message proto.Message) {

--- a/demos/disco.sh
+++ b/demos/disco.sh
@@ -67,15 +67,15 @@ registry list projects/disco/apis/-/versions/-/specs
 registry get projects/disco/apis/translate/versions/v3/specs/discovery.json
 
 # You can also get this with the automatically-generated `apg` command line tool:
-apg registry get-spec --name projects/disco/apis/translate/versions/v3/specs/discovery.json
+apg registry get-api-spec --name projects/disco/apis/translate/versions/v3/specs/discovery.json
 
 # Add the `--json` flag to get this as JSON:
-apg registry get-spec --name projects/disco/apis/translate/versions/v3/specs/discovery.json --json
+apg registry get-api-spec --name projects/disco/apis/translate/versions/v3/specs/discovery.json --json
 
-# You might notice that this doesn't return the actual spec. That's because the get-spec
+# You might notice that this doesn't return the actual spec. That's because the get-api-spec
 # API takes a `view` argument, and its default value ("BASIC") excludes the spec bytes.
 # To get the spec contents, add "--view FULL" to your API call:
-apg registry get-spec --name projects/disco/apis/translate/versions/v3/specs/discovery.json --json --view FULL
+apg registry get-api-spec --name projects/disco/apis/translate/versions/v3/specs/discovery.json --json --view FULL
 
 # An easier way to get the bytes of the spec is to use `registry get` with the `--contents` flag.
 registry get projects/disco/apis/translate/versions/v3/specs/discovery.json --contents

--- a/demos/protos.sh
+++ b/demos/protos.sh
@@ -136,3 +136,11 @@ registry export sheet projects/protos/artifacts/vocabulary
 # track changes across versions, and find unique terms in APIs that we are reviewing.
 # By storing these results and other artifacts in the Registry, we can build a
 # centralized store of API information that can help manage an API program.
+
+# We can also run analysis tools like linters and store the results in the Registry.
+# Here we run the Google api-linter and compile summary statistics.
+registry compute lint projects/protos/apis/-/versions/-/specs/-
+registry compute lintstats projects/protos/apis/-/versions/-/specs/- --linter aip
+registry compute lintstats projects/protos --linter aip
+
+

--- a/demos/protos.sh
+++ b/demos/protos.sh
@@ -73,15 +73,15 @@ registry list projects/protos/apis/-/versions/-/specs
 registry get projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip
 
 # You can also get this with the automatically-generated `apg` command line tool:
-apg registry get-spec --name projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip
+apg registry get-api-spec --name projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip
 
 # Add the `--json` flag to get this as JSON:
-apg registry get-spec --name projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip --json
+apg registry get-api-spec --name projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip --json
 
-# You might notice that this doesn't return the actual spec. That's because the get-spec
+# You might notice that this doesn't return the actual spec. That's because the get-api-spec
 # API takes a `view` argument, and its default value ("BASIC") excludes the spec bytes.
 # To get the spec contents, add "--view FULL" to your API call:
-apg registry get-spec --name projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip --json --view FULL
+apg registry get-api-spec --name projects/protos/apis/google-cloud-translate/versions/v3/specs/protos.zip --json --view FULL
 
 # An easier way to get the bytes of the spec is to use `registry get` with the `--contents` flag.
 # This writes the bytes to stdout, so you probably want to redirect this to a file, as follows:

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -124,7 +124,6 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 			{"update_time", filterArgTypeTimestamp},
 			{"availability", filterArgTypeString},
 			{"recommended_version", filterArgTypeString},
-			{"owner", filterArgTypeString},
 			{"labels", filterArgTypeStringMap},
 		})
 	if err != nil {


### PR DESCRIPTION
With this, "registry get" for specs and artifacts will print the message body by default and, if the --contents flag is provided, the contents of the spec or artifact.