### PR TITLE
Specs Testing + Handler Updates

### DIFF
--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -1,0 +1,721 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/names"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+func seedSpecs(ctx context.Context, t *testing.T, s *RegistryServer, versions ...*rpc.ApiSpec) {
+	t.Helper()
+
+	for _, p := range versions {
+		m, err := names.ParseSpec(p.Name)
+		if err != nil {
+			t.Fatalf("Setup/Seeding: ParseSpec(%q) returned error: %s", p.Name, err)
+		}
+
+		parent := fmt.Sprintf("projects/%s/apis/%s/versions/%s", m[1], m[2], m[3])
+		seedVersions(ctx, t, s, &rpc.ApiVersion{
+			Name: parent,
+		})
+
+		req := &rpc.CreateApiSpecRequest{
+			Parent:    parent,
+			ApiSpecId: m[4],
+			ApiSpec:   p,
+		}
+
+		switch _, err := s.CreateApiSpec(ctx, req); status.Code(err) {
+		case codes.OK, codes.AlreadyExists:
+			// ApiSpec is now ready for use in test.
+		default:
+			t.Fatalf("Setup/Seeding: CreateApiSpec(%+v) returned error: %s", req, err)
+		}
+	}
+}
+
+func TestCreateApiSpec(t *testing.T) {
+	tests := []struct {
+		desc      string
+		req       *rpc.CreateApiSpecRequest
+		want      *rpc.ApiSpec
+		extraOpts cmp.Option
+	}{
+		{
+			desc: "default parameters",
+			req: &rpc.CreateApiSpecRequest{
+				Parent: "projects/p/apis/a/versions/v1",
+				ApiSpec: &rpc.ApiSpec{
+					Description: "ApiSpec for my versions",
+				},
+			},
+			want: &rpc.ApiSpec{
+				Description: "ApiSpec for my versions",
+			},
+			// Name field is generated.
+			extraOpts: protocmp.IgnoreFields(new(rpc.ApiSpec), "name"),
+		},
+		{
+			desc: "custom identifier",
+			req: &rpc.CreateApiSpecRequest{
+				Parent:    "projects/p/apis/a/versions/v1",
+				ApiSpecId: "my-version",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: &rpc.ApiSpec{
+				Name: "projects/p/apis/a/versions/v1/specs/my-version",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+
+			created, err := server.CreateApiSpec(ctx, test.req)
+			if err != nil {
+				t.Fatalf("CreateApiSpec(%+v) returned error: %s", test.req, err)
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+				test.extraOpts,
+			}
+
+			if !cmp.Equal(test.want, created, opts) {
+				t.Errorf("CreateApiSpec(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, created, opts))
+			}
+
+			if !strings.HasPrefix(created.GetName(), test.req.GetParent()+"/specs/") {
+				t.Errorf("CreateApiSpec(%+v) returned unexpected name %q, expected collection prefix", test.req, created.GetName())
+			}
+
+			if created.CreateTime == nil || created.RevisionCreateTime == nil || created.RevisionUpdateTime == nil {
+				t.Errorf("CreateApiSpec(%+v) returned unset create_time (%v), revision_create_time (%v), or revision_update_time (%v)", test.req, created.CreateTime, created.RevisionCreateTime, created.RevisionUpdateTime)
+			} else if !created.CreateTime.AsTime().Equal(created.RevisionCreateTime.AsTime()) {
+				t.Errorf("CreateApiSpec(%+v) returned unexpected timestamps: create_time %v != revision_create_time %v", test.req, created.CreateTime, created.RevisionCreateTime)
+			} else if !created.RevisionCreateTime.AsTime().Equal(created.RevisionUpdateTime.AsTime()) {
+				t.Errorf("CreateApiSpec(%+v) returned unexpected timestamps: revision_create_time %v != revision_update_time %v", test.req, created.RevisionCreateTime, created.RevisionUpdateTime)
+			}
+
+			t.Run("GetApiSpec", func(t *testing.T) {
+				req := &rpc.GetApiSpecRequest{
+					Name: created.GetName(),
+				}
+
+				got, err := server.GetApiSpec(ctx, req)
+				if err != nil {
+					t.Fatalf("GetApiSpec(%+v) returned error: %s", req, err)
+				}
+
+				opts := protocmp.Transform()
+				if !cmp.Equal(created, got, opts) {
+					t.Errorf("GetApiSpec(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(created, got, opts))
+				}
+			})
+		})
+	}
+}
+
+func TestCreateApiSpecResponseCodes(t *testing.T) {
+	t.Skip("Validation rules are not implemented")
+
+	tests := []struct {
+		desc string
+		req  *rpc.CreateApiSpecRequest
+		want codes.Code
+	}{
+		{
+			desc: "short custom identifier",
+			req: &rpc.CreateApiSpecRequest{
+				ApiSpecId: "abc",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "long custom identifier",
+			req: &rpc.CreateApiSpecRequest{
+				ApiSpecId: "this-identifier-exceeds-the-sixty-three-character-maximum-length",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "custom identifier underscores",
+			req: &rpc.CreateApiSpecRequest{
+				ApiSpecId: "underscore_identifier",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "customer identifier dots",
+			req: &rpc.CreateApiSpecRequest{
+				ApiSpecId: "dot.identifier",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "customer identifier uuid format",
+			req: &rpc.CreateApiSpecRequest{
+				ApiSpecId: "072d2288-c685-42d8-9df0-5edbb2a809ea",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+
+			if _, err := server.CreateApiSpec(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("CreateApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
+func TestCreateApiSpecDuplicates(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seedSpecs(ctx, t, server, &rpc.ApiSpec{
+		Name: "projects/p/apis/a/versions/v1/specs/my-spec",
+	})
+
+	t.Run("case sensitive duplicate", func(t *testing.T) {
+		req := &rpc.CreateApiSpecRequest{
+			Parent:    "projects/p/apis/a/versions/v1",
+			ApiSpecId: "my-spec",
+			ApiSpec:   &rpc.ApiSpec{},
+		}
+
+		if _, err := server.CreateApiSpec(ctx, req); status.Code(err) != codes.AlreadyExists {
+			t.Errorf("CreateApiSpec(%+v) returned status code %q, want %q: %v", req, status.Code(err), codes.AlreadyExists, err)
+		}
+	})
+
+	t.Skip("Resource names are not yet case insensitive")
+	t.Run("case insensitive duplicate", func(t *testing.T) {
+		req := &rpc.CreateApiSpecRequest{
+			Parent:    "projects/p/apis/a/versions/v1",
+			ApiSpecId: "MY-SPEC",
+			ApiSpec:   &rpc.ApiSpec{},
+		}
+
+		if _, err := server.CreateApiSpec(ctx, req); status.Code(err) != codes.AlreadyExists {
+			t.Errorf("CreateApiSpec(%+v) returned status code %q, want %q: %v", req, status.Code(err), codes.AlreadyExists, err)
+		}
+	})
+}
+
+func TestGetApiSpecResponseCodes(t *testing.T) {
+	tests := []struct {
+		desc string
+		req  *rpc.GetApiSpecRequest
+		want codes.Code
+	}{
+		{
+			desc: "resource not found",
+			req: &rpc.GetApiSpecRequest{
+				Name: "projects/p/apis/a/versions/v1/specs/doesnt-exist",
+			},
+			want: codes.NotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+
+			if _, err := server.GetApiSpec(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("GetApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
+func TestListApiSpecs(t *testing.T) {
+	tests := []struct {
+		desc      string
+		seed      []*rpc.ApiSpec
+		req       *rpc.ListApiSpecsRequest
+		want      *rpc.ListApiSpecsResponse
+		wantToken bool
+		extraOpts cmp.Option
+	}{
+		{
+			desc: "default parameters",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s3"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/p/apis/a/versions/v1",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+					{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+					{Name: "projects/p/apis/a/versions/v1/specs/s3"},
+				},
+			},
+		},
+		{
+			desc: "custom page size",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s3"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent:   "projects/p/apis/a/versions/v1",
+				PageSize: 1,
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{},
+				},
+			},
+			wantToken: true,
+			// Ordering is not guaranteed by API, so any resource may be returned.
+			extraOpts: protocmp.IgnoreFields(new(rpc.ApiSpec), "name"),
+		},
+		{
+			desc: "name equality filtering",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s3"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/p/apis/a/versions/v1",
+				Filter: "name == 'projects/p/apis/a/versions/v1/specs/s2'",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+				},
+			},
+		},
+		{
+			desc: "description inequality filtering",
+			seed: []*rpc.ApiSpec{
+				{
+					Name:        "projects/p/apis/a/versions/v1/specs/s1",
+					Description: "First ApiSpec",
+				},
+				{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+				{Name: "projects/p/apis/a/versions/v1/specs/s3"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/p/apis/a/versions/v1",
+				Filter: "description != ''",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{
+						Name:        "projects/p/apis/a/versions/v1/specs/s1",
+						Description: "First ApiSpec",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedSpecs(ctx, t, server, test.seed...)
+
+			got, err := server.ListApiSpecs(ctx, test.req)
+			if err != nil {
+				t.Fatalf("ListApiSpecs(%+v) returned error: %s", test.req, err)
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(new(rpc.ListApiSpecsResponse), "next_page_token"),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+				test.extraOpts,
+			}
+
+			if !cmp.Equal(test.want, got, opts) {
+				t.Errorf("ListApiSpecs(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, got, opts))
+			}
+
+			if test.wantToken && got.NextPageToken == "" {
+				t.Errorf("ListApiSpecs(%+v) returned empty next_page_token, expected non-empty next_page_token", test.req)
+			} else if !test.wantToken && got.NextPageToken != "" {
+				// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
+				t.Logf("ListApiSpecs(%+v) returned non-empty next_page_token, expected empty next_page_token: %s", test.req, got.GetNextPageToken())
+			}
+		})
+	}
+}
+
+func TestListApiSpecsResponseCodes(t *testing.T) {
+	tests := []struct {
+		desc string
+		req  *rpc.ListApiSpecsRequest
+		want codes.Code
+	}{
+		{
+			desc: "negative page size",
+			req: &rpc.ListApiSpecsRequest{
+				PageSize: -1,
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "invalid filter",
+			req: &rpc.ListApiSpecsRequest{
+				Filter: "this filter is not valid",
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "invalid page token",
+			req: &rpc.ListApiSpecsRequest{
+				PageToken: "this token is not valid",
+			},
+			want: codes.InvalidArgument,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+
+			if _, err := server.ListApiSpecs(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("ListApiSpecs(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
+func TestListApiSpecsSequence(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seed := []*rpc.ApiSpec{
+		{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+		{Name: "projects/p/apis/a/versions/v1/specs/s2"},
+		{Name: "projects/p/apis/a/versions/v1/specs/s3"},
+	}
+	seedSpecs(ctx, t, server, seed...)
+
+	listed := make([]*rpc.ApiSpec, 0, 3)
+
+	var nextToken string
+	t.Run("first page", func(t *testing.T) {
+		req := &rpc.ListApiSpecsRequest{
+			Parent:   "projects/p/apis/a/versions/v1",
+			PageSize: 1,
+		}
+
+		got, err := server.ListApiSpecs(ctx, req)
+		if err != nil {
+			t.Fatalf("ListApiSpecs(%+v) returned error: %s", req, err)
+		}
+
+		listed = append(listed, got.ApiSpecs...)
+		nextToken = got.GetNextPageToken()
+	})
+
+	if t.Failed() {
+		t.Fatal("Cannot test intermediate page after failure on first page")
+	}
+
+	t.Run("intermediate page", func(t *testing.T) {
+		req := &rpc.ListApiSpecsRequest{
+			Parent:    "projects/p/apis/a/versions/v1",
+			PageSize:  1,
+			PageToken: nextToken,
+		}
+
+		got, err := server.ListApiSpecs(ctx, req)
+		if err != nil {
+			t.Fatalf("ListApiSpecs(%+v) returned error: %s", req, err)
+		}
+
+		listed = append(listed, got.ApiSpecs...)
+		nextToken = got.GetNextPageToken()
+	})
+
+	if t.Failed() {
+		t.Fatal("Cannot test final page after failure on intermediate page")
+	}
+
+	t.Run("final page", func(t *testing.T) {
+		req := &rpc.ListApiSpecsRequest{
+			Parent:    "projects/p/apis/a/versions/v1",
+			PageSize:  1,
+			PageToken: nextToken,
+		}
+
+		got, err := server.ListApiSpecs(ctx, req)
+		if err != nil {
+			t.Fatalf("ListApiSpecs(%+v) returned error: %s", req, err)
+		}
+
+		if got.GetNextPageToken() != "" {
+			// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
+			t.Logf("ListApiSpecs(%+v) returned next_page_token, expected no next page", req)
+		}
+
+		listed = append(listed, got.ApiSpecs...)
+	})
+
+	opts := cmp.Options{
+		protocmp.Transform(),
+		protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+		cmpopts.SortSlices(func(a, b *rpc.ApiSpec) bool {
+			return a.GetName() < b.GetName()
+		}),
+	}
+
+	if !cmp.Equal(seed, listed, opts) {
+		t.Errorf("List sequence returned unexpected diff (-want +got):\n%s", cmp.Diff(seed, listed, opts))
+	}
+}
+
+func TestUpdateApiSpec(t *testing.T) {
+	t.Skip("Default/empty mask behavior is incorrect and replacement wildcard is not implemented")
+
+	tests := []struct {
+		desc string
+		seed *rpc.ApiSpec
+		req  *rpc.UpdateApiSpecRequest
+		want *rpc.ApiSpec
+	}{
+		{
+			desc: "default parameters",
+			seed: &rpc.ApiSpec{
+				Name:        "projects/p/apis/a/versions/v1",
+				Description: "ApiSpec for my APIs",
+			},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/p/apis/a/versions/v1/specs/s1",
+				},
+			},
+			want: &rpc.ApiSpec{
+				Name:        "projects/p/apis/a/versions/v1",
+				Description: "ApiSpec for my APIs",
+			},
+		},
+		{
+			desc: "field specific mask",
+			seed: &rpc.ApiSpec{
+				Name:        "projects/p/apis/a/versions/v1",
+				Description: "ApiSpec for my APIs",
+			},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name:        "projects/p/apis/a/versions/v1",
+					Description: "Ignored",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"display_name"}},
+			},
+			want: &rpc.ApiSpec{
+				Name:        "projects/p/apis/a/versions/v1",
+				Description: "ApiSpec for my APIs",
+			},
+		},
+		{
+			desc: "full replacement wildcard mask",
+			seed: &rpc.ApiSpec{
+				Name:        "projects/p/apis/a/versions/v1",
+				Description: "ApiSpec for my APIs",
+			},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/p/apis/a/versions/v1/specs/s1",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+			},
+			want: &rpc.ApiSpec{
+				Name:        "projects/p/apis/a/versions/v1",
+				Description: "",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedSpecs(ctx, t, server, test.seed)
+
+			updated, err := server.UpdateApiSpec(ctx, test.req)
+			if err != nil {
+				t.Fatalf("UpdateApiSpec(%+v) returned error: %s", test.req, err)
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+			}
+
+			if !cmp.Equal(test.want, updated, opts) {
+				t.Errorf("UpdateApiSpec(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, updated, opts))
+			}
+
+			t.Run("GetApiSpec", func(t *testing.T) {
+				req := &rpc.GetApiSpecRequest{
+					Name: updated.GetName(),
+				}
+
+				got, err := server.GetApiSpec(ctx, req)
+				if err != nil {
+					t.Fatalf("GetApiSpec(%+v) returned error: %s", req, err)
+				}
+
+				opts := protocmp.Transform()
+				if !cmp.Equal(updated, got, opts) {
+					t.Errorf("GetApiSpec(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(updated, got, opts))
+				}
+			})
+		})
+	}
+}
+
+func TestUpdateApiSpecsResponseCodes(t *testing.T) {
+	t.Skip("Update mask validation is not implemented")
+
+	tests := []struct {
+		desc string
+		seed *rpc.ApiSpec
+		req  *rpc.UpdateApiSpecRequest
+		want codes.Code
+	}{
+		{
+			desc: "resource not found",
+			seed: &rpc.ApiSpec{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/p/apis/a/versions/v1/specs/doesnt-exist",
+				},
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "missing resource name",
+			seed: &rpc.ApiSpec{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "nonexistent field in mask",
+			seed: &rpc.ApiSpec{Name: "projects/p/apis/a/versions/v1/specs/s1"},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/p/apis/a/versions/v1/specs/s1",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"this field does not exist"}},
+			},
+			want: codes.InvalidArgument,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedSpecs(ctx, t, server, test.seed)
+
+			if _, err := server.UpdateApiSpec(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("UpdateApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
+func TestDeleteApiSpec(t *testing.T) {
+	tests := []struct {
+		desc string
+		seed *rpc.ApiSpec
+		req  *rpc.DeleteApiSpecRequest
+	}{
+		{
+			desc: "existing version",
+			seed: &rpc.ApiSpec{
+				Name: "projects/p/apis/a/versions/v1/specs/s1",
+			},
+			req: &rpc.DeleteApiSpecRequest{
+				Name: "projects/p/apis/a/versions/v1/specs/s1",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedSpecs(ctx, t, server, test.seed)
+
+			if _, err := server.DeleteApiSpec(ctx, test.req); err != nil {
+				t.Fatalf("DeleteApiSpec(%+v) returned error: %s", test.req, err)
+			}
+
+			t.Run("GetApiSpec", func(t *testing.T) {
+				req := &rpc.GetApiSpecRequest{
+					Name: test.req.GetName(),
+				}
+
+				if _, err := server.GetApiSpec(ctx, req); status.Code(err) != codes.NotFound {
+					t.Fatalf("GetApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), codes.NotFound, err)
+				}
+			})
+		})
+	}
+}
+
+func TestDeleteApiSpecResponseCodes(t *testing.T) {
+	tests := []struct {
+		desc string
+		req  *rpc.DeleteApiSpecRequest
+		want codes.Code
+	}{
+		{
+			desc: "resource not found",
+			req: &rpc.DeleteApiSpecRequest{
+				Name: "projects/p/apis/a/versions/v1/specs/doesnt-exist",
+			},
+			want: codes.NotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+
+			if _, err := server.DeleteApiSpec(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("DeleteApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -264,27 +264,27 @@ func TestListApiVersions(t *testing.T) {
 		{
 			desc: "default parameters",
 			seed: []*rpc.ApiVersion{
-				{Name: "projects/p/apis/a/versions/p1"},
-				{Name: "projects/p/apis/a/versions/p2"},
-				{Name: "projects/p/apis/a/versions/p3"},
+				{Name: "projects/p/apis/a/versions/v1"},
+				{Name: "projects/p/apis/a/versions/v2"},
+				{Name: "projects/p/apis/a/versions/v3"},
 			},
 			req: &rpc.ListApiVersionsRequest{
 				Parent: "projects/p/apis/a",
 			},
 			want: &rpc.ListApiVersionsResponse{
 				ApiVersions: []*rpc.ApiVersion{
-					{Name: "projects/p/apis/a/versions/p1"},
-					{Name: "projects/p/apis/a/versions/p2"},
-					{Name: "projects/p/apis/a/versions/p3"},
+					{Name: "projects/p/apis/a/versions/v1"},
+					{Name: "projects/p/apis/a/versions/v2"},
+					{Name: "projects/p/apis/a/versions/v3"},
 				},
 			},
 		},
 		{
 			desc: "custom page size",
 			seed: []*rpc.ApiVersion{
-				{Name: "projects/p/apis/a/versions/p1"},
-				{Name: "projects/p/apis/a/versions/p2"},
-				{Name: "projects/p/apis/a/versions/p3"},
+				{Name: "projects/p/apis/a/versions/v1"},
+				{Name: "projects/p/apis/a/versions/v2"},
+				{Name: "projects/p/apis/a/versions/v3"},
 			},
 			req: &rpc.ListApiVersionsRequest{
 				Parent:   "projects/p/apis/a",
@@ -302,17 +302,17 @@ func TestListApiVersions(t *testing.T) {
 		{
 			desc: "name equality filtering",
 			seed: []*rpc.ApiVersion{
-				{Name: "projects/p/apis/a/versions/p1"},
-				{Name: "projects/p/apis/a/versions/p2"},
-				{Name: "projects/p/apis/a/versions/p3"},
+				{Name: "projects/p/apis/a/versions/v1"},
+				{Name: "projects/p/apis/a/versions/v2"},
+				{Name: "projects/p/apis/a/versions/v3"},
 			},
 			req: &rpc.ListApiVersionsRequest{
 				Parent: "projects/p/apis/a",
-				Filter: "name == 'projects/p/apis/a/versions/p2'",
+				Filter: "name == 'projects/p/apis/a/versions/v2'",
 			},
 			want: &rpc.ListApiVersionsResponse{
 				ApiVersions: []*rpc.ApiVersion{
-					{Name: "projects/p/apis/a/versions/p2"},
+					{Name: "projects/p/apis/a/versions/v2"},
 				},
 			},
 		},
@@ -320,11 +320,11 @@ func TestListApiVersions(t *testing.T) {
 			desc: "description inequality filtering",
 			seed: []*rpc.ApiVersion{
 				{
-					Name:        "projects/p/apis/a/versions/p1",
+					Name:        "projects/p/apis/a/versions/v1",
 					Description: "First ApiVersion",
 				},
-				{Name: "projects/p/apis/a/versions/p2"},
-				{Name: "projects/p/apis/a/versions/p3"},
+				{Name: "projects/p/apis/a/versions/v2"},
+				{Name: "projects/p/apis/a/versions/v3"},
 			},
 			req: &rpc.ListApiVersionsRequest{
 				Parent: "projects/p/apis/a",
@@ -333,7 +333,7 @@ func TestListApiVersions(t *testing.T) {
 			want: &rpc.ListApiVersionsResponse{
 				ApiVersions: []*rpc.ApiVersion{
 					{
-						Name:        "projects/p/apis/a/versions/p1",
+						Name:        "projects/p/apis/a/versions/v1",
 						Description: "First ApiVersion",
 					},
 				},
@@ -418,9 +418,9 @@ func TestListApiVersionsSequence(t *testing.T) {
 	ctx := context.Background()
 	server := defaultTestServer(t)
 	seed := []*rpc.ApiVersion{
-		{Name: "projects/p/apis/a/versions/p1"},
-		{Name: "projects/p/apis/a/versions/p2"},
-		{Name: "projects/p/apis/a/versions/p3"},
+		{Name: "projects/p/apis/a/versions/v1"},
+		{Name: "projects/p/apis/a/versions/v2"},
+		{Name: "projects/p/apis/a/versions/v3"},
 	}
 	seedVersions(ctx, t, server, seed...)
 

--- a/server/datastore/deletions.go
+++ b/server/datastore/deletions.go
@@ -116,3 +116,14 @@ func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version *models.Ve
 	}
 	return nil
 }
+
+// DeleteChildrenOfSpec deletes all the children of a spec.
+func (c *Client) DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error {
+	q := datastore.NewQuery(models.BlobEntityName)
+	q = q.KeysOnly()
+	q = q.Filter("ProjectID =", spec.ProjectID)
+	q = q.Filter("ApiID =", spec.ApiID)
+	q = q.Filter("VersionID =", spec.VersionID)
+	q = q.Filter("SpecID =", spec.SpecID)
+	return c.DeleteAllMatches(ctx, &Query{query: q})
+}

--- a/server/gorm/deletions.go
+++ b/server/gorm/deletions.go
@@ -61,7 +61,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project *models.Pr
 		q = q.Require("ProjectID", project.ProjectID)
 		err := c.DeleteAllMatches(ctx, q)
 		if err != nil {
-			//return err
+			return err
 		}
 	}
 	return nil
@@ -79,7 +79,7 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api *models.Api) error
 		q = q.Require("ApiID", api.ApiID)
 		err := c.DeleteAllMatches(ctx, q)
 		if err != nil {
-			//return err
+			return err
 		}
 	}
 	return nil
@@ -97,8 +97,18 @@ func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version *models.Ve
 		q = q.Require("VersionID", version.VersionID)
 		err := c.DeleteAllMatches(ctx, q)
 		if err != nil {
-			//return err
+			return err
 		}
 	}
 	return nil
+}
+
+// DeleteChildrenOfSpec deletes all the children of a spec.
+func (c *Client) DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error {
+	q := c.NewQuery(models.BlobEntityName)
+	q = q.Require("ProjectID", spec.ProjectID)
+	q = q.Require("ApiID", spec.ApiID)
+	q = q.Require("VersionID", spec.VersionID)
+	q = q.Require("SpecID", spec.SpecID)
+	return c.DeleteAllMatches(ctx, q)
 }

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -40,6 +40,7 @@ type Client interface {
 	DeleteChildrenOfProject(ctx context.Context, project *models.Project) error
 	DeleteChildrenOfApi(ctx context.Context, api *models.Api) error
 	DeleteChildrenOfVersion(ctx context.Context, version *models.Version) error
+	DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error
 }
 
 type Key interface {


### PR DESCRIPTION
This change doesn't include all the testing needed for the specs API. It just covers the main CRUD operations as we've covered them for projects/apis/versions. Some examples of behaviors that still need testing:
- Revisions
- Tagging
- UpdateSpec with allow_missing