### PR TITLE
Refactor API service

### DIFF
--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -16,14 +16,14 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
 	"github.com/apigee/registry/server/names"
+	"github.com/apigee/registry/server/storage"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // CreateApi handles the corresponding API request.
@@ -34,29 +34,47 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 	}
 	defer s.releaseStorageClient(client)
 
-	if req.GetApiId() == "" {
-		req.ApiId = names.GenerateID()
-	}
-
-	api, err := models.NewApiFromParentAndApiID(req.GetParent(), req.GetApiId())
+	parent, err := names.ParseProject(req.GetParent())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.ApiEntityName, api.ResourceName())
-	// fail if api already exists
-	existingApi := &models.Api{}
-	err = client.Get(ctx, k, existingApi)
-	if err == nil {
-		return nil, status.Error(codes.AlreadyExists, api.ResourceName()+" already exists")
+
+	// Creation should only succeed when the parent exists.
+	if _, err := getProject(ctx, client, parent); err != nil {
+		return nil, err
 	}
-	err = api.Update(req.GetApi(), nil)
-	api.CreateTime = api.UpdateTime
-	k, err = client.Put(ctx, k, api)
+
+	name := parent.Api(req.GetApiId())
+	if name.ApiID == "" {
+		name.ApiID = names.GenerateID()
+	}
+
+	if _, err := getApi(ctx, client, name); err == nil {
+		return nil, alreadyExistsError(fmt.Errorf("API %q already exists", name))
+	} else if !isNotFound(err) {
+		return nil, err
+	}
+
+	if err := name.Validate(); err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	api, err := models.NewApi(name, req.GetApi())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	if err := saveApi(ctx, client, api); err != nil {
+		return nil, err
+	}
+
+	message, err := api.Message(rpc.View_BASIC)
 	if err != nil {
 		return nil, internalError(err)
 	}
-	s.notify(rpc.Notification_CREATED, api.ResourceName())
-	return api.Message(rpc.View_BASIC)
+
+	s.notify(rpc.Notification_CREATED, name.String())
+	return message, nil
 }
 
 // DeleteApi handles the corresponding API request.
@@ -67,28 +85,21 @@ func (s *RegistryServer) DeleteApi(ctx context.Context, req *rpc.DeleteApiReques
 	}
 	defer s.releaseStorageClient(client)
 
-	// Validate name and create dummy api (we just need the ID fields).
-	api, err := models.NewApiFromResourceName(req.GetName())
+	name, err := names.ParseApi(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
 
-	k := client.NewKey(models.ApiEntityName, req.GetName())
-	if err := client.Get(ctx, k, &models.Api{}); client.IsNotFound(err) {
-		return nil, notFoundError(err)
-	} else if err != nil {
-		return nil, internalError(err)
+	// Deletion should only succeed on APIs that currently exist.
+	if _, err := getApi(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if err := client.DeleteChildrenOfApi(ctx, api); err != nil {
-		return nil, internalError(err)
+	if err := deleteApi(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if err := client.Delete(ctx, k); err != nil {
-		return nil, internalError(err)
-	}
-
-	s.notify(rpc.Notification_DELETED, req.GetName())
+	s.notify(rpc.Notification_DELETED, name.String())
 	return &empty.Empty{}, nil
 }
 
@@ -99,18 +110,23 @@ func (s *RegistryServer) GetApi(ctx context.Context, req *rpc.GetApiRequest) (*r
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	api, err := models.NewApiFromResourceName(req.GetName())
+
+	name, err := names.ParseApi(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.ApiEntityName, api.ResourceName())
-	err = client.Get(ctx, k, api)
-	if client.IsNotFound(err) {
-		return nil, status.Error(codes.NotFound, "not found")
-	} else if err != nil {
+
+	api, err := getApi(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := api.Message(req.GetView())
+	if err != nil {
 		return nil, internalError(err)
 	}
-	return api.Message(req.GetView())
+
+	return message, nil
 }
 
 // ListApis handles the corresponding API request.
@@ -122,10 +138,10 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 	defer s.releaseStorageClient(client)
 
 	if req.GetPageSize() < 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid page_size: must not be negative")
+		return nil, invalidArgumentError(fmt.Errorf("invalid page_size %q: must not be negative", req.GetPageSize()))
 	}
 
-	q := client.NewQuery(models.ApiEntityName)
+	q := client.NewQuery(storage.ApiEntityName)
 	q, err = q.ApplyCursor(req.GetPageToken())
 	if err != nil {
 		return nil, invalidArgumentError(err)
@@ -210,23 +226,67 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	api, err := models.NewApiFromResourceName(req.GetApi().GetName())
+
+	name, err := names.ParseApi(req.Api.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.ApiEntityName, api.ResourceName())
-	err = client.Get(ctx, k, api)
+
+	api, err := getApi(ctx, client, name)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "not found")
+		return nil, err
 	}
-	err = api.Update(req.GetApi(), req.GetUpdateMask())
+
+	if err := api.Update(req.GetApi(), req.GetUpdateMask()); err != nil {
+		return nil, internalError(err)
+	}
+
+	if err := saveApi(ctx, client, api); err != nil {
+		return nil, err
+	}
+
+	message, err := api.Message(rpc.View_BASIC)
 	if err != nil {
 		return nil, internalError(err)
 	}
-	k, err = client.Put(ctx, k, api)
-	if err != nil {
+
+	s.notify(rpc.Notification_UPDATED, name.String())
+	return message, nil
+}
+
+func saveApi(ctx context.Context, client storage.Client, api *models.Api) error {
+	k := client.NewKey(storage.ApiEntityName, api.ResourceName())
+	if _, err := client.Put(ctx, k, api); err != nil {
+		return internalError(err)
+	}
+
+	return nil
+}
+
+func getApi(ctx context.Context, client storage.Client, name names.Api) (*models.Api, error) {
+	api := &models.Api{
+		ApiID: name.ApiID,
+	}
+
+	k := client.NewKey(storage.ApiEntityName, name.String())
+	if err := client.Get(ctx, k, api); client.IsNotFound(err) {
+		return nil, notFoundError(fmt.Errorf("api %q not found", name))
+	} else if err != nil {
 		return nil, internalError(err)
 	}
-	s.notify(rpc.Notification_UPDATED, api.ResourceName())
-	return api.Message(rpc.View_BASIC)
+
+	return api, nil
+}
+
+func deleteApi(ctx context.Context, client storage.Client, name names.Api) error {
+	if err := client.DeleteChildrenOfApi(ctx, name); err != nil {
+		return internalError(err)
+	}
+
+	k := client.NewKey(storage.ApiEntityName, name.String())
+	if err := client.Delete(ctx, k); err != nil {
+		return internalError(err)
+	}
+
+	return nil
 }

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -176,7 +176,7 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 	for _, err = it.Next(&api); err == nil; _, err = it.Next(&api) {
 		if prg != nil {
 			filterInputs := map[string]interface{}{
-				"name":                api.ResourceName(),
+				"name":                api.Name(),
 				"project_id":          api.ProjectID,
 				"api_id":              api.ApiID,
 				"display_name":        api.DisplayName,
@@ -255,7 +255,7 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 }
 
 func saveApi(ctx context.Context, client storage.Client, api *models.Api) error {
-	k := client.NewKey(storage.ApiEntityName, api.ResourceName())
+	k := client.NewKey(storage.ApiEntityName, api.Name())
 	if _, err := client.Put(ctx, k, api); err != nil {
 		return internalError(err)
 	}

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -131,15 +131,15 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	m, err := names.ParseApi(req.GetParent())
+	parent, err := names.ParseApi(req.GetParent())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	if m[1] != "-" {
-		q = q.Require("ProjectID", m[1])
+	if parent.ProjectID != "-" {
+		q = q.Require("ProjectID", parent.ProjectID)
 	}
-	if m[2] != "-" {
-		q = q.Require("ApiID", m[2])
+	if parent.ApiID != "-" {
+		q = q.Require("ApiID", parent.ApiID)
 	}
 	prg, err := createFilterOperator(req.GetFilter(),
 		[]filterArg{

--- a/server/datastore/deletions.go
+++ b/server/datastore/deletions.go
@@ -66,7 +66,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 		models.SpecEntityName,
 		models.SpecRevisionTagEntityName,
 		models.VersionEntityName,
-		models.ApiEntityName,
+		storage.ApiEntityName,
 	}
 	for _, entityName := range entityNames {
 		q := datastore.NewQuery(entityName)
@@ -81,7 +81,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 }
 
 // DeleteChildrenOfApi deletes all the children of a api.
-func (c *Client) DeleteChildrenOfApi(ctx context.Context, api *models.Api) error {
+func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
 		models.SpecEntityName,

--- a/server/gorm/deletions.go
+++ b/server/gorm/deletions.go
@@ -55,7 +55,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 		models.SpecEntityName,
 		models.SpecRevisionTagEntityName,
 		models.VersionEntityName,
-		models.ApiEntityName,
+		storage.ApiEntityName,
 	}
 	for _, entityName := range entityNames {
 		q := c.NewQuery(entityName)
@@ -69,7 +69,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 }
 
 // DeleteChildrenOfApi deletes all the children of a api.
-func (c *Client) DeleteChildrenOfApi(ctx context.Context, api *models.Api) error {
+func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
 		models.SpecEntityName,

--- a/server/gorm/gorm_test.go
+++ b/server/gorm/gorm_test.go
@@ -112,7 +112,7 @@ func TestLoad(t *testing.T) {
 					CreateTime:  now,
 					UpdateTime:  now,
 				}
-				k := c.NewKey(storage.ApiEntityName, api.ResourceName())
+				k := c.NewKey(storage.ApiEntityName, api.Name())
 				// fail if api already exists
 				existing := &models.Api{}
 				err := c.Get(ctx, k, existing)

--- a/server/gorm/gorm_test.go
+++ b/server/gorm/gorm_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/apigee/registry/server/models"
+	"github.com/apigee/registry/server/storage"
 )
 
 func TestCRUD(t *testing.T) {
@@ -111,7 +112,7 @@ func TestLoad(t *testing.T) {
 					CreateTime:  now,
 					UpdateTime:  now,
 				}
-				k := c.NewKey(models.ApiEntityName, api.ResourceName())
+				k := c.NewKey(storage.ApiEntityName, api.ResourceName())
 				// fail if api already exists
 				existing := &models.Api{}
 				err := c.Get(ctx, k, existing)

--- a/server/models/api.go
+++ b/server/models/api.go
@@ -66,38 +66,38 @@ func NewApi(name names.Api, body *rpc.Api) (api *Api, err error) {
 	return api, nil
 }
 
-// ResourceName generates the resource name of a api.
-func (a *Api) ResourceName() string {
-	return fmt.Sprintf("projects/%s/apis/%s", a.ProjectID, a.ApiID)
+// Name returns the resource name of the api.
+func (api *Api) Name() string {
+	return fmt.Sprintf("projects/%s/apis/%s", api.ProjectID, api.ApiID)
 }
 
 // Message returns a message representing an api.
-func (a *Api) Message(view rpc.View) (message *rpc.Api, err error) {
+func (api *Api) Message(view rpc.View) (message *rpc.Api, err error) {
 	message = &rpc.Api{
-		Name:               a.ResourceName(),
-		DisplayName:        a.DisplayName,
-		Description:        a.Description,
-		Availability:       a.Availability,
-		RecommendedVersion: a.RecommendedVersion,
+		Name:               api.Name(),
+		DisplayName:        api.DisplayName,
+		Description:        api.Description,
+		Availability:       api.Availability,
+		RecommendedVersion: api.RecommendedVersion,
 	}
 
-	message.CreateTime, err = ptypes.TimestampProto(a.CreateTime)
+	message.CreateTime, err = ptypes.TimestampProto(api.CreateTime)
 	if err != nil {
 		return nil, err
 	}
 
-	message.UpdateTime, err = ptypes.TimestampProto(a.UpdateTime)
+	message.UpdateTime, err = ptypes.TimestampProto(api.UpdateTime)
 	if err != nil {
 		return nil, err
 	}
 
-	message.Labels, err = a.LabelsMap()
+	message.Labels, err = api.LabelsMap()
 	if err != nil {
 		return nil, err
 	}
 
 	if view == rpc.View_FULL {
-		message.Annotations, err = mapForBytes(a.Annotations)
+		message.Annotations, err = mapForBytes(api.Annotations)
 		if err != nil {
 			return nil, err
 		}
@@ -107,48 +107,48 @@ func (a *Api) Message(view rpc.View) (message *rpc.Api, err error) {
 }
 
 // Update modifies a api using the contents of a message.
-func (a *Api) Update(message *rpc.Api, mask *fieldmaskpb.FieldMask) error {
+func (api *Api) Update(message *rpc.Api, mask *fieldmaskpb.FieldMask) error {
 	if activeUpdateMask(mask) {
 		for _, field := range mask.Paths {
 			switch field {
 			case "display_name":
-				a.DisplayName = message.GetDisplayName()
+				api.DisplayName = message.GetDisplayName()
 			case "description":
-				a.Description = message.GetDescription()
+				api.Description = message.GetDescription()
 			case "availability":
-				a.Availability = message.GetAvailability()
+				api.Availability = message.GetAvailability()
 			case "recommended_version":
-				a.RecommendedVersion = message.GetRecommendedVersion()
+				api.RecommendedVersion = message.GetRecommendedVersion()
 			case "labels":
 				var err error
-				if a.Labels, err = bytesForMap(message.GetLabels()); err != nil {
+				if api.Labels, err = bytesForMap(message.GetLabels()); err != nil {
 					return err
 				}
 			case "annotations":
 				var err error
-				if a.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
+				if api.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
 					return err
 				}
 			}
 		}
 	} else {
-		a.DisplayName = message.GetDisplayName()
-		a.Description = message.GetDescription()
-		a.Availability = message.GetAvailability()
-		a.RecommendedVersion = message.GetRecommendedVersion()
+		api.DisplayName = message.GetDisplayName()
+		api.Description = message.GetDescription()
+		api.Availability = message.GetAvailability()
+		api.RecommendedVersion = message.GetRecommendedVersion()
 		var err error
-		if a.Labels, err = bytesForMap(message.GetLabels()); err != nil {
+		if api.Labels, err = bytesForMap(message.GetLabels()); err != nil {
 			return err
 		}
-		if a.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
+		if api.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
 			return err
 		}
 	}
-	a.UpdateTime = time.Now()
+	api.UpdateTime = time.Now()
 	return nil
 }
 
 // LabelsMap returns a map representation of stored labels.
-func (a *Api) LabelsMap() (map[string]string, error) {
-	return mapForBytes(a.Labels)
+func (api *Api) LabelsMap() (map[string]string, error) {
+	return mapForBytes(api.Labels)
 }

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	ptypes "github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -44,7 +44,7 @@ type Version struct {
 
 // NewVersionFromParentAndVersionID returns an initialized version for a specified parent and ID.
 func NewVersionFromParentAndVersionID(parent string, id string) (*Version, error) {
-	m, err := names.ParseApi(parent)
+	api, err := names.ParseApi(parent)
 	if err != nil {
 		return nil, err
 	} else if err := names.ValidateID(id); err != nil {
@@ -52,8 +52,8 @@ func NewVersionFromParentAndVersionID(parent string, id string) (*Version, error
 	}
 
 	return &Version{
-		ProjectID: m[1],
-		ApiID:     m[2],
+		ProjectID: api.ProjectID,
+		ApiID:     api.ApiID,
 		VersionID: id,
 	}, nil
 }

--- a/server/names/project.go
+++ b/server/names/project.go
@@ -35,6 +35,14 @@ func (p Project) Validate() error {
 	return nil
 }
 
+// Api returns an API with the provided ID and this resource as its parent.
+func (p Project) Api(id string) Api {
+	return Api{
+		ProjectID: p.ProjectID,
+		ApiID:     id,
+	}
+}
+
 func (p Project) String() string {
 	return fmt.Sprintf("projects/%s", p.ProjectID)
 }

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -26,6 +26,8 @@ import (
 const (
 	// ProjectEntityName is the storage entity name for project resources.
 	ProjectEntityName = "Project"
+	// ApiEntityName is the storage entity name for project resources.
+	ApiEntityName = "Api"
 )
 
 type Client interface {
@@ -44,7 +46,7 @@ type Client interface {
 
 	DeleteAllMatches(ctx context.Context, q Query) error
 	DeleteChildrenOfProject(ctx context.Context, project names.Project) error
-	DeleteChildrenOfApi(ctx context.Context, api *models.Api) error
+	DeleteChildrenOfApi(ctx context.Context, api names.Api) error
 	DeleteChildrenOfVersion(ctx context.Context, version *models.Version) error
 	DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error
 }


### PR DESCRIPTION
* Add type for API resource names, refactor interfaces where applicable.
* Move API storage entity name into storage package.
* Refactor common API operations into helper functions.
* Check additional errors before returning
* Consistently use error helper functions.
* Remove redundant import names.