### PR TITLE
rename the "atlas" demo to "openapi"

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -3,7 +3,7 @@
 This directory contains scripts that demonstrate some possible uses of the
 Registry API.
 
-- [atlas.sh](atlas.sh) builds and analyzes a collection of APIs from the
+- [openapi.sh](openapi.sh) builds and analyzes a collection of APIs from the
   [OpenAPI Directory](https://github.com/APIs-guru/openapi-directory), a
   curated collection of OpenAPI descriptions of public APIs.
 - [disco.sh](disco.sh) builds and analyzes a collection of APIs described by

--- a/demos/openapi.sh
+++ b/demos/openapi.sh
@@ -16,7 +16,7 @@
 #
 
 # This script uses the [OpenAPI Directory](https://github.com/APIs-guru/openapi-directory)
-# to build an "atlas" of world APIs and then performs some analysis on the uploaded API
+# to build a collection of APIs and then performs some analysis on the uploaded API
 # descriptions. It assumes that this repo has been cloned to the user's Desktop,
 # so that it can be found at `~/Desktop/openapi-directory`.
 
@@ -27,8 +27,8 @@
 # server, run `source auth/LOCAL.sh` in the shell before running the following
 # commands.
 
-# First, delete the "atlas" project to get a fresh start.
-apg registry delete-project --name projects/atlas
+# First, delete the "openapi" project to get a fresh start.
+apg registry delete-project --name projects/openapi
 
 # Get the commit hash of the checked-out OpenAPI directory
 export COMMIT=`(cd ~/Desktop/openapi-directory; git rev-parse HEAD)`
@@ -36,92 +36,92 @@ export COMMIT=`(cd ~/Desktop/openapi-directory; git rev-parse HEAD)`
 # Upload all of the APIs in the OpenAPI directory at once.
 # This happens in parallel and usually takes around 2 minutes.
 registry upload bulk openapi \
-	--project_id atlas ~/Desktop/openapi-directory/APIs \
+	--project_id openapi ~/Desktop/openapi-directory/APIs \
 	--base_uri https://github.com/APIs-guru/openapi-directory/blob/$COMMIT/APIs 
 
-# The Atlas project was automatically created. Here we'll use an
+# The openapi project was automatically created. Here we'll use an
 # update-project call to set a few properties of the project.
 apg registry update-project \
-	--project.name "projects/atlas" \
-	--project.display_name "Atlas" \
+	--project.name "projects/openapi" \
+	--project.display_name "OpenAPI Directory" \
 	--project.description "APIs collected from the APIs.guru OpenAPI Directory"
 
 # Now compute summary details of all of the APIs in the project. 
 # This will log errors if any of the API specs can't be parsed,
 # but for every spec that is parsed, this will set the display name
 # and description of the corresponding API from the values in the specs.
-registry compute details projects/atlas/apis/-
+registry compute details projects/openapi/apis/-
 
 # Verify this for one of the APIs.
-registry get projects/atlas/apis/wordnik.com
+registry get projects/openapi/apis/wordnik.com
 
 # You can also get this API with the lower-level apg command.
 # Add the --json option to get JSON-formatted output.
-apg registry get-api --name projects/atlas/apis/wordnik.com --json
+apg registry get-api --name projects/openapi/apis/wordnik.com --json
 
 # List all of the APIs in the project.
-registry list projects/atlas/apis
+registry list projects/openapi/apis
 
 # List all of the versions of an API.
-registry list projects/atlas/apis/wordnik.com/versions
+registry list projects/openapi/apis/wordnik.com/versions
 
 # List all of the specs associated with an API version.
-registry list projects/atlas/apis/wordnik.com/versions/4.0/specs
+registry list projects/openapi/apis/wordnik.com/versions/4.0/specs
 
 # Following [AIP-159](https://google.aip.dev/159), the list operations support the "-" wildcard.
 # This allows us to list objects across multiple collections.
-registry list projects/atlas/apis/wordnik.com/versions/-/specs/-
+registry list projects/openapi/apis/wordnik.com/versions/-/specs/-
 
 # Now let's list all of the specs in the project.
-registry list projects/atlas/apis/-/versions/-/specs/-
+registry list projects/openapi/apis/-/versions/-/specs/-
 
 # That's a lot. Let's count them with `wc -l`.
-registry list projects/atlas/apis/-/versions/-/specs/- | wc -l
+registry list projects/openapi/apis/-/versions/-/specs/- | wc -l
 
 # Using wildcards, we can list all of the specs with a particular version.
-registry list projects/atlas/apis/-/versions/1.0.0/specs/-
+registry list projects/openapi/apis/-/versions/1.0.0/specs/-
 
 # List operations also support filtering by following [AIP-160](https://google.aip.dev/160).
 # Filter functions are evaluated using [CEL](https://github.com/google/cel-spec).
 # Here's an example:
-registry list projects/atlas/apis/-/versions/-/specs/- --filter "api_id.startsWith('goog')"
+registry list projects/openapi/apis/-/versions/-/specs/- --filter "api_id.startsWith('goog')"
 
 # This is a bit more verbose than glob expressions but much more powerful.
 # You can also refer to other fields in the messages that match the pattern:
-registry list projects/atlas/apis/- --filter "description.contains('speech')"
+registry list projects/openapi/apis/- --filter "description.contains('speech')"
 
 # The registry command can also compute some basic API properties.
 # This computes simple complexity metrics for every spec in the project.
-registry compute complexity projects/atlas/apis/-/versions/-/specs/-
+registry compute complexity projects/openapi/apis/-/versions/-/specs/-
 
 # The complexity metrics are stored in artifacts associated with each spec.
 # In this case, the artifacts were stored in a serialized protocol buffer.
 # You can get their values with the "get" subcommand.
-registry get projects/atlas/apis/wordnik.com/versions/4.0/specs/swagger.yaml/artifacts/complexity
+registry get projects/openapi/apis/wordnik.com/versions/4.0/specs/swagger.yaml/artifacts/complexity
 
 # It's also possible to export artifacts to a Google sheet.
 # (The following command expects OAuth client credentials with access to the
 # Google Sheets API to be available locally in ~/.credentials/registry.json)
-registry export sheet projects/atlas/apis/-/versions/-/specs/-/artifacts/complexity \
-	--as projects/atlas/artifacts/complexity-sheet
+registry export sheet projects/openapi/apis/-/versions/-/specs/-/artifacts/complexity \
+	--as projects/openapi/artifacts/complexity-sheet
 
 # Another interesting property that can be computed is the "vocabulary" of an API.
 # The following command computes vocabularies of every API spec in the project.
-registry compute vocabulary projects/atlas/apis/-/versions/-/specs/-
+registry compute vocabulary projects/openapi/apis/-/versions/-/specs/-
 
 # Vocabularies are stored in the "vocabulary" property.
-registry get projects/atlas/apis/wordnik.com/versions/4.0/specs/swagger.yaml/artifacts/vocabulary
+registry get projects/openapi/apis/wordnik.com/versions/4.0/specs/swagger.yaml/artifacts/vocabulary
 
 # The registry command can perform set operations on vocabularies.
 # To find common terms in all Google APIs, use the following:
-registry vocabulary intersection projects/atlas/apis/-/versions/-/specs/-/artifacts/vocabulary --filter "api_id.startsWith('googleapis')"
+registry vocabulary intersection projects/openapi/apis/-/versions/-/specs/-/artifacts/vocabulary --filter "api_id.startsWith('googleapis')"
 
 # We can also save this to a property.
-registry vocabulary intersection projects/atlas/apis/-/versions/-/specs/-/artifacts/vocabulary --filter "api_id.startsWith('googleapis')" --output projects/atlas/artifacts/google-common
+registry vocabulary intersection projects/openapi/apis/-/versions/-/specs/-/artifacts/vocabulary --filter "api_id.startsWith('googleapis')" --output projects/openapi/artifacts/google-common
 
 # We can then read it directly or export it to a Google Sheet.
-registry get projects/atlas/artifacts/google-common
-registry export sheet projects/atlas/artifacts/google-common
+registry get projects/openapi/artifacts/google-common
+registry export sheet projects/openapi/artifacts/google-common
 
 # With vocabulary operations we can discover common terms across groups of APIs,
 # track changes across versions, and find unique terms in APIs that we are reviewing.

--- a/demos/protos.sh
+++ b/demos/protos.sh
@@ -40,7 +40,7 @@ registry upload bulk protos \
 	--project_id protos ~/Desktop/googleapis \
 	--base_uri https://github.com/googleapis/googleapis/blob/$COMMIT 
 
-# The Atlas project was automatically created. Here we'll use an
+# The protos project was automatically created. Here we'll use an
 # update-project call to set a few properties of the project.
 apg registry update-project \
 	--project.name "projects/protos" \


### PR DESCRIPTION
Renaming "atlas" top "openapi" for consistency with the other format-specific demos.