### PR TITLE
Fix forgotten Project/Api/Version behaviors

### DIFF
--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -230,6 +230,10 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 	}
 	defer s.releaseStorageClient(client)
 
+	if req.GetApi() == nil {
+		return nil, invalidArgumentError(fmt.Errorf("invalid api %v: body must be provided", req.GetApi()))
+	}
+
 	name, err := names.ParseApi(req.Api.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
@@ -267,10 +271,7 @@ func saveApi(ctx context.Context, client storage.Client, api *models.Api) error 
 }
 
 func getApi(ctx context.Context, client storage.Client, name names.Api) (*models.Api, error) {
-	api := &models.Api{
-		ApiID: name.ApiID,
-	}
-
+	api := new(models.Api)
 	k := client.NewKey(storage.ApiEntityName, name.String())
 	if err := client.Get(ctx, k, api); client.IsNotFound(err) {
 		return nil, notFoundError(fmt.Errorf("api %q not found", name))

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -799,6 +799,12 @@ func TestUpdateApiResponseCodes(t *testing.T) {
 			want: codes.NotFound,
 		},
 		{
+			desc: "missing resource body",
+			seed: &rpc.Api{Name: "projects/my-project/apis/my-api"},
+			req:  &rpc.UpdateApiRequest{},
+			want: codes.InvalidArgument,
+		},
+		{
 			desc: "missing resource name",
 			seed: &rpc.Api{Name: "projects/my-project/apis/my-api"},
 			req: &rpc.UpdateApiRequest{

--- a/server/actions_projects_test.go
+++ b/server/actions_projects_test.go
@@ -641,6 +641,12 @@ func TestUpdateProjectResponseCodes(t *testing.T) {
 			want: codes.NotFound,
 		},
 		{
+			desc: "missing resource body",
+			seed: &rpc.Project{Name: "projects/my-project"},
+			req:  &rpc.UpdateProjectRequest{},
+			want: codes.InvalidArgument,
+		},
+		{
 			desc: "missing resource name",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.UpdateProjectRequest{

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -379,6 +379,7 @@ func TestListApiVersions(t *testing.T) {
 			seed: []*rpc.ApiVersion{
 				{Name: "projects/my-project/apis/my-api/versions/v1"},
 				{Name: "projects/my-project/apis/other-api/versions/v1"},
+				{Name: "projects/other-project/apis/my-api/versions/v1"},
 			},
 			req: &rpc.ListApiVersionsRequest{
 				Parent: "projects/my-project/apis/-",
@@ -411,6 +412,7 @@ func TestListApiVersions(t *testing.T) {
 			seed: []*rpc.ApiVersion{
 				{Name: "projects/my-project/apis/my-api/versions/v1"},
 				{Name: "projects/other-project/apis/my-api/versions/v1"},
+				{Name: "projects/my-project/apis/other-api/versions/v1"},
 			},
 			req: &rpc.ListApiVersionsRequest{
 				Parent: "projects/-/apis/my-api",
@@ -797,6 +799,12 @@ func TestUpdateApiVersionResponseCodes(t *testing.T) {
 				},
 			},
 			want: codes.NotFound,
+		},
+		{
+			desc: "missing resource body",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			req:  &rpc.UpdateApiVersionRequest{},
+			want: codes.InvalidArgument,
 		},
 		{
 			desc: "missing resource name",

--- a/server/models/api.go
+++ b/server/models/api.go
@@ -15,7 +15,6 @@
 package models
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/apigee/registry/rpc"
@@ -68,7 +67,10 @@ func NewApi(name names.Api, body *rpc.Api) (api *Api, err error) {
 
 // Name returns the resource name of the api.
 func (api *Api) Name() string {
-	return fmt.Sprintf("projects/%s/apis/%s", api.ProjectID, api.ApiID)
+	return names.Api{
+		ProjectID: api.ProjectID,
+		ApiID:     api.ApiID,
+	}.String()
 }
 
 // Message returns a message representing an api.

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -15,7 +15,6 @@
 package models
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/apigee/registry/rpc"
@@ -68,7 +67,11 @@ func NewVersion(name names.Version, body *rpc.ApiVersion) (version *Version, err
 
 // Name returns the resource name of the version.
 func (v *Version) Name() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s", v.ProjectID, v.ApiID, v.VersionID)
+	return names.Version{
+		ProjectID: v.ProjectID,
+		ApiID:     v.ApiID,
+		VersionID: v.VersionID,
+	}.String()
 }
 
 // Message returns a message representing a version.


### PR DESCRIPTION
* Add check for resource body in Update methods
* Add notification on UpdateProject success
* Add seed data to ensure listing only returns expected resources
* Update model name methods to use names package
* Remove unnecessary manual population of IDs on storage reads