### PR TITLE
Remove whitespace from artifact media type.

### DIFF
--- a/cmd/registry/cmd/upload-bulk-protos.go
+++ b/cmd/registry/cmd/upload-bulk-protos.go
@@ -208,7 +208,7 @@ func (task *uploadProtoTask) createSpec() error {
 		Parent:    task.versionName(),
 		ApiSpecId: task.fileName(),
 		ApiSpec: &rpcpb.ApiSpec{
-			MimeType: core.ProtoMimeType("+zip"),
+			MimeType: core.ProtobufMimeType("+zip"),
 			Filename: task.fileName(),
 			Contents: contents,
 		},

--- a/cmd/registry/cmd/upload-spec.go
+++ b/cmd/registry/cmd/upload-spec.go
@@ -107,7 +107,7 @@ func uploadSpecDirectory(dirname string, client *gapic.RegistryClient, version s
 		ApiSpecId: "protos.zip",
 		ApiSpec: &rpcpb.ApiSpec{
 			MimeType: style,
-			Filename: core.ProtoMimeType("+zip"),
+			Filename: core.ProtobufMimeType("+zip"),
 			Contents: buf.Bytes(),
 		},
 	}

--- a/cmd/registry/core/types.go
+++ b/cmd/registry/core/types.go
@@ -71,12 +71,12 @@ func IsZipArchive(mimeType string) bool {
 
 // MimeTypeForMessageType returns a MIME type that represents a Protocol Buffer message type.
 func MimeTypeForMessageType(protoType string) string {
-	return fmt.Sprintf("application/octet-stream; type=%s", protoType)
+	return fmt.Sprintf("application/octet-stream;type=%s", protoType)
 }
 
 // MessageTypeForMimeType returns the Protocol Buffer message type represented by a MIME type.
 func MessageTypeForMimeType(protoType string) (string, error) {
-	re := regexp.MustCompile("^application/octet-stream; type=(.*)$")
+	re := regexp.MustCompile("^application/octet-stream;type=(.*)$")
 	m := re.FindStringSubmatch(protoType)
 	if m == nil || len(m) < 2 || len(m[1]) == 0 {
 		return "", fmt.Errorf("invalid Protocol Buffer type: %s", protoType)

--- a/cmd/registry/core/types.go
+++ b/cmd/registry/core/types.go
@@ -22,7 +22,7 @@ import (
 
 // OpenAPIMimeType returns a MIME type for an OpenAPI description of an API.
 func OpenAPIMimeType(compression, version string) string {
-	return fmt.Sprintf("application/x.openapi%s; version=%s", compression, version)
+	return fmt.Sprintf("application/x.openapi%s;version=%s", compression, version)
 }
 
 // DiscoveryMimeType returns a MIME type for a Discovery description of an API.
@@ -30,9 +30,9 @@ func DiscoveryMimeType(compression string) string {
 	return fmt.Sprintf("application/x.discovery%s", compression)
 }
 
-// ProtoMimeType returns a MIME type for a Protocol Buffers description of an API.
-func ProtoMimeType(compression string) string {
-	return fmt.Sprintf("application/x.proto%s", compression)
+// ProtobufMimeType returns a MIME type for a Protocol Buffers description of an API.
+func ProtobufMimeType(compression string) string {
+	return fmt.Sprintf("application/x.protobuf%s", compression)
 }
 
 // TODO: tighten these up, possibly using regular expressions.

--- a/tests/crud/crud_test.go
+++ b/tests/crud/crud_test.go
@@ -138,7 +138,7 @@ func TestCRUD(t *testing.T) {
 			Parent:    "projects/test/apis/sample/versions/1.0.0",
 			ApiSpecId: "openapi.yaml",
 			ApiSpec: &rpc.ApiSpec{
-				MimeType:    "application/x.openapi+gzip; version=3.0.0",
+				MimeType:    "application/x.openapi+gzip;version=3.0.0",
 				Contents:    buf.Bytes(),
 				Labels:      sampleMap,
 				Annotations: sampleMap,

--- a/tests/demo/demo_test.go
+++ b/tests/demo/demo_test.go
@@ -208,7 +208,7 @@ func TestDemo(t *testing.T) {
 			Parent:    "projects/demo/apis/petstore/versions/1.0.0",
 			ApiSpecId: "openapi.yaml",
 			ApiSpec: &rpc.ApiSpec{
-				MimeType: "application/x.openapi+gzip; version=3.0.0",
+				MimeType: "application/x.openapi+gzip;version=3.0.0",
 				Contents: buf.Bytes(),
 			},
 		}

--- a/tests/demo/walkthrough.sh
+++ b/tests/demo/walkthrough.sh
@@ -70,7 +70,7 @@ echo
 echo Update an attribute of the spec.
 apg registry update-api-spec \
 	--api_spec.name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
-	--api_spec.mime_type "application/x.openapi+gzip; version=3" \
+	--api_spec.mime_type "application/x.openapi+gzip;version=3" \
     --json
 
 echo


### PR DESCRIPTION
Following guidance from [MDN developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) and a formal syntax on [Wikipedia](https://en.wikipedia.org/wiki/Media_type), this removes the whitespace between `application/octet-stream;` and the `type` parameter. Note that this change only affects tools and not the core API, which currently does not require that `mime_type` values be valid Media Types.