### PR TITLE
fix crashes caused by brittle type cast in filter evaluation

### DIFF
--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -16,7 +16,7 @@ package server
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -179,11 +179,9 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			v, ok := out.Value().(bool)
-			if !ok {
-				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
-			}
-			if !v {
+			if v, ok := out.Value().(bool); !ok {
+				return nil, invalidArgumentError(fmt.Errorf("expression does not evaluate to a boolean (instead yielding %T)", out.Value()))
+			} else if !v {
 				continue
 			}
 		}

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -178,7 +179,11 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			if !out.Value().(bool) {
+			v, ok := out.Value().(bool)
+			if !ok {
+				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
+			}
+			if !v {
 				continue
 			}
 		}

--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"github.com/apigee/registry/rpc"
@@ -187,7 +188,11 @@ func (s *RegistryServer) ListArtifacts(ctx context.Context, req *rpc.ListArtifac
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			if !out.Value().(bool) {
+			v, ok := out.Value().(bool)
+			if !ok {
+				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
+			}
+			if !v {
 				continue
 			}
 		}

--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -16,7 +16,7 @@ package server
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
 
 	"github.com/apigee/registry/rpc"
@@ -188,11 +188,9 @@ func (s *RegistryServer) ListArtifacts(ctx context.Context, req *rpc.ListArtifac
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			v, ok := out.Value().(bool)
-			if !ok {
-				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
-			}
-			if !v {
+			if v, ok := out.Value().(bool); !ok {
+				return nil, invalidArgumentError(fmt.Errorf("expression does not evaluate to a boolean (instead yielding %T)", out.Value()))
+			} else if !v {
 				continue
 			}
 		}

--- a/server/actions_projects.go
+++ b/server/actions_projects.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -159,7 +160,11 @@ func (s *RegistryServer) ListProjects(ctx context.Context, req *rpc.ListProjects
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			if !out.Value().(bool) {
+			v, ok := out.Value().(bool)
+			if !ok {
+				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
+			}
+			if !v {
 				continue
 			}
 		}

--- a/server/actions_projects.go
+++ b/server/actions_projects.go
@@ -16,7 +16,7 @@ package server
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -160,11 +160,9 @@ func (s *RegistryServer) ListProjects(ctx context.Context, req *rpc.ListProjects
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			v, ok := out.Value().(bool)
-			if !ok {
-				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
-			}
-			if !v {
+			if v, ok := out.Value().(bool); !ok {
+				return nil, invalidArgumentError(fmt.Errorf("expression does not evaluate to a boolean (instead yielding %T)", out.Value()))
+			} else if !v {
 				continue
 			}
 		}

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -249,7 +249,11 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			if !out.Value().(bool) {
+			v, ok := out.Value().(bool)
+			if !ok {
+				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
+			}
+			if !v {
 				continue
 			}
 		}

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"sort"
 	"time"
@@ -249,11 +250,9 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			v, ok := out.Value().(bool)
-			if !ok {
-				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
-			}
-			if !v {
+			if v, ok := out.Value().(bool); !ok {
+				return nil, invalidArgumentError(fmt.Errorf("expression does not evaluate to a boolean (instead yielding %T)", out.Value()))
+			} else if !v {
 				continue
 			}
 		}

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -182,7 +183,11 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			if !out.Value().(bool) {
+			v, ok := out.Value().(bool)
+			if !ok {
+				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
+			}
+			if !v {
 				continue
 			}
 		}

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -16,7 +16,7 @@ package server
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -183,11 +183,9 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 			if err != nil {
 				return nil, invalidArgumentError(err)
 			}
-			v, ok := out.Value().(bool)
-			if !ok {
-				return nil, invalidArgumentError(errors.New("expression does not evaluate to a boolean"))
-			}
-			if !v {
+			if v, ok := out.Value().(bool); !ok {
+				return nil, invalidArgumentError(fmt.Errorf("expression does not evaluate to a boolean (instead yielding %T)", out.Value()))
+			} else if !v {
 				continue
 			}
 		}


### PR DESCRIPTION
This fixes crashes that occurred when filter expressions did not evaluate to bool. Such expressions are now treated as invalid arguments.