### PR TITLE
Add support for arm64 containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,26 @@ Requirements:
 For detailed steps on how to deploy to GKE, please refer to
 [deployments/gke/README.md](deployments/gke/README.md).
 
+## Running the Registry API server locally with Docker
+
+The Registry API server container can also be built locally with Docker
+and run on both x64 and arm64 platforms. Arm64 builds require a build flag
+to specify the architecture of the `protoc` tool used during builds.
+That can be provided as follows:
+
+```
+docker build --build-arg "ARCH=aarch_64" -t registry .
+```
+
+The `--build-arg` flag can be omitted from x86 builds.
+To run the image with docker, you'll need to set the `PORT`
+environment variable in the container. Your `docker run`
+invocation will look like this:
+
+```
+docker run -e PORT=8080 -p 8080:8080 registry:latest
+```
+
 ## License
 
 This software is licensed under the Apache License, Version 2.0. See

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ enterprise API catalog designed to back online directories, portals, and
 workflow managers.
 
 The Registry API is formally described by the Protocol Buffer source files in
-[google/cloud/apigee/registry/v1](google/cloud/apigee/registry/v1).
-It closely follows the Google API Design Guidelines at
-[aip.dev](https://aip.dev) and presents a developer experience consistent with
-production Google APIs. Please tell us about your experience if you use it.
+[google/cloud/apigee/registry/v1](google/cloud/apigee/registry/v1). It closely
+follows the Google API Design Guidelines at [aip.dev](https://aip.dev) and
+presents a developer experience consistent with production Google APIs. Please
+tell us about your experience if you use it.
 
 ## This Implementation
 
@@ -278,19 +278,18 @@ For detailed steps on how to deploy to GKE, please refer to
 
 ## Running the Registry API server locally with Docker
 
-The Registry API server container can also be built locally with Docker
-and run on both x64 and arm64 platforms. Arm64 builds require a build flag
-to specify the architecture of the `protoc` tool used during builds.
-That can be provided as follows:
+The Registry API server container can also be built locally with Docker and run
+on both x64 and arm64 platforms. Arm64 builds require a build flag to specify
+the architecture of the `protoc` tool used during builds. That can be provided
+as follows:
 
 ```
 docker build --build-arg "ARCH=aarch_64" -t registry .
 ```
 
-The `--build-arg` flag can be omitted from x86 builds.
-To run the image with docker, you'll need to set the `PORT`
-environment variable in the container. Your `docker run`
-invocation will look like this:
+The `--build-arg` flag can be omitted from x86 builds. To run the image with
+docker, you'll need to set the `PORT` environment variable in the container.
+Your `docker run` invocation will look like this:
 
 ```
 docker run -e PORT=8080 -p 8080:8080 registry:latest

--- a/deployments/container/Dockerfile.envoy
+++ b/deployments/container/Dockerfile.envoy
@@ -5,9 +5,13 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.15 as builder
+
+# use aarch_64 for arm64
+ARG ARCH=x86_64
+
 RUN apt-get update
 RUN apt-get install unzip
-RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip > /tmp/protoc.zip
+RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.15.1/protoc-3.15.1-linux-$ARCH.zip > /tmp/protoc.zip
 RUN unzip /tmp/protoc.zip -d /usr/local
 
 # Create and change to the app directory.
@@ -31,7 +35,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry-server ./cmd/registry-serve
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o authz-server ./cmd/authz-server
 
 # Use an Envoy release image to get envoy in the image.
-FROM envoyproxy/envoy:v1.14.4
+FROM envoyproxy/envoy:v1.16.0
 
 ARG DB_CONFIG=registry
 
@@ -48,6 +52,9 @@ COPY --from=builder /app/authz-server /authz-server
 # Copy configuration files to the production image.
 COPY config/${DB_CONFIG}.yaml /registry.yaml
 COPY cmd/authz-server/authz.yaml /authz.yaml
+
+# Make sure that the CMD (below, which runs as the envoy user) is able to rewrite /etc/envoy/envoy.yaml
+RUN chown -R envoy /etc/envoy
 
 # Run the web service on container startup.
 CMD ["/RUN-WITH-ENVOY.sh"]

--- a/deployments/container/Dockerfile.envoy
+++ b/deployments/container/Dockerfile.envoy
@@ -41,7 +41,7 @@ ARG DB_CONFIG=registry
 
 COPY deployments/container/RUN-WITH-ENVOY.sh /RUN-WITH-ENVOY.sh
 COPY deployments/envoy/envoy.yaml /etc/envoy/envoy.yaml
-COPY deployments/envoy/proto.pb /proto.pb
+COPY --from=builder /app/deployments/envoy/proto.pb /proto.pb
 
 # Copy the registry-server binary to the production image from the builder stage.
 COPY --from=builder /app/registry-server /registry-server
@@ -53,8 +53,8 @@ COPY --from=builder /app/authz-server /authz-server
 COPY config/${DB_CONFIG}.yaml /registry.yaml
 COPY cmd/authz-server/authz.yaml /authz.yaml
 
-# Make sure that the CMD (below, which runs as the envoy user) is able to rewrite /etc/envoy/envoy.yaml
-RUN chown -R envoy /etc/envoy
+# Run as root in the container.
+ENV ENVOY_UID=0
 
-# Run the web service on container startup.
+# Run services on container startup.
 CMD ["/RUN-WITH-ENVOY.sh"]

--- a/deployments/envoy/GETENVOY.sh
+++ b/deployments/envoy/GETENVOY.sh
@@ -17,4 +17,4 @@
 
 # curl -L https://getenvoy.io/cli | bash -s -- -b /usr/local/bin 
 
-getenvoy run standard:1.14.4 -- -c envoy.yaml
+getenvoy run standard:1.16.0 -- -c envoy.yaml

--- a/deployments/envoy/envoy.yaml
+++ b/deployments/envoy/envoy.yaml
@@ -25,7 +25,7 @@ static_resources:
         - filters:
             - name: envoy.filters.network.http_connection_manager
               typed_config:
-                "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                 stat_prefix: grpc_json
                 codec_type: AUTO
                 route_config:

--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -79,6 +79,11 @@ func (c *RegistryClient) GrpcClient() rpcpb.RegistryClient {
 }
 END
 
+# patch the generated GAPIC to send Authorization tokens with insecure requests
+# (this allows the registry command line tools to test container builds)
+sed -i 's/return metadata.NewOutgoingContext(ctx, out)/insecure := os.Getenv("APG_REGISTRY_INSECURE")\ntoken := os.Getenv("APG_REGISTRY_TOKEN")\nif insecure == "1" \&\& token != "" \{ \nout["authorization"] = append(out["authorization"], "Bearer "+token) \n\}\nreturn metadata.NewOutgoingContext(ctx, out)/' gapic/doc.go
+gofmt -w gapic/doc.go
+
 echo "Generating GAPIC-based CLI."
 protoc --proto_path=. --proto_path=${ANNOTATIONS} \
 	${PROTOS[*]} \


### PR DESCRIPTION
This updates the Dockerfile and run scripts to allow the Registry server to be run in containers locally and in Kubernetes installations on both x86 and arm64 architectures. New README instructions document the process of building and running containers locally. Arm64 support required updating to Envoy 1.16 (which has published images for both x86 and arm64) and some small configuration changes related to the version change.