### PR TITLE
Expand testing for API Version methods

### DIFF
--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -160,7 +160,7 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 		if _, err := getApi(ctx, client, parent); err != nil {
 			return nil, err
 		}
-	} else if parent.ProjectID != "-" {
+	} else if parent.ProjectID != "-" && parent.ApiID == "-" {
 		if _, err := getProject(ctx, client, parent.Project()); err != nil {
 			return nil, err
 		}

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -156,6 +156,15 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 	if parent.ApiID != "-" {
 		q = q.Require("ApiID", parent.ApiID)
 	}
+	if parent.ProjectID != "-" && parent.ApiID != "-" {
+		if _, err := getApi(ctx, client, parent); err != nil {
+			return nil, err
+		}
+	} else if parent.ProjectID != "-" {
+		if _, err := getProject(ctx, client, parent.Project()); err != nil {
+			return nil, err
+		}
+	}
 	prg, err := createFilterOperator(req.GetFilter(),
 		[]filterArg{
 			{"name", filterArgTypeString},

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -261,6 +261,64 @@ func TestCreateApiVersionDuplicates(t *testing.T) {
 	})
 }
 
+func TestGetApiVersion(t *testing.T) {
+	tests := []struct {
+		desc string
+		seed *rpc.ApiVersion
+		req  *rpc.GetApiVersionRequest
+		want *rpc.ApiVersion
+	}{
+		{
+			desc: "default view",
+			seed: fullVersion,
+			req: &rpc.GetApiVersionRequest{
+				Name: fullVersion.Name,
+			},
+			want: basicVersion,
+		},
+		{
+			desc: "basic view",
+			seed: fullVersion,
+			req: &rpc.GetApiVersionRequest{
+				Name: fullVersion.Name,
+				View: rpc.View_BASIC,
+			},
+			want: basicVersion,
+		},
+		{
+			desc: "full view",
+			seed: fullVersion,
+			req: &rpc.GetApiVersionRequest{
+				Name: fullVersion.Name,
+				View: rpc.View_FULL,
+			},
+			want: fullVersion,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedVersions(ctx, t, server, test.seed)
+
+			got, err := server.GetApiVersion(ctx, test.req)
+			if err != nil {
+				t.Fatalf("GetApi(%+v) returned error: %s", test.req, err)
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(new(rpc.ApiVersion), "create_time", "update_time"),
+			}
+
+			if !cmp.Equal(test.want, got, opts) {
+				t.Errorf("GetApi(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, got, opts))
+			}
+		})
+	}
+}
+
 func TestGetApiVersionResponseCodes(t *testing.T) {
 	tests := []struct {
 		desc string

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -603,7 +603,17 @@ func TestUpdateApiVersion(t *testing.T) {
 		want *rpc.ApiVersion
 	}{
 		{
-			desc: "default parameters",
+			desc: "populated resource with default parameters",
+			seed: fullVersion,
+			req: &rpc.UpdateApiVersionRequest{
+				ApiVersion: &rpc.ApiVersion{
+					Name: fullVersion.Name,
+				},
+			},
+			want: fullVersion,
+		},
+		{
+			desc: "implicit mask",
 			seed: &rpc.ApiVersion{
 				Name:        "projects/my-project/apis/my-api/versions/p",
 				DisplayName: "My ApiVersion",


### PR DESCRIPTION
* Check for non-existent parent resources in List/Create methods
* Check basic/full API responses in Create/Get/Update methods
* Check that List only returns versions from a specified parent API
* Check that List works across multiple collections