### PR TITLE
Expand testing for API methods

### DIFF
--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -68,7 +68,7 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 		return nil, err
 	}
 
-	message, err := api.Message(rpc.View_BASIC)
+	message, err := api.Message(rpc.View_FULL)
 	if err != nil {
 		return nil, internalError(err)
 	}

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -245,7 +245,7 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 		return nil, err
 	}
 
-	message, err := api.Message(rpc.View_BASIC)
+	message, err := api.Message(rpc.View_FULL)
 	if err != nil {
 		return nil, internalError(err)
 	}

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -152,6 +152,9 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 	}
 	if name.ProjectID != "-" {
 		q = q.Require("ProjectID", name.ProjectID)
+		if _, err := getProject(ctx, client, name); err != nil {
+			return nil, err
+		}
 	}
 	prg, err := createFilterOperator(req.GetFilter(),
 		[]filterArg{

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -68,7 +68,7 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 		return nil, err
 	}
 
-	message, err := api.Message(rpc.View_FULL)
+	message, err := api.Message(rpc.View_BASIC)
 	if err != nil {
 		return nil, internalError(err)
 	}
@@ -248,7 +248,7 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 		return nil, err
 	}
 
-	message, err := api.Message(rpc.View_FULL)
+	message, err := api.Message(rpc.View_BASIC)
 	if err != nil {
 		return nil, internalError(err)
 	}

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -637,7 +637,17 @@ func TestUpdateApi(t *testing.T) {
 		want *rpc.Api
 	}{
 		{
-			desc: "default parameters",
+			desc: "populated resource with default parameters",
+			seed: fullApi,
+			req: &rpc.UpdateApiRequest{
+				Api: &rpc.Api{
+					Name: fullApi.Name,
+				},
+			},
+			want: fullApi,
+		},
+		{
+			desc: "implicit mask",
 			seed: &rpc.Api{
 				Name:        "projects/my-project/apis/my-api",
 				DisplayName: "My Api",

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -90,7 +90,7 @@ func TestCreateApi(t *testing.T) {
 				Parent: "projects/my-project",
 				Api:    fullApi,
 			},
-			want: fullApi,
+			want: basicApi,
 			// Name field is generated.
 			extraOpts: protocmp.IgnoreFields(new(rpc.Api), "name"),
 		},
@@ -144,7 +144,7 @@ func TestCreateApi(t *testing.T) {
 			t.Run("GetApi", func(t *testing.T) {
 				req := &rpc.GetApiRequest{
 					Name: created.GetName(),
-					View: rpc.View_FULL,
+					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApi(ctx, req)
@@ -675,7 +675,7 @@ func TestUpdateApi(t *testing.T) {
 					Name: fullApi.Name,
 				},
 			},
-			want: fullApi,
+			want: basicApi,
 		},
 		{
 			desc: "implicit mask",
@@ -762,6 +762,7 @@ func TestUpdateApi(t *testing.T) {
 			t.Run("GetApi", func(t *testing.T) {
 				req := &rpc.GetApiRequest{
 					Name: updated.GetName(),
+					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApi(ctx, req)

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -264,6 +264,64 @@ func TestCreateApiDuplicates(t *testing.T) {
 	})
 }
 
+func TestGetApi(t *testing.T) {
+	tests := []struct {
+		desc string
+		seed *rpc.Api
+		req  *rpc.GetApiRequest
+		want *rpc.Api
+	}{
+		{
+			desc: "default view",
+			seed: fullApi,
+			req: &rpc.GetApiRequest{
+				Name: fullApi.Name,
+			},
+			want: basicApi,
+		},
+		{
+			desc: "basic view",
+			seed: fullApi,
+			req: &rpc.GetApiRequest{
+				Name: fullApi.Name,
+				View: rpc.View_BASIC,
+			},
+			want: basicApi,
+		},
+		{
+			desc: "full view",
+			seed: fullApi,
+			req: &rpc.GetApiRequest{
+				Name: fullApi.Name,
+				View: rpc.View_FULL,
+			},
+			want: fullApi,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedApis(ctx, t, server, test.seed)
+
+			got, err := server.GetApi(ctx, test.req)
+			if err != nil {
+				t.Fatalf("GetApi(%+v) returned error: %s", test.req, err)
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(new(rpc.Api), "create_time", "update_time"),
+			}
+
+			if !cmp.Equal(test.want, got, opts) {
+				t.Errorf("GetApi(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, got, opts))
+			}
+		})
+	}
+}
+
 func TestGetApiResponseCodes(t *testing.T) {
 	tests := []struct {
 		desc string


### PR DESCRIPTION
* Check for non-existent parent resources in List/Create methods
* Check basic/full API responses in Create/Get/Update methods
* Check that List only returns APIs from a specified parent project
* Check that List works across multiple collections