### PR TITLE
Refactor Projects API implementation

### DIFF
--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -130,12 +130,12 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	m, err := names.ParseProject(req.GetParent())
+	name, err := names.ParseProject(req.GetParent())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	if m[1] != "-" {
-		q = q.Require("ProjectID", m[1])
+	if name.ID != "-" {
+		q = q.Require("ProjectID", name.ID)
 	}
 	prg, err := createFilterOperator(req.GetFilter(),
 		[]filterArg{

--- a/server/actions_projects.go
+++ b/server/actions_projects.go
@@ -16,14 +16,14 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
 	"github.com/apigee/registry/server/names"
+	"github.com/apigee/registry/server/storage"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // CreateProject handles the corresponding API request.
@@ -34,29 +34,35 @@ func (s *RegistryServer) CreateProject(ctx context.Context, req *rpc.CreateProje
 	}
 	defer s.releaseStorageClient(client)
 
-	if req.GetProjectId() == "" {
-		req.ProjectId = names.GenerateID()
+	name := names.Project{}
+	if req.GetProjectId() != "" {
+		name.ID = req.GetProjectId()
+	} else {
+		name.ID = names.GenerateID()
 	}
 
-	project, err := models.NewProjectFromProjectID(req.GetProjectId())
-	if err != nil {
+	if _, err := getProject(ctx, client, name); err == nil {
+		return nil, alreadyExistsError(fmt.Errorf("project %q already exists", name))
+	} else if !isNotFound(err) {
+		return nil, err
+	}
+
+	if err := name.Validate(); err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.ProjectEntityName, project.ResourceName())
-	// fail if project already exists
-	existingProject := &models.Project{}
-	err = client.Get(ctx, k, existingProject)
-	if err == nil {
-		return nil, status.Error(codes.AlreadyExists, project.ResourceName()+" already exists")
+
+	project := models.NewProject(name, req.GetProject())
+	if err := saveProject(ctx, client, project); err != nil {
+		return nil, err
 	}
-	err = project.Update(req.GetProject(), nil)
-	project.CreateTime = project.UpdateTime
-	k, err = client.Put(ctx, k, project)
+
+	message, err := project.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}
-	s.notify(rpc.Notification_CREATED, project.ResourceName())
-	return project.Message()
+
+	s.notify(rpc.Notification_CREATED, name.String())
+	return message, nil
 }
 
 // DeleteProject handles the corresponding API request.
@@ -67,28 +73,21 @@ func (s *RegistryServer) DeleteProject(ctx context.Context, req *rpc.DeleteProje
 	}
 	defer s.releaseStorageClient(client)
 
-	// Validate name and create dummy project (we just need the ID field).
-	project, err := models.NewProjectFromResourceName(req.GetName())
+	name, err := names.ParseProject(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
 
-	k := client.NewKey(models.ProjectEntityName, project.ResourceName())
-	if err := client.Get(ctx, k, &models.Project{}); client.IsNotFound(err) {
-		return nil, notFoundError(err)
-	} else if err != nil {
-		return nil, internalError(err)
+	// Deletion should only succeed on projects that currently exist.
+	if _, err := getProject(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if err := client.DeleteChildrenOfProject(ctx, project); err != nil {
-		return nil, internalError(err)
+	if err := deleteProject(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if err := client.Delete(ctx, k); err != nil {
-		return nil, internalError(err)
-	}
-
-	s.notify(rpc.Notification_DELETED, req.GetName())
+	s.notify(rpc.Notification_DELETED, name.String())
 	return &empty.Empty{}, nil
 }
 
@@ -99,18 +98,23 @@ func (s *RegistryServer) GetProject(ctx context.Context, req *rpc.GetProjectRequ
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	project, err := models.NewProjectFromResourceName(req.GetName())
+
+	name, err := names.ParseProject(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.ProjectEntityName, project.ResourceName())
-	err = client.Get(ctx, k, project)
-	if client.IsNotFound(err) {
-		return nil, status.Error(codes.NotFound, "not found")
-	} else if err != nil {
+
+	project, err := getProject(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := project.Message()
+	if err != nil {
 		return nil, internalError(err)
 	}
-	return project.Message()
+
+	return message, nil
 }
 
 // ListProjects handles the corresponding API request.
@@ -122,10 +126,10 @@ func (s *RegistryServer) ListProjects(ctx context.Context, req *rpc.ListProjects
 	defer s.releaseStorageClient(client)
 
 	if req.GetPageSize() < 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid page_size: must not be negative")
+		return nil, invalidArgumentError(fmt.Errorf("invalid page_size %q: must not be negative", req.GetPageSize()))
 	}
 
-	q := client.NewQuery(models.ProjectEntityName)
+	q := client.NewQuery(storage.ProjectEntityName)
 	q, err = q.ApplyCursor(req.GetPageToken())
 	if err != nil {
 		return nil, invalidArgumentError(err)
@@ -149,7 +153,7 @@ func (s *RegistryServer) ListProjects(ctx context.Context, req *rpc.ListProjects
 	for _, err = it.Next(&project); err == nil; _, err = it.Next(&project) {
 		if prg != nil {
 			out, _, err := prg.Eval(map[string]interface{}{
-				"name":         project.ResourceName(),
+				"name":         project.Name(),
 				"project_id":   project.ProjectID,
 				"display_name": project.DisplayName,
 				"description":  project.Description,
@@ -191,22 +195,63 @@ func (s *RegistryServer) UpdateProject(ctx context.Context, req *rpc.UpdateProje
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	project, err := models.NewProjectFromResourceName(req.GetProject().GetName())
+
+	name, err := names.ParseProject(req.GetProject().GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.ProjectEntityName, project.ResourceName())
-	err = client.Get(ctx, k, project)
+
+	project, err := getProject(ctx, client, name)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "not found")
+		return nil, err
 	}
-	err = project.Update(req.GetProject(), req.GetUpdateMask())
+
+	project.Update(req.GetProject(), req.GetUpdateMask())
+	if err := saveProject(ctx, client, project); err != nil {
+		return nil, err
+	}
+
+	message, err := project.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}
-	k, err = client.Put(ctx, k, project)
-	if err != nil {
+
+	return message, nil
+}
+
+func saveProject(ctx context.Context, client storage.Client, project *models.Project) error {
+	k := client.NewKey(storage.ProjectEntityName, project.Name())
+	if _, err := client.Put(ctx, k, project); err != nil {
+		return internalError(err)
+	}
+
+	return nil
+}
+
+func getProject(ctx context.Context, client storage.Client, name names.Project) (*models.Project, error) {
+	project := &models.Project{
+		ProjectID: name.ID,
+	}
+
+	k := client.NewKey(storage.ProjectEntityName, name.String())
+	if err := client.Get(ctx, k, project); client.IsNotFound(err) {
+		return nil, notFoundError(fmt.Errorf("project %q not found", name))
+	} else if err != nil {
 		return nil, internalError(err)
 	}
-	return project.Message()
+
+	return project, nil
+}
+
+func deleteProject(ctx context.Context, client storage.Client, name names.Project) error {
+	if err := client.DeleteChildrenOfProject(ctx, name); err != nil {
+		return internalError(err)
+	}
+
+	k := client.NewKey(storage.ProjectEntityName, name.String())
+	if err := client.Delete(ctx, k); err != nil {
+		return internalError(err)
+	}
+
+	return nil
 }

--- a/server/actions_projects_test.go
+++ b/server/actions_projects_test.go
@@ -20,13 +20,13 @@ func seedProjects(ctx context.Context, t *testing.T, s *RegistryServer, projects
 	t.Helper()
 
 	for _, p := range projects {
-		m, err := names.ParseProject(p.Name)
+		name, err := names.ParseProject(p.Name)
 		if err != nil {
 			t.Fatalf("Setup/Seeding: ParseProject(%q) returned error: %s", p.Name, err)
 		}
 
 		req := &rpc.CreateProjectRequest{
-			ProjectId: m[1],
+			ProjectId: name.ID,
 			Project:   p,
 		}
 

--- a/server/datastore/deletions.go
+++ b/server/datastore/deletions.go
@@ -20,6 +20,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/apigee/registry/server/models"
+	"github.com/apigee/registry/server/names"
 	"github.com/apigee/registry/server/storage"
 	"google.golang.org/api/iterator"
 )
@@ -58,7 +59,7 @@ func (c *Client) DeleteAllMatches(ctx context.Context, q storage.Query) error {
 }
 
 // DeleteChildrenOfProject deletes all the children of a project.
-func (c *Client) DeleteChildrenOfProject(ctx context.Context, project *models.Project) error {
+func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Project) error {
 	entityNames := []string{
 		models.ArtifactEntityName,
 		models.BlobEntityName,
@@ -70,7 +71,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project *models.Pr
 	for _, entityName := range entityNames {
 		q := datastore.NewQuery(entityName)
 		q = q.KeysOnly()
-		q = q.Filter("ProjectID =", project.ProjectID)
+		q = q.Filter("ProjectID =", project.ID)
 		err := c.DeleteAllMatches(ctx, &Query{query: q})
 		if err != nil {
 			return err

--- a/server/errors.go
+++ b/server/errors.go
@@ -48,3 +48,10 @@ func notFoundError(err error) error {
 	}
 	return status.Error(codes.NotFound, err.Error())
 }
+
+func alreadyExistsError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return status.Error(codes.AlreadyExists, err.Error())
+}

--- a/server/gorm/deletions.go
+++ b/server/gorm/deletions.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/apigee/registry/server/models"
+	"github.com/apigee/registry/server/names"
 	"github.com/apigee/registry/server/storage"
 )
 
@@ -47,7 +48,7 @@ func (c *Client) DeleteAllMatches(ctx context.Context, q storage.Query) error {
 }
 
 // DeleteChildrenOfProject deletes all the children of a project.
-func (c *Client) DeleteChildrenOfProject(ctx context.Context, project *models.Project) error {
+func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Project) error {
 	entityNames := []string{
 		models.ArtifactEntityName,
 		models.BlobEntityName,
@@ -58,7 +59,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project *models.Pr
 	}
 	for _, entityName := range entityNames {
 		q := c.NewQuery(entityName)
-		q = q.Require("ProjectID", project.ProjectID)
+		q = q.Require("ProjectID", project.ID)
 		err := c.DeleteAllMatches(ctx, q)
 		if err != nil {
 			return err

--- a/server/models/api.go
+++ b/server/models/api.go
@@ -44,7 +44,7 @@ type Api struct {
 
 // NewApiFromParentAndApiID returns an initialized api for a specified parent and ID.
 func NewApiFromParentAndApiID(parent string, id string) (*Api, error) {
-	m, err := names.ParseProject(parent)
+	project, err := names.ParseProject(parent)
 	if err != nil {
 		return nil, err
 	} else if err := names.ValidateID(id); err != nil {
@@ -52,7 +52,7 @@ func NewApiFromParentAndApiID(parent string, id string) (*Api, error) {
 	}
 
 	return &Api{
-		ProjectID: m[1],
+		ProjectID: project.ID,
 		ApiID:     id,
 	}, nil
 }

--- a/server/names/project.go
+++ b/server/names/project.go
@@ -19,6 +19,26 @@ import (
 	"regexp"
 )
 
+// Project represents a resource name for a project.
+type Project struct {
+	ID string
+}
+
+// Validate returns an error if the resource name is invalid.
+// For backward compatibility, names should only be validated at creation time.
+func (p Project) Validate() error {
+	r := ProjectRegexp()
+	if name := p.String(); !r.MatchString(name) {
+		return fmt.Errorf("invalid project name %q: must match %q", name, r)
+	}
+
+	return nil
+}
+
+func (p Project) String() string {
+	return fmt.Sprintf("projects/%s", p.ID)
+}
+
 // ProjectsRegexp returns a regular expression that matches collection of projects.
 func ProjectsRegexp() *regexp.Regexp {
 	return regexp.MustCompile("^projects$")
@@ -30,11 +50,14 @@ func ProjectRegexp() *regexp.Regexp {
 }
 
 // ParseProject parses the name of a project.
-func ParseProject(name string) ([]string, error) {
+func ParseProject(name string) (Project, error) {
 	r := ProjectRegexp()
-	m := r.FindStringSubmatch(name)
-	if m == nil {
-		return nil, fmt.Errorf("invalid project name %q: must match %q", name, r)
+	if !r.MatchString(name) {
+		return Project{}, fmt.Errorf("invalid project name %q: must match %q", name, r)
 	}
-	return m, nil
+
+	m := r.FindStringSubmatch(name)
+	return Project{
+		ID: m[1],
+	}, nil
 }

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -20,6 +20,12 @@ import (
 	"context"
 
 	"github.com/apigee/registry/server/models"
+	"github.com/apigee/registry/server/names"
+)
+
+const (
+	// ProjectEntityName is the storage entity name for project resources.
+	ProjectEntityName = "Project"
 )
 
 type Client interface {
@@ -37,7 +43,7 @@ type Client interface {
 	NewQuery(query string) Query
 
 	DeleteAllMatches(ctx context.Context, q Query) error
-	DeleteChildrenOfProject(ctx context.Context, project *models.Project) error
+	DeleteChildrenOfProject(ctx context.Context, project names.Project) error
 	DeleteChildrenOfApi(ctx context.Context, api *models.Api) error
 	DeleteChildrenOfVersion(ctx context.Context, version *models.Version) error
 	DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error


### PR DESCRIPTION
This change is in preparation for incoming functional changes. The
purpose of adding a resource name type is to remove string processing
from our RPC handler implementations as the string manipulation
increases in complexity. Name types will be added to Api/Version/Spec in
a follow-up.

* Add type for project resource names, refactor APIs where applicable.
* Move project storage entity name into storage package.
* Refactor common project operations into helper functions.
* Check additional errors before returning
* Consistently use error helper functions.
* Remove redundant import names.