### PR TITLE
Refactor Versions service

### DIFF
--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
 	"github.com/apigee/registry/server/names"
-	storage "github.com/apigee/registry/server/storage"
+	"github.com/apigee/registry/server/storage"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
@@ -186,18 +186,18 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	m, err := names.ParseVersion(req.GetParent())
+	parent, err := names.ParseVersion(req.GetParent())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	if m[1] != "-" {
-		q = q.Require("ProjectID", m[1])
+	if id := parent.ProjectID; id != "-" {
+		q = q.Require("ProjectID", id)
 	}
-	if m[2] != "-" {
-		q = q.Require("ApiID", m[2])
+	if id := parent.ApiID; id != "-" {
+		q = q.Require("ApiID", id)
 	}
-	if m[3] != "-" {
-		q = q.Require("VersionID", m[3])
+	if id := parent.VersionID; id != "-" {
+		q = q.Require("VersionID", id)
 	}
 	q = q.Require("Currency", models.IsCurrent)
 	prg, err := createFilterOperator(req.GetFilter(),

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -16,14 +16,14 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
 	"github.com/apigee/registry/server/names"
+	"github.com/apigee/registry/server/storage"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // CreateApiVersion handles the corresponding API request.
@@ -34,29 +34,47 @@ func (s *RegistryServer) CreateApiVersion(ctx context.Context, req *rpc.CreateAp
 	}
 	defer s.releaseStorageClient(client)
 
-	if req.GetApiVersionId() == "" {
-		req.ApiVersionId = names.GenerateID()
-	}
-
-	version, err := models.NewVersionFromParentAndVersionID(req.GetParent(), req.GetApiVersionId())
+	parent, err := names.ParseApi(req.GetParent())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.VersionEntityName, version.ResourceName())
-	// fail if version already exists
-	existingVersion := &models.Version{}
-	err = client.Get(ctx, k, existingVersion)
-	if err == nil {
-		return nil, status.Error(codes.AlreadyExists, version.ResourceName()+" already exists")
+
+	// Creation should only succeed when the parent exists.
+	if _, err := getApi(ctx, client, parent); err != nil {
+		return nil, err
 	}
-	err = version.Update(req.GetApiVersion(), nil)
-	version.CreateTime = version.UpdateTime
-	k, err = client.Put(ctx, k, version)
+
+	name := parent.Version(req.GetApiVersionId())
+	if name.VersionID == "" {
+		name.VersionID = names.GenerateID()
+	}
+
+	if _, err := getVersion(ctx, client, name); err == nil {
+		return nil, alreadyExistsError(fmt.Errorf("API version %q already exists", name))
+	} else if !isNotFound(err) {
+		return nil, err
+	}
+
+	if err := name.Validate(); err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	version, err := models.NewVersion(name, req.GetApiVersion())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	if err := saveVersion(ctx, client, version); err != nil {
+		return nil, err
+	}
+
+	message, err := version.Message(rpc.View_BASIC)
 	if err != nil {
 		return nil, internalError(err)
 	}
-	s.notify(rpc.Notification_CREATED, version.ResourceName())
-	return version.Message(rpc.View_BASIC)
+
+	s.notify(rpc.Notification_CREATED, name.String())
+	return message, nil
 }
 
 // DeleteApiVersion handles the corresponding API request.
@@ -67,29 +85,21 @@ func (s *RegistryServer) DeleteApiVersion(ctx context.Context, req *rpc.DeleteAp
 	}
 	defer s.releaseStorageClient(client)
 
-	// Validate name and create dummy version (we just need the ID fields).
-	version, err := models.NewVersionFromResourceName(req.GetName())
+	name, err := names.ParseVersion(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
 
-	k := client.NewKey(models.VersionEntityName, req.GetName())
-	if err := client.Get(ctx, k, &models.Version{}); client.IsNotFound(err) {
-		return nil, notFoundError(err)
-	} else if err != nil {
-		return nil, internalError(err)
+	// Deletion should only succeed on API versions that currently exist.
+	if _, err := getVersion(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	// Delete children first and then delete the version.
-	if err := client.DeleteChildrenOfVersion(ctx, version); err != nil {
-		return nil, internalError(err)
+	if err := deleteVersion(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if err := client.Delete(ctx, k); err != nil {
-		return nil, internalError(err)
-	}
-
-	s.notify(rpc.Notification_DELETED, req.GetName())
+	s.notify(rpc.Notification_DELETED, name.String())
 	return &empty.Empty{}, nil
 }
 
@@ -100,18 +110,23 @@ func (s *RegistryServer) GetApiVersion(ctx context.Context, req *rpc.GetApiVersi
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	version, err := models.NewVersionFromResourceName(req.GetName())
+
+	name, err := names.ParseVersion(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.VersionEntityName, version.ResourceName())
-	err = client.Get(ctx, k, version)
-	if client.IsNotFound(err) {
-		return nil, status.Error(codes.NotFound, "not found")
-	} else if err != nil {
+
+	version, err := getVersion(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := version.Message(req.GetView())
+	if err != nil {
 		return nil, internalError(err)
 	}
-	return version.Message(req.GetView())
+
+	return message, nil
 }
 
 // ListApiVersions handles the corresponding API request.
@@ -123,10 +138,10 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 	defer s.releaseStorageClient(client)
 
 	if req.GetPageSize() < 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid page_size: must not be negative")
+		return nil, invalidArgumentError(fmt.Errorf("invalid page_size %q: must not be negative", req.GetPageSize()))
 	}
 
-	q := client.NewQuery(models.VersionEntityName)
+	q := client.NewQuery(storage.VersionEntityName)
 	q, err = q.ApplyCursor(req.GetPageToken())
 	if err != nil {
 		return nil, invalidArgumentError(err)
@@ -164,7 +179,7 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 	for _, err = it.Next(&version); err == nil; _, err = it.Next(&version) {
 		if prg != nil {
 			filterInputs := map[string]interface{}{
-				"name":         version.ResourceName(),
+				"name":         version.Name(),
 				"project_id":   version.ProjectID,
 				"api_id":       version.ApiID,
 				"version_id":   version.VersionID,
@@ -212,23 +227,67 @@ func (s *RegistryServer) UpdateApiVersion(ctx context.Context, req *rpc.UpdateAp
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	version, err := models.NewVersionFromResourceName(req.GetApiVersion().GetName())
+
+	name, err := names.ParseVersion(req.ApiVersion.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	k := client.NewKey(models.VersionEntityName, version.ResourceName())
-	err = client.Get(ctx, k, version)
+
+	version, err := getVersion(ctx, client, name)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "not found")
+		return nil, err
 	}
-	err = version.Update(req.GetApiVersion(), req.GetUpdateMask())
+
+	if err := version.Update(req.GetApiVersion(), req.GetUpdateMask()); err != nil {
+		return nil, internalError(err)
+	}
+
+	if err := saveVersion(ctx, client, version); err != nil {
+		return nil, internalError(err)
+	}
+
+	message, err := version.Message(rpc.View_BASIC)
 	if err != nil {
 		return nil, internalError(err)
 	}
-	k, err = client.Put(ctx, k, version)
-	if err != nil {
+
+	s.notify(rpc.Notification_UPDATED, version.Name())
+	return message, nil
+}
+
+func saveVersion(ctx context.Context, client storage.Client, version *models.Version) error {
+	k := client.NewKey(storage.VersionEntityName, version.Name())
+	if _, err := client.Put(ctx, k, version); err != nil {
+		return internalError(err)
+	}
+
+	return nil
+}
+
+func getVersion(ctx context.Context, client storage.Client, name names.Version) (*models.Version, error) {
+	api := &models.Version{
+		VersionID: name.VersionID,
+	}
+
+	k := client.NewKey(storage.VersionEntityName, name.String())
+	if err := client.Get(ctx, k, api); client.IsNotFound(err) {
+		return nil, notFoundError(fmt.Errorf("api version %q not found", name))
+	} else if err != nil {
 		return nil, internalError(err)
 	}
-	s.notify(rpc.Notification_UPDATED, version.ResourceName())
-	return version.Message(rpc.View_BASIC)
+
+	return api, nil
+}
+
+func deleteVersion(ctx context.Context, client storage.Client, name names.Version) error {
+	if err := client.DeleteChildrenOfVersion(ctx, name); err != nil {
+		return internalError(err)
+	}
+
+	k := client.NewKey(storage.VersionEntityName, name.String())
+	if err := client.Delete(ctx, k); err != nil {
+		return internalError(err)
+	}
+
+	return nil
 }

--- a/server/datastore/deletions.go
+++ b/server/datastore/deletions.go
@@ -65,7 +65,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 		models.BlobEntityName,
 		models.SpecEntityName,
 		models.SpecRevisionTagEntityName,
-		models.VersionEntityName,
+		storage.VersionEntityName,
 		storage.ApiEntityName,
 	}
 	for _, entityName := range entityNames {
@@ -85,7 +85,7 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
 		models.SpecEntityName,
-		models.VersionEntityName,
+		storage.VersionEntityName,
 	} {
 		q := datastore.NewQuery(entityName)
 		q = q.KeysOnly()
@@ -100,7 +100,7 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 }
 
 // DeleteChildrenOfVersion deletes all the children of a version.
-func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version *models.Version) error {
+func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version names.Version) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
 		models.SpecEntityName,

--- a/server/gorm/deletions.go
+++ b/server/gorm/deletions.go
@@ -54,7 +54,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 		models.BlobEntityName,
 		models.SpecEntityName,
 		models.SpecRevisionTagEntityName,
-		models.VersionEntityName,
+		storage.VersionEntityName,
 		storage.ApiEntityName,
 	}
 	for _, entityName := range entityNames {
@@ -73,7 +73,7 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
 		models.SpecEntityName,
-		models.VersionEntityName,
+		storage.VersionEntityName,
 	} {
 		q := c.NewQuery(entityName)
 		q = q.Require("ProjectID", api.ProjectID)
@@ -87,7 +87,7 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 }
 
 // DeleteChildrenOfVersion deletes all the children of a version.
-func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version *models.Version) error {
+func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version names.Version) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
 		models.SpecEntityName,

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	ptypes "github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -66,7 +66,7 @@ type Spec struct {
 
 // NewSpecFromParentAndSpecID returns an initialized spec for a specified parent and ID.
 func NewSpecFromParentAndSpecID(parent string, id string) (*Spec, error) {
-	m, err := names.ParseVersion(parent)
+	version, err := names.ParseVersion(parent)
 	if err != nil {
 		return nil, err
 	} else if err := names.ValidateID(id); err != nil {
@@ -74,9 +74,9 @@ func NewSpecFromParentAndSpecID(parent string, id string) (*Spec, error) {
 	}
 
 	return &Spec{
-		ProjectID: m[1],
-		ApiID:     m[2],
-		VersionID: m[3],
+		ProjectID: version.ProjectID,
+		ApiID:     version.ApiID,
+		VersionID: version.VersionID,
 		SpecID:    id,
 	}, nil
 }

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -24,9 +24,6 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-// VersionEntityName is used to represent versions in storage.
-const VersionEntityName = "Version"
-
 // Version is the storage-side representation of a version.
 type Version struct {
 	Key         string    `datastore:"-" gorm:"primaryKey"`
@@ -42,113 +39,112 @@ type Version struct {
 	Annotations []byte    `datastore:",noindex"` // Serialized annotations.
 }
 
-// NewVersionFromParentAndVersionID returns an initialized version for a specified parent and ID.
-func NewVersionFromParentAndVersionID(parent string, id string) (*Version, error) {
-	api, err := names.ParseApi(parent)
-	if err != nil {
-		return nil, err
-	} else if err := names.ValidateID(id); err != nil {
-		return nil, err
+// NewVersion initializes a new resource.
+func NewVersion(name names.Version, body *rpc.ApiVersion) (version *Version, err error) {
+	now := time.Now()
+	version = &Version{
+		ProjectID:   name.ProjectID,
+		ApiID:       name.ApiID,
+		VersionID:   name.VersionID,
+		Description: body.GetDescription(),
+		DisplayName: body.GetDisplayName(),
+		State:       body.GetState(),
+		CreateTime:  now,
+		UpdateTime:  now,
 	}
 
-	return &Version{
-		ProjectID: api.ProjectID,
-		ApiID:     api.ApiID,
-		VersionID: id,
-	}, nil
-}
-
-// NewVersionFromResourceName parses resource names and returns an initialized version.
-func NewVersionFromResourceName(name string) (*Version, error) {
-	m, err := names.ParseVersion(name)
+	version.Labels, err = bytesForMap(body.GetLabels())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Version{
-		ProjectID: m[1],
-		ApiID:     m[2],
-		VersionID: m[3],
-	}, nil
-}
-
-// NewVersionFromMessage returns an initialized version from a message.
-func NewVersionFromMessage(message *rpc.ApiVersion) (*Version, error) {
-	version, err := NewVersionFromResourceName(message.GetName())
+	version.Annotations, err = bytesForMap(body.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
-	version.DisplayName = message.GetDisplayName()
-	version.Description = message.GetDescription()
-	version.State = message.GetState()
+
 	return version, nil
 }
 
-// ResourceName generates the resource name of a version.
-func (version *Version) ResourceName() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s", version.ProjectID, version.ApiID, version.VersionID)
+// Name returns the resource name of the version.
+func (v *Version) Name() string {
+	return fmt.Sprintf("projects/%s/apis/%s/versions/%s", v.ProjectID, v.ApiID, v.VersionID)
 }
 
 // Message returns a message representing a version.
-func (version *Version) Message(view rpc.View) (message *rpc.ApiVersion, err error) {
-	message = &rpc.ApiVersion{}
-	message.Name = version.ResourceName()
-	message.DisplayName = version.DisplayName
-	message.Description = version.Description
-	message.CreateTime, err = ptypes.TimestampProto(version.CreateTime)
-	message.UpdateTime, err = ptypes.TimestampProto(version.UpdateTime)
-	message.State = version.State
-	if message.Labels, err = mapForBytes(version.Labels); err != nil {
+func (v *Version) Message(view rpc.View) (message *rpc.ApiVersion, err error) {
+	message = &rpc.ApiVersion{
+		Name:        v.Name(),
+		DisplayName: v.DisplayName,
+		Description: v.Description,
+		State:       v.State,
+	}
+
+	message.CreateTime, err = ptypes.TimestampProto(v.CreateTime)
+	if err != nil {
 		return nil, err
 	}
+
+	message.UpdateTime, err = ptypes.TimestampProto(v.UpdateTime)
+	if err != nil {
+		return nil, err
+	}
+
+	message.Labels, err = v.LabelsMap()
+	if err != nil {
+		return nil, err
+	}
+
 	if view == rpc.View_FULL {
-		if message.Annotations, err = mapForBytes(version.Annotations); err != nil {
+		message.Annotations, err = mapForBytes(v.Annotations)
+		if err != nil {
 			return nil, err
 		}
 	}
+
 	return message, err
 }
 
 // Update modifies a version using the contents of a message.
-func (version *Version) Update(message *rpc.ApiVersion, mask *fieldmaskpb.FieldMask) error {
+func (v *Version) Update(message *rpc.ApiVersion, mask *fieldmaskpb.FieldMask) error {
 	if activeUpdateMask(mask) {
 		for _, field := range mask.Paths {
 			switch field {
 			case "display_name":
-				version.DisplayName = message.GetDisplayName()
+				v.DisplayName = message.GetDisplayName()
 			case "description":
-				version.Description = message.GetDescription()
+				v.Description = message.GetDescription()
 			case "state":
-				version.State = message.GetState()
+				v.State = message.GetState()
 			case "labels":
 				var err error
-				if version.Labels, err = bytesForMap(message.GetLabels()); err != nil {
+				if v.Labels, err = bytesForMap(message.GetLabels()); err != nil {
 					return err
 				}
 			case "annotations":
 				var err error
-				if version.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
+				if v.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
 					return err
 				}
 			}
 		}
 	} else {
-		version.DisplayName = message.GetDisplayName()
-		version.Description = message.GetDescription()
-		version.State = message.GetState()
+		v.DisplayName = message.GetDisplayName()
+		v.Description = message.GetDescription()
+		v.State = message.GetState()
 		var err error
-		if version.Labels, err = bytesForMap(message.GetLabels()); err != nil {
+		if v.Labels, err = bytesForMap(message.GetLabels()); err != nil {
 			return err
 		}
-		if version.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
+		if v.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
 			return err
 		}
 	}
-	version.UpdateTime = time.Now()
+	v.UpdateTime = time.Now()
 	return nil
 }
 
 // LabelsMap returns a map representation of stored labels.
-func (version *Version) LabelsMap() (map[string]string, error) {
-	return mapForBytes(version.Labels)
+func (v *Version) LabelsMap() (map[string]string, error) {
+	return mapForBytes(v.Labels)
 }

--- a/server/names/api.go
+++ b/server/names/api.go
@@ -43,6 +43,15 @@ func (a Api) Project() Project {
 	}
 }
 
+// Version returns an API version with the provided ID and this resource as its parent.
+func (a Api) Version(id string) Version {
+	return Version{
+		ProjectID: a.ProjectID,
+		ApiID:     a.ApiID,
+		VersionID: id,
+	}
+}
+
 func (a Api) String() string {
 	return fmt.Sprintf("projects/%s/apis/%s", a.ProjectID, a.ApiID)
 }

--- a/server/names/version.go
+++ b/server/names/version.go
@@ -19,6 +19,41 @@ import (
 	"regexp"
 )
 
+// Version represents a resource name for an API version.
+type Version struct {
+	ProjectID string
+	ApiID     string
+	VersionID string
+}
+
+// Validate returns an error if the resource name is invalid.
+// For backward compatibility, names should only be validated at creation time.
+func (v Version) Validate() error {
+	r := VersionRegexp()
+	if name := v.String(); !r.MatchString(name) {
+		return fmt.Errorf("invalid version name %q: must match %q", name, r)
+	}
+
+	return nil
+}
+
+// Project returns the parent project for this resource.
+func (v Version) Project() Project {
+	return v.Api().Project()
+}
+
+// Api returns the parent API for this resource.
+func (v Version) Api() Api {
+	return Api{
+		ProjectID: v.ProjectID,
+		ApiID:     v.ApiID,
+	}
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("projects/%s/apis/%s/versions/%s", v.ProjectID, v.ApiID, v.VersionID)
+}
+
 // VersionsRegexp returns a regular expression that matches a collection of versions.
 func VersionsRegexp() *regexp.Regexp {
 	return regexp.MustCompile("^projects/" + identifier + "/apis/" + identifier + "/versions$")
@@ -30,11 +65,16 @@ func VersionRegexp() *regexp.Regexp {
 }
 
 // ParseVersion parses the name of a version.
-func ParseVersion(name string) ([]string, error) {
+func ParseVersion(name string) (Version, error) {
 	r := VersionRegexp()
-	m := r.FindStringSubmatch(name)
-	if m == nil {
-		return nil, fmt.Errorf("invalid version name %q: must match %q", name, r)
+	if !r.MatchString(name) {
+		return Version{}, fmt.Errorf("invalid version name %q: must match %q", name, r)
 	}
-	return m, nil
+
+	m := r.FindStringSubmatch(name)
+	return Version{
+		ProjectID: m[1],
+		ApiID:     m[2],
+		VersionID: m[3],
+	}, nil
 }

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -26,8 +26,10 @@ import (
 const (
 	// ProjectEntityName is the storage entity name for project resources.
 	ProjectEntityName = "Project"
-	// ApiEntityName is the storage entity name for project resources.
+	// ApiEntityName is the storage entity name for API resources.
 	ApiEntityName = "Api"
+	// VersionEntityName is the storage entity name for API version resources.
+	VersionEntityName = "Version"
 )
 
 type Client interface {
@@ -47,7 +49,7 @@ type Client interface {
 	DeleteAllMatches(ctx context.Context, q Query) error
 	DeleteChildrenOfProject(ctx context.Context, project names.Project) error
 	DeleteChildrenOfApi(ctx context.Context, api names.Api) error
-	DeleteChildrenOfVersion(ctx context.Context, version *models.Version) error
+	DeleteChildrenOfVersion(ctx context.Context, version names.Version) error
 	DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error
 }
 


### PR DESCRIPTION
* Add type for version resource names, refactor interfaces where applicable.
* Move version storage entity name into storage package.
* Refactor common version operations into helper functions.
* Check additional errors before returning
* Consistently use error helper functions.
* Remove redundant import names