### PR TITLE
Add VSCode launch settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+# Generated files
 cmd/apg/*.go
 gapic/*.go
 rpc/*.go
 *.pb.go
 *.bleve
+deployments/envoy/proto.pb
 
-proto.pb
+# VSCode
+.vscode/*
+!launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,4 @@
+{
+    "version": "0.2.0",
+    "configurations": []
+}


### PR DESCRIPTION
This change allows developers to debug tests using VSCode without
creating untracked files in their workspace. We could ignore the entire
directory if we want vscode users to have to generate their own
launch.json before debugging tests.