### PR TITLE
Fix for sed command on MacOS

### DIFF
--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -81,7 +81,7 @@ END
 
 # patch the generated GAPIC to send Authorization tokens with insecure requests
 # (this allows the registry command line tools to test container builds)
-sed -i 's/return metadata.NewOutgoingContext(ctx, out)/insecure := os.Getenv("APG_REGISTRY_INSECURE")\ntoken := os.Getenv("APG_REGISTRY_TOKEN")\nif insecure == "1" \&\& token != "" \{ \nout["authorization"] = append(out["authorization"], "Bearer "+token) \n\}\nreturn metadata.NewOutgoingContext(ctx, out)/' gapic/doc.go
+sed -i.bak 's/return metadata.NewOutgoingContext(ctx, out)/insecure := os.Getenv("APG_REGISTRY_INSECURE")\ntoken := os.Getenv("APG_REGISTRY_TOKEN")\nif insecure == "1" \&\& token != "" \{ \nout["authorization"] = append(out["authorization"], "Bearer "+token) \n\}\nreturn metadata.NewOutgoingContext(ctx, out)/' gapic/doc.go
 gofmt -w gapic/doc.go
 
 echo "Generating GAPIC-based CLI."


### PR DESCRIPTION
This command was previously. failing on MacOS leading to the insecure mode not working properly for different CLI tools.