### PR TITLE
Update API Spec and SpecRevision methods 

### DIFF
--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -566,6 +566,14 @@ func TestListApisSequence(t *testing.T) {
 			t.Fatalf("ListApis(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetApis()); count != 1 {
+			t.Errorf("ListApis(%+v) returned %d apis, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApis(%+v) returned empty next_page_token, expected another page", req)
+		}
+
 		listed = append(listed, got.Apis...)
 		nextToken = got.GetNextPageToken()
 	})
@@ -584,6 +592,14 @@ func TestListApisSequence(t *testing.T) {
 		got, err := server.ListApis(ctx, req)
 		if err != nil {
 			t.Fatalf("ListApis(%+v) returned error: %s", req, err)
+		}
+
+		if count := len(got.GetApis()); count != 1 {
+			t.Errorf("ListApis(%+v) returned %d apis, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApis(%+v) returned empty next_page_token, expected another page", req)
 		}
 
 		listed = append(listed, got.Apis...)
@@ -606,6 +622,10 @@ func TestListApisSequence(t *testing.T) {
 			t.Fatalf("ListApis(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetApis()); count != 1 {
+			t.Errorf("ListApis(%+v) returned %d apis, expected exactly one", req, count)
+		}
+
 		if got.GetNextPageToken() != "" {
 			// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
 			t.Logf("ListApis(%+v) returned next_page_token, expected no next page", req)
@@ -613,6 +633,10 @@ func TestListApisSequence(t *testing.T) {
 
 		listed = append(listed, got.Apis...)
 	})
+
+	if t.Failed() {
+		t.Fatal("Cannot test sequence result after failure on final page")
+	}
 
 	opts := cmp.Options{
 		protocmp.Transform(),

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/actions_projects_test.go
+++ b/server/actions_projects_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/actions_projects_test.go
+++ b/server/actions_projects_test.go
@@ -422,6 +422,14 @@ func TestListProjectsSequence(t *testing.T) {
 			t.Fatalf("ListProjects(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetProjects()); count != 1 {
+			t.Errorf("ListProjects(%+v) returned %d projects, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListProjects(%+v) returned empty next_page_token, expected another page", req)
+		}
+
 		listed = append(listed, got.Projects...)
 		nextToken = got.GetNextPageToken()
 	})
@@ -439,6 +447,14 @@ func TestListProjectsSequence(t *testing.T) {
 		got, err := server.ListProjects(ctx, req)
 		if err != nil {
 			t.Fatalf("ListProjects(%+v) returned error: %s", req, err)
+		}
+
+		if count := len(got.GetProjects()); count != 1 {
+			t.Errorf("ListProjects(%+v) returned %d projects, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListProjects(%+v) returned empty next_page_token, expected another page", req)
 		}
 
 		listed = append(listed, got.Projects...)
@@ -460,6 +476,10 @@ func TestListProjectsSequence(t *testing.T) {
 			t.Fatalf("ListProjects(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetProjects()); count != 1 {
+			t.Errorf("ListProjects(%+v) returned %d projects, expected exactly one", req, count)
+		}
+
 		if got.GetNextPageToken() != "" {
 			// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
 			t.Logf("ListProjects(%+v) returned next_page_token, expected no next page", req)
@@ -467,6 +487,10 @@ func TestListProjectsSequence(t *testing.T) {
 
 		listed = append(listed, got.Projects...)
 	})
+
+	if t.Failed() {
+		t.Fatal("Cannot test sequence result after failure on final page")
+	}
 
 	opts := cmp.Options{
 		protocmp.Transform(),

--- a/server/actions_spec_revisions.go
+++ b/server/actions_spec_revisions.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/models"
+	"github.com/apigee/registry/server/names"
+	"github.com/apigee/registry/server/storage"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/api/iterator"
+)
+
+// ListApiSpecRevisions handles the corresponding API request.
+func (s *RegistryServer) ListApiSpecRevisions(ctx context.Context, req *rpc.ListApiSpecRevisionsRequest) (*rpc.ListApiSpecRevisionsResponse, error) {
+	client, err := s.getStorageClient(ctx)
+	if err != nil {
+		return nil, unavailableError(err)
+	}
+	defer s.releaseStorageClient(client)
+
+	if req.GetPageSize() < 0 {
+		return nil, invalidArgumentError(fmt.Errorf("invalid page_size %d: must not be negative", req.GetPageSize()))
+	}
+
+	name, err := names.ParseSpec(req.GetName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	q := client.NewQuery(storage.SpecEntityName)
+	q = q.Require("ProjectID", name.ProjectID)
+	q = q.Require("ApiID", name.ApiID)
+	q = q.Require("VersionID", name.VersionID)
+	q = q.Require("SpecID", name.SpecID)
+	q = q.Order("-RevisionCreateTime")
+	q, err = q.ApplyCursor(req.GetPageToken())
+	if err != nil {
+		return nil, internalError(err)
+	}
+
+	pageSize := boundPageSize(req.GetPageSize())
+	response := &rpc.ListApiSpecRevisionsResponse{
+		Specs: make([]*rpc.ApiSpec, 0, pageSize),
+	}
+
+	var spec models.Spec
+	it := client.Run(ctx, q)
+	for _, err := it.Next(&spec); err == nil; _, err = it.Next(&spec) {
+		specMessage, err := spec.BasicMessage(spec.RevisionName())
+		if err != nil {
+			continue
+		}
+		response.Specs = append(response.GetSpecs(), specMessage)
+
+		// Exit when page is full and before the iterator moves forward again.
+		// This ensures the cursor is returned in the correct position.
+		if len(response.GetSpecs()) >= pageSize {
+			break
+		}
+	}
+	if err != nil && err != iterator.Done {
+		return nil, internalError(err)
+	}
+
+	response.NextPageToken, err = it.GetCursor(len(response.GetSpecs()))
+	if err != nil {
+		return nil, internalError(err)
+	}
+
+	return response, nil
+}
+
+// DeleteApiSpecRevision handles the corresponding API request.
+func (s *RegistryServer) DeleteApiSpecRevision(ctx context.Context, req *rpc.DeleteApiSpecRevisionRequest) (*empty.Empty, error) {
+	client, err := s.getStorageClient(ctx)
+	if err != nil {
+		return nil, unavailableError(err)
+	}
+	defer s.releaseStorageClient(client)
+
+	name, err := names.ParseSpecRevision(req.GetName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	revision, err := getSpecRevision(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the retrieved spec revision name, which has a non-tag revision ID.
+	// This is necessary to ensure the actual revision is deleted.
+	name, err = names.ParseSpecRevision(revision.RevisionName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	// If the one we will delete is the current revision, we need to designate a new current revision.
+	if revision.Currency == models.IsCurrent {
+		// get the most recent non-current revision and make it current
+		newKey, newCurrentRevision, err := s.fetchMostRecentNonCurrentRevisionOfSpec(ctx, client, name.Spec())
+		if err == nil && newCurrentRevision != nil {
+			newCurrentRevision.Currency = models.IsCurrent
+			_, _ = client.Put(ctx, newKey, newCurrentRevision)
+		}
+	}
+
+	if err := client.Delete(ctx, client.NewKey(models.BlobEntityName, name.String())); err != nil {
+		return nil, internalError(err)
+	}
+
+	if err := client.Delete(ctx, client.NewKey(storage.SpecEntityName, name.String())); err != nil {
+		return nil, internalError(err)
+	}
+
+	s.notify(rpc.Notification_DELETED, name.String())
+	return &empty.Empty{}, nil
+}
+
+// TagApiSpecRevision handles the corresponding API request.
+func (s *RegistryServer) TagApiSpecRevision(ctx context.Context, req *rpc.TagApiSpecRevisionRequest) (*rpc.ApiSpec, error) {
+	client, err := s.getStorageClient(ctx)
+	if err != nil {
+		return nil, unavailableError(err)
+	}
+	defer s.releaseStorageClient(client)
+
+	if req.GetTag() == "" {
+		return nil, invalidArgumentError(fmt.Errorf("invalid tag %q, must not be empty", req.GetTag()))
+	}
+
+	// Parse the requested spec revision name, which may include a tag name.
+	name, err := names.ParseSpecRevision(req.GetName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	revision, err := getSpecRevision(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the retrieved spec revision name, which has a non-tag revision ID.
+	// This is necessary to ensure the new tag is associated with a revision ID, not another tag.
+	name, err = names.ParseSpecRevision(revision.RevisionName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	tag := models.NewSpecRevisionTag(name, req.GetTag())
+	if err := saveSpecRevisionTag(ctx, client, tag); err != nil {
+		return nil, err
+	}
+
+	message, err := revision.BasicMessage(tag.String())
+	if err != nil {
+		return nil, internalError(err)
+	}
+
+	s.notify(rpc.Notification_UPDATED, tag.String())
+	return message, nil
+}
+
+// RollbackApiSpec handles the corresponding API request.
+func (s *RegistryServer) RollbackApiSpec(ctx context.Context, req *rpc.RollbackApiSpecRequest) (*rpc.ApiSpec, error) {
+	client, err := s.getStorageClient(ctx)
+	if err != nil {
+		return nil, unavailableError(err)
+	}
+	defer s.releaseStorageClient(client)
+
+	if req.GetRevisionId() == "" {
+		return nil, invalidArgumentError(fmt.Errorf("invalid revision ID %q, must not be empty", req.GetRevisionId()))
+	}
+
+	parent, err := names.ParseSpec(req.GetName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	current, err := getSpec(ctx, client, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark the current revision as non-current.
+	current.Currency = models.NotCurrent
+	if err := saveSpecRevision(ctx, client, current); err != nil {
+		return nil, err
+	}
+
+	// Get the target spec revision to use as a base for the new rollback revision.
+	name := parent.Revision(req.GetRevisionId())
+	target, err := getSpecRevision(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Save a new rollback revision based on the target revision.
+	rollback := target.NewRevision()
+	if err := saveSpecRevision(ctx, client, rollback); err != nil {
+		return nil, err
+	}
+
+	blob, err := getSpecRevisionContents(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Save a new copy of the target revision blob for the rollback revision.
+	blob.RevisionID = name.RevisionID
+	if err := saveSpecRevisionContents(ctx, client, rollback, blob.Contents); err != nil {
+		return nil, err
+	}
+
+	message, err := rollback.BasicMessage(rollback.RevisionName())
+	if err != nil {
+		return nil, internalError(err)
+	}
+
+	s.notify(rpc.Notification_UPDATED, rollback.RevisionName())
+	return message, nil
+}
+
+func saveSpecRevision(ctx context.Context, client storage.Client, spec *models.Spec) error {
+	k := client.NewKey(storage.SpecEntityName, spec.RevisionName())
+	if _, err := client.Put(ctx, k, spec); err != nil {
+		return internalError(err)
+	}
+
+	return nil
+}
+
+func getSpecRevision(ctx context.Context, client storage.Client, name names.SpecRevision) (*models.Spec, error) {
+	spec := new(models.Spec)
+
+	// If the provided revision ID is a known tag, use the associated revision for lookup.
+	tag := new(models.SpecRevisionTag)
+	if err := client.Get(ctx, client.NewKey(storage.SpecRevisionTagEntityName, name.String()), tag); err == nil {
+		name.RevisionID = tag.RevisionID
+	} else if !client.IsNotFound(err) {
+		return nil, internalError(err)
+	}
+
+	k := client.NewKey(storage.SpecEntityName, name.String())
+	if err := client.Get(ctx, k, spec); client.IsNotFound(err) {
+		return nil, notFoundError(fmt.Errorf("spec revision %q not found", name))
+	} else if err != nil {
+		return nil, internalError(err)
+	}
+
+	return spec, nil
+}
+
+func saveSpecRevisionContents(ctx context.Context, client storage.Client, spec *models.Spec, contents []byte) error {
+	blob := models.NewBlobForSpec(spec, contents)
+	k := client.NewKey(models.BlobEntityName, spec.RevisionName())
+	if _, err := client.Put(ctx, k, blob); err != nil {
+		return internalError(err)
+	}
+
+	return nil
+}
+
+func getSpecRevisionContents(ctx context.Context, client storage.Client, name names.SpecRevision) (*models.Blob, error) {
+	// If the provided revision ID is a known tag, use the associated revision for lookup.
+	tag := new(models.SpecRevisionTag)
+	if err := client.Get(ctx, client.NewKey(storage.SpecRevisionTagEntityName, name.String()), tag); err == nil {
+		name.RevisionID = tag.RevisionID
+	} else if !client.IsNotFound(err) {
+		return nil, internalError(err)
+	}
+
+	blob := new(models.Blob)
+	k := client.NewKey(models.BlobEntityName, name.String())
+	if err := client.Get(ctx, k, blob); client.IsNotFound(err) {
+		return nil, notFoundError(fmt.Errorf("spec revision contents %q not found", name.String()))
+	} else if err != nil {
+		return nil, internalError(err)
+	}
+
+	return blob, nil
+}
+
+func saveSpecRevisionTag(ctx context.Context, client storage.Client, tag *models.SpecRevisionTag) error {
+	k := client.NewKey(storage.SpecRevisionTagEntityName, tag.String())
+	if _, err := client.Put(ctx, k, tag); err != nil {
+		return internalError(err)
+	}
+
+	return nil
+}

--- a/server/actions_spec_revisions.go
+++ b/server/actions_spec_revisions.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/actions_spec_revisions_test.go
+++ b/server/actions_spec_revisions_test.go
@@ -1,0 +1,465 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestTagApiSpecRevision(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seedSpecs(ctx, t, server, &rpc.ApiSpec{
+		Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+	})
+
+	updateReq := &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
+			Name:     "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+			Contents: specContents,
+		},
+	}
+
+	revision, err := server.UpdateApiSpec(ctx, updateReq)
+	if err != nil {
+		t.Fatalf("Setup: UpdateApiSpec(%+v) returned error: %s", updateReq, err)
+	}
+
+	req := &rpc.TagApiSpecRevisionRequest{
+		Name: fmt.Sprintf("%s@%s", revision.GetName(), revision.GetRevisionId()),
+		Tag:  "my-tag",
+	}
+
+	got, err := server.TagApiSpecRevision(ctx, req)
+	if err != nil {
+		t.Fatalf("TagApiSpecRevision(%+v) returned error: %s", req, err)
+	}
+
+	opts := cmp.Options{
+		protocmp.Transform(),
+		protocmp.IgnoreFields(revision, "name", "revision_tags"),
+	}
+
+	t.Run("response", func(t *testing.T) {
+		if !cmp.Equal(revision, got, opts) {
+			t.Errorf("TagApiSpecRevision(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(revision, got, opts))
+		}
+
+		if want := fmt.Sprintf("%s@my-tag", revision.GetName()); want != got.GetName() {
+			t.Errorf("TagApiSpecRevision(%+v) returned unexpected name %q, want %q", req, got.GetName(), want)
+		}
+	})
+
+	t.Run("GetApiSpec", func(t *testing.T) {
+		req := &rpc.GetApiSpecRequest{
+			Name: got.GetName(),
+		}
+
+		got, err := server.GetApiSpec(ctx, req)
+		if err != nil {
+			t.Fatalf("GetApiSpec(%+v) returned error: %s", req, err)
+		}
+
+		if !cmp.Equal(revision, got, opts) {
+			t.Errorf("GetApiSpec(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(revision, got, opts))
+		}
+
+		if got.GetName() != req.GetName() {
+			t.Errorf("GetApiSpec(%+v) returned unexpected name %q, want %q", req, got.GetName(), req.GetName())
+		}
+	})
+
+	t.Run("add another tag to a tagged revision", func(t *testing.T) {
+		req := &rpc.TagApiSpecRevisionRequest{
+			Name: got.GetName(),
+			Tag:  "my-second-tag",
+		}
+
+		got, err := server.TagApiSpecRevision(ctx, req)
+		if err != nil {
+			t.Fatalf("TagApiSpecRevision(%+v) returned error: %s", req, err)
+		}
+
+		opts := cmp.Options{
+			protocmp.Transform(),
+			protocmp.IgnoreFields(revision, "name", "revision_tags"),
+		}
+
+		if !cmp.Equal(revision, got, opts) {
+			t.Errorf("TagApiSpecRevision(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(revision, got, opts))
+		}
+
+		if want := fmt.Sprintf("%s@my-second-tag", revision.GetName()); want != got.GetName() {
+			t.Errorf("TagApiSpecRevision(%+v) returned unexpected name %q, want %q", req, got.GetName(), want)
+		}
+
+		t.Run("GetApiSpec", func(t *testing.T) {
+			req := &rpc.GetApiSpecRequest{
+				Name: got.GetName(),
+			}
+
+			got, err := server.GetApiSpec(ctx, req)
+			if err != nil {
+				t.Fatalf("GetApiSpec(%+v) returned error: %s", req, err)
+			}
+
+			if !cmp.Equal(revision, got, opts) {
+				t.Errorf("GetApiSpec(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(revision, got, opts))
+			}
+
+			if got.GetName() != req.GetName() {
+				t.Errorf("GetApiSpec(%+v) returned unexpected name %q, want %q", req, got.GetName(), req.GetName())
+			}
+		})
+	})
+
+	t.Run("DeleteApiSpecRevision", func(t *testing.T) {
+		req := &rpc.DeleteApiSpecRevisionRequest{
+			Name: got.GetName(),
+		}
+
+		if _, err := server.DeleteApiSpecRevision(ctx, req); err != nil {
+			t.Fatalf("DeleteApiSpecRevision(%+v) returned error: %s", req, err)
+		}
+
+		t.Run("GetApiSpec", func(t *testing.T) {
+			req := &rpc.GetApiSpecRequest{
+				Name: req.GetName(),
+			}
+
+			if _, err := server.GetApiSpec(ctx, req); status.Code(err) != codes.NotFound {
+				t.Fatalf("GetApiSpec(%+v) returned status code %q, want %q: %v", req, status.Code(err), codes.NotFound, err)
+			}
+		})
+	})
+}
+
+func TestRollbackApiSpec(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seedVersions(ctx, t, server, &rpc.ApiVersion{
+		Name: "projects/my-project/apis/my-api/versions/v1",
+	})
+
+	createReq := &rpc.CreateApiSpecRequest{
+		Parent:    "projects/my-project/apis/my-api/versions/v1",
+		ApiSpecId: "my-spec",
+		ApiSpec:   &rpc.ApiSpec{},
+	}
+
+	firstRevision, err := server.CreateApiSpec(ctx, createReq)
+	if err != nil {
+		t.Fatalf("Setup: CreateApiSpec(%+v) returned error: %s", createReq, err)
+	}
+
+	// Create a new revision so we can roll back from it.
+	updateReq := &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
+			Name:     firstRevision.GetName(),
+			Contents: specContents,
+		},
+	}
+
+	secondRevision, err := server.UpdateApiSpec(ctx, updateReq)
+	if err != nil {
+		t.Fatalf("Setup: UpdateApiSpec(%+v) returned error: %s", updateReq, err)
+	}
+
+	if secondRevision.GetRevisionId() == firstRevision.GetRevisionId() {
+		t.Fatalf("Setup: UpdateApiSpec(%+v) returned unexpected revision_id %q matching first revision, expected new revision ID", updateReq, secondRevision.GetRevisionId())
+	}
+
+	req := &rpc.RollbackApiSpecRequest{
+		Name:       secondRevision.GetName(),
+		RevisionId: firstRevision.GetRevisionId(),
+	}
+
+	rollback, err := server.RollbackApiSpec(ctx, req)
+	if err != nil {
+		t.Fatalf("RollbackApiSpec(%+v) returned error: %s", req, err)
+	}
+
+	opts := cmp.Options{
+		protocmp.Transform(),
+		protocmp.IgnoreFields(new(rpc.ApiSpec), "name", "revision_id", "revision_create_time", "revision_update_time"),
+	}
+
+	if !cmp.Equal(firstRevision, rollback, opts) {
+		t.Errorf("RollbackApiSpec(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(firstRevision, rollback, opts))
+	}
+
+	// Rollback should create a new revision, i.e. it should not reuse an existing revision ID.
+	if rollback.GetRevisionId() == firstRevision.GetRevisionId() {
+		t.Fatalf("RollbackApiSpec(%+v) returned unexpected revision_id %q matching first revision, expected new revision ID", req, rollback.GetRevisionId())
+	} else if rollback.GetRevisionId() == secondRevision.GetRevisionId() {
+		t.Fatalf("RollbackApiSpec(%+v) returned unexpected revision_id %q matching second revision, expected new revision ID", req, rollback.GetRevisionId())
+	}
+
+	// Rollback should return a resource revision name, including the revision ID tag.
+	if want := fmt.Sprintf("%s@%s", firstRevision.GetName(), rollback.GetRevisionId()); want != rollback.GetName() {
+		t.Errorf("RollbackApiSpec(%+v) returned unexpected name %q, want %q", req, rollback.GetName(), want)
+	}
+}
+
+func TestDeleteApiSpecRevision(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seedSpecs(ctx, t, server, &rpc.ApiSpec{
+		Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+	})
+
+	t.Run("only remaining revision", func(t *testing.T) {
+		t.Skip("not yet supported")
+
+		req := &rpc.DeleteApiSpecRevisionRequest{
+			Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+		}
+
+		if _, err := server.DeleteApiSpecRevision(ctx, req); status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("DeleteApiSpecRevision(%+v) returned unexpected status code %q, want %q: %v", req, status.Code(err), codes.FailedPrecondition, err)
+		}
+	})
+
+	// Create a new revision so we can delete it.
+	updateReq := &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
+			Name:     "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+			Contents: specContents,
+		},
+	}
+
+	secondRevision, err := server.UpdateApiSpec(ctx, updateReq)
+	if err != nil {
+		t.Fatalf("Setup: UpdateApiSpec(%+v) returned error: %s", updateReq, err)
+	}
+
+	t.Run("one of multiple existing revisions", func(t *testing.T) {
+		req := &rpc.DeleteApiSpecRevisionRequest{
+			Name: fmt.Sprintf("projects/my-project/apis/my-api/versions/v1/specs/my-spec@%s", secondRevision.GetRevisionId()),
+		}
+
+		if _, err := server.DeleteApiSpecRevision(ctx, req); err != nil {
+			t.Fatalf("DeleteApiSpecRevision(%+v) returned error: %s", req, err)
+		}
+
+		t.Run("GetApiSpec", func(t *testing.T) {
+			req := &rpc.GetApiSpecRequest{
+				Name: req.GetName(),
+			}
+
+			if _, err := server.GetApiSpec(ctx, req); status.Code(err) != codes.NotFound {
+				t.Fatalf("GetApiSpec(%+v) returned status code %q, want %q: %v", req, status.Code(err), codes.NotFound, err)
+			}
+		})
+	})
+}
+
+func TestListApiSpecRevisions(t *testing.T) {
+	t.Skip("Response is not currently sorted by revision creation time")
+
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seedVersions(ctx, t, server, &rpc.ApiVersion{
+		Name: "projects/my-project/apis/my-api/versions/v1",
+	})
+
+	createReq := &rpc.CreateApiSpecRequest{
+		Parent:  "projects/my-project/apis/my-api/versions/v1",
+		ApiSpec: &rpc.ApiSpec{},
+	}
+
+	firstRevision, err := server.CreateApiSpec(ctx, createReq)
+	if err != nil {
+		t.Fatalf("Setup: CreateApiSpec(%+v) returned error: %s", createReq, err)
+	}
+
+	firstWant := &rpc.ApiSpec{
+		Name:               fmt.Sprintf("%s@%s", firstRevision.GetName(), firstRevision.GetRevisionId()),
+		CreateTime:         firstRevision.GetCreateTime(),
+		RevisionCreateTime: firstRevision.GetRevisionCreateTime(),
+		RevisionUpdateTime: firstRevision.GetRevisionUpdateTime(),
+		RevisionId:         firstRevision.GetRevisionId(),
+	}
+
+	updateReq := &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
+			Name:      firstRevision.GetName(),
+			Contents:  specContents,
+			Hash:      sha256hash(specContents),
+			SizeBytes: int32(len(specContents)),
+		},
+	}
+
+	secondRevision, err := server.UpdateApiSpec(ctx, updateReq)
+	if err != nil {
+		t.Fatalf("Setup: UpdateApiSpec(%+v) returned error: %s", updateReq, err)
+	}
+
+	secondWant := &rpc.ApiSpec{
+		Name:               fmt.Sprintf("%s@%s", secondRevision.GetName(), secondRevision.GetRevisionId()),
+		Hash:               secondRevision.GetHash(),
+		SizeBytes:          secondRevision.GetSizeBytes(),
+		CreateTime:         secondRevision.GetCreateTime(),
+		RevisionCreateTime: secondRevision.GetRevisionCreateTime(),
+		RevisionUpdateTime: secondRevision.GetRevisionUpdateTime(),
+		RevisionId:         secondRevision.GetRevisionId(),
+	}
+
+	opts := cmp.Options{
+		protocmp.Transform(),
+	}
+
+	var nextToken string
+	t.Run("first page", func(t *testing.T) {
+		req := &rpc.ListApiSpecRevisionsRequest{
+			Name:     firstRevision.GetName(),
+			PageSize: 1,
+		}
+
+		got, err := server.ListApiSpecRevisions(ctx, req)
+		if err != nil {
+			t.Fatalf("ListApiSpecRevisions(%+v) returned error: %s", req, err)
+		}
+
+		if count := len(got.GetSpecs()); count != 1 {
+			t.Errorf("ListApiSpecRevisions(%+v) returned %d specs, expected exactly one", req, count)
+		}
+
+		// Check that the most recent revision is returned.
+		want := []*rpc.ApiSpec{secondWant}
+		if !cmp.Equal(want, got.GetSpecs(), opts) {
+			t.Errorf("List sequence returned unexpected diff (-want +got):\n%s", cmp.Diff(want, got.GetSpecs(), opts))
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApiSpecRevisions(%+v) returned empty next_page_token, expected another page", req)
+		}
+
+		nextToken = got.GetNextPageToken()
+	})
+
+	if t.Failed() {
+		t.Fatal("Cannot test final page after failure on first page")
+	}
+
+	t.Run("final page", func(t *testing.T) {
+		req := &rpc.ListApiSpecRevisionsRequest{
+			Name:      firstRevision.GetName(),
+			PageToken: nextToken,
+		}
+
+		got, err := server.ListApiSpecRevisions(ctx, req)
+		if err != nil {
+			t.Fatalf("ListApiSpecRevisions(%+v) returned error: %s", req, err)
+		}
+
+		if count := len(got.GetSpecs()); count != 1 {
+			t.Errorf("ListApiSpecRevisions(%+v) returned %d specs, expected exactly one", req, count)
+		}
+
+		// Check that the original revision is returned.
+		want := []*rpc.ApiSpec{firstWant}
+		if !cmp.Equal(want, got.GetSpecs(), opts) {
+			t.Errorf("List sequence returned unexpected diff (-want +got):\n%s", cmp.Diff(want, got.GetSpecs(), opts))
+		}
+
+		if got.GetNextPageToken() != "" {
+			// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
+			t.Logf("ListApiSpecRevisions(%+v) returned next_page_token, expected no next page", req)
+		}
+	})
+}
+
+func TestUpdateApiSpecRevisions(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seedVersions(ctx, t, server, &rpc.ApiVersion{
+		Name: "projects/my-project/apis/my-api/versions/v1",
+	})
+
+	createReq := &rpc.CreateApiSpecRequest{
+		Parent: "projects/my-project/apis/my-api/versions/v1",
+		ApiSpec: &rpc.ApiSpec{
+			Description: "Empty First Revision",
+		},
+	}
+
+	created, err := server.CreateApiSpec(ctx, createReq)
+	if err != nil {
+		t.Fatalf("Setup: CreateApiSpec(%+v) returned error: %s", createReq, err)
+	}
+
+	opts := cmp.Options{
+		protocmp.Transform(),
+		protocmp.IgnoreFields(new(rpc.ApiSpec), "revision_id", "create_time", "revision_create_time", "revision_update_time"),
+	}
+
+	t.Run("modify revision without content changes", func(t *testing.T) {
+		req := &rpc.UpdateApiSpecRequest{
+			ApiSpec: &rpc.ApiSpec{
+				Name: created.GetName(),
+			},
+		}
+
+		got, err := server.UpdateApiSpec(ctx, req)
+		if err != nil {
+			t.Fatalf("UpdateApiSpec(%+v) returned error: %s", req, err)
+		}
+
+		if got.GetRevisionId() != created.GetRevisionId() {
+			t.Errorf("UpdateApiSpec(%+v) returned unexpected revision_id %q, expected no change (%q)", req, got.GetRevisionId(), created.GetRevisionId())
+		}
+
+		if ct, ut := got.GetRevisionCreateTime().AsTime(), got.GetRevisionUpdateTime().AsTime(); !ct.Before(ut) {
+			t.Errorf("UpdateApiSpec(%+v) returned unexpected timestamps, expected revision_update_time %v > revision_create_time %v", req, ut, ct)
+		}
+	})
+
+	t.Run("modify revision with content changes", func(t *testing.T) {
+		req := &rpc.UpdateApiSpecRequest{
+			ApiSpec: &rpc.ApiSpec{
+				Name:     created.GetName(),
+				Contents: specContents,
+			},
+		}
+		want := proto.Clone(created).(*rpc.ApiSpec)
+		want.SizeBytes = int32(len(req.ApiSpec.GetContents()))
+		want.Hash = sha256hash(req.ApiSpec.GetContents())
+
+		got, err := server.UpdateApiSpec(ctx, req)
+		if err != nil {
+			t.Fatalf("UpdateApiSpec(%+v) returned error: %s", req, err)
+		}
+
+		if !cmp.Equal(want, got, opts) {
+			t.Errorf("TagApiSpecRevision(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(want, got, opts))
+		}
+
+		if got.GetRevisionId() == created.GetRevisionId() {
+			t.Errorf("UpdateApiSpec(%+v) returned unexpected revision_id %q, expected new revision", req, got.GetRevisionId())
+		}
+
+		if ct, ut := got.GetCreateTime().AsTime(), got.GetRevisionUpdateTime().AsTime(); !ct.Before(ut) {
+			t.Errorf("UpdateApiSpec(%+v) returned unexpected timestamps, expected revision_update_time %v > create_time %v", req, ut, ct)
+		}
+	})
+
+	t.Run("modify specific revision", func(t *testing.T) {
+		req := &rpc.UpdateApiSpecRequest{
+			ApiSpec: &rpc.ApiSpec{
+				Name: fmt.Sprintf("%s@%s", created.GetName(), created.GetRevisionId()),
+			},
+		}
+
+		if _, err := server.UpdateApiSpec(ctx, req); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("UpdateApiSpec(%+v) returned unexpected status code %q, want %q: %v", req, status.Code(err), codes.InvalidArgument, err)
+		}
+	})
+}

--- a/server/actions_spec_revisions_test.go
+++ b/server/actions_spec_revisions_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -16,10 +16,8 @@ package server
 
 import (
 	"context"
-	"errors"
-	"log"
+	"fmt"
 	"sort"
-	"time"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/models"
@@ -27,85 +25,66 @@ import (
 	"github.com/apigee/registry/server/storage"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // CreateApiSpec handles the corresponding API request.
 func (s *RegistryServer) CreateApiSpec(ctx context.Context, req *rpc.CreateApiSpecRequest) (*rpc.ApiSpec, error) {
+	parent, err := names.ParseVersion(req.GetParent())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	name := parent.Spec(req.GetApiSpecId())
+	if name.SpecID == "" {
+		name.SpecID = names.GenerateID()
+	}
+
+	return s.createSpec(ctx, name, req.GetApiSpec())
+}
+
+func (s *RegistryServer) createSpec(ctx context.Context, name names.Spec, body *rpc.ApiSpec) (*rpc.ApiSpec, error) {
 	client, err := s.getStorageClient(ctx)
 	if err != nil {
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
 
-	if req.GetApiSpecId() == "" {
-		req.ApiSpecId = names.GenerateID()
+	if _, err := getSpec(ctx, client, name); err == nil {
+		return nil, alreadyExistsError(fmt.Errorf("API spec %q already exists", name))
+	} else if !isNotFound(err) {
+		return nil, err
 	}
 
-	spec, err := models.NewSpecFromParentAndSpecID(req.GetParent(), req.GetApiSpecId())
+	if err := name.Validate(); err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	// Creation should only succeed when the parent exists.
+	if _, err := getVersion(ctx, client, name.Version()); err != nil {
+		return nil, err
+	}
+
+	spec, err := models.NewSpec(name, body)
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
+
+	if err := saveSpecRevision(ctx, client, spec); err != nil {
+		return nil, err
+	}
+
+	if err := saveSpecRevisionContents(ctx, client, spec, body.GetContents()); err != nil {
+		return nil, err
+	}
+
+	message, err := spec.BasicMessage(name.String())
 	if err != nil {
 		return nil, internalError(err)
 	}
 
-	if err := spec.Update(req.GetApiSpec(), nil); err != nil {
-		return nil, internalError(err)
-	}
-
-	return s.createSpec(ctx, client, spec, req.ApiSpec.GetContents())
-}
-
-func (s *RegistryServer) createSpec(ctx context.Context, client storage.Client, spec *models.Spec, contents []byte) (*rpc.ApiSpec, error) {
-	q := client.NewQuery(models.SpecEntityName)
-	q = q.Require("ProjectID", spec.ProjectID)
-	q = q.Require("ApiID", spec.ApiID)
-	q = q.Require("VersionID", spec.VersionID)
-	q = q.Require("SpecID", spec.SpecID)
-	it := client.Run(ctx, q)
-
-	if _, err := it.Next(&models.Spec{}); err == nil {
-		return nil, status.Errorf(codes.AlreadyExists, "spec %q already exists", spec.ResourceName())
-	}
-
-	spec.CreateTime = spec.RevisionUpdateTime
-	spec.RevisionCreateTime = spec.RevisionUpdateTime
-	spec.Currency = models.IsCurrent
-	if err := saveSpec(ctx, client, spec); err != nil {
-		return nil, internalError(err)
-	}
-
-	if err := saveSpecContents(ctx, client, spec, contents); err != nil {
-		return nil, internalError(err)
-	}
-
-	response, err := spec.Message(rpc.View_BASIC, nil, "")
-	if err != nil {
-		return nil, internalError(err)
-	}
-
-	s.notify(rpc.Notification_CREATED, spec.ResourceNameWithRevision())
-	return response, nil
-}
-
-func saveSpec(ctx context.Context, client storage.Client, spec *models.Spec) error {
-	k := client.NewKey(models.SpecEntityName, spec.ResourceNameWithRevision())
-	if _, err := client.Put(ctx, k, spec); err != nil {
-		log.Printf("save spec error %+v", err)
-		return err
-	}
-
-	return nil
-}
-
-func saveSpecContents(ctx context.Context, client storage.Client, spec *models.Spec, contents []byte) error {
-	blob := models.NewBlobForSpec(spec, contents)
-	k := client.NewKey(models.BlobEntityName, spec.ResourceNameWithRevision())
-	if _, err := client.Put(ctx, k, blob); err != nil {
-		log.Printf("save blob error %+v", err)
-		return err
-	}
-
-	return nil
+	s.notify(rpc.Notification_CREATED, spec.RevisionName())
+	return message, nil
 }
 
 // DeleteApiSpec handles the corresponding API request.
@@ -115,58 +94,100 @@ func (s *RegistryServer) DeleteApiSpec(ctx context.Context, req *rpc.DeleteApiSp
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	// Validate name and create dummy spec (we just need the ID fields).
-	spec, err := models.NewSpecFromResourceName(req.GetName())
+
+	name, err := names.ParseSpec(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
 	}
-	if spec.RevisionID != "" {
-		return nil, invalidArgumentError(errors.New("specific revisions should be deleted with DeleteSpecRevision"))
+
+	// Deletion should only succeed on API specs that currently exist.
+	if _, err := getSpec(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if _, _, err := fetchSpec(ctx, client, req.GetName()); client.IsNotFound(err) {
-		return nil, notFoundError(err)
-	} else if err != nil {
-		return nil, internalError(err)
+	if err := deleteSpec(ctx, client, name); err != nil {
+		return nil, err
 	}
 
-	if err := client.DeleteChildrenOfSpec(ctx, spec); err != nil {
-		return nil, internalError(err)
-	}
-
-	// Delete all revisions of the spec.
-	q := client.NewQuery(models.SpecEntityName)
-	q = q.Require("ProjectID", spec.ProjectID)
-	q = q.Require("ApiID", spec.ApiID)
-	q = q.Require("VersionID", spec.VersionID)
-	q = q.Require("SpecID", spec.SpecID)
-	if err := client.DeleteAllMatches(ctx, q); err != nil {
-		return nil, internalError(err)
-	}
-
-	s.notify(rpc.Notification_DELETED, req.GetName())
-	return &empty.Empty{}, err
+	s.notify(rpc.Notification_DELETED, name.String())
+	return &empty.Empty{}, nil
 }
 
 // GetApiSpec handles the corresponding API request.
 func (s *RegistryServer) GetApiSpec(ctx context.Context, req *rpc.GetApiSpecRequest) (*rpc.ApiSpec, error) {
+	if name, err := names.ParseSpec(req.GetName()); err == nil {
+		return s.getApiSpec(ctx, name, req.GetView())
+	} else if name, err := names.ParseSpecRevision(req.GetName()); err == nil {
+		return s.getApiSpecRevision(ctx, name, req.GetView())
+	}
+
+	return nil, invalidArgumentError(fmt.Errorf("invalid resource name %q, must be an API spec or revision", req.GetName()))
+}
+
+func (s *RegistryServer) getApiSpec(ctx context.Context, name names.Spec, view rpc.View) (*rpc.ApiSpec, error) {
 	client, err := s.getStorageClient(ctx)
 	if err != nil {
 		return nil, unavailableError(err)
 	}
 	defer s.releaseStorageClient(client)
-	spec, userSpecifiedRevision, err := fetchSpec(ctx, client, req.GetName())
+
+	spec, err := getSpec(ctx, client, name)
 	if err != nil {
-		if client.IsNotFound(err) {
-			return nil, notFoundError(err)
+		return nil, err
+	}
+
+	blob, err := getSpecRevisionContents(ctx, client, name.Revision(spec.RevisionID))
+	if err != nil {
+		return nil, err
+	}
+
+	var message *rpc.ApiSpec
+	if view == rpc.View_FULL {
+		message, err = spec.FullMessage(blob, name.String())
+		if err != nil {
+			return nil, internalError(err)
 		}
-		return nil, internalError(err)
+	} else {
+		message, err = spec.BasicMessage(name.String())
+		if err != nil {
+			return nil, internalError(err)
+		}
 	}
-	var blob *models.Blob
-	if req.GetView() == rpc.View_FULL {
-		blob, _ = fetchBlobForSpec(ctx, client, spec)
+
+	return message, nil
+}
+
+func (s *RegistryServer) getApiSpecRevision(ctx context.Context, name names.SpecRevision, view rpc.View) (*rpc.ApiSpec, error) {
+	client, err := s.getStorageClient(ctx)
+	if err != nil {
+		return nil, unavailableError(err)
 	}
-	return spec.Message(req.GetView(), blob, userSpecifiedRevision)
+	defer s.releaseStorageClient(client)
+
+	revision, err := getSpecRevision(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	blob, err := getSpecRevisionContents(ctx, client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	var message *rpc.ApiSpec
+	if view == rpc.View_FULL {
+		message, err = revision.FullMessage(blob, name.String())
+		if err != nil {
+			return nil, internalError(err)
+		}
+	} else {
+		message, err = revision.BasicMessage(name.String())
+		if err != nil {
+			return nil, internalError(err)
+		}
+	}
+
+	return message, nil
 }
 
 // ListApiSpecs handles the corresponding API request.
@@ -178,10 +199,10 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 	defer s.releaseStorageClient(client)
 
 	if req.GetPageSize() < 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid page_size: must not be negative")
+		return nil, invalidArgumentError(fmt.Errorf("invalid page_size %d: must not be negative", req.GetPageSize()))
 	}
 
-	q := client.NewQuery(models.SpecEntityName)
+	q := client.NewQuery(storage.SpecEntityName)
 	q, err = q.ApplyCursor(req.GetPageToken())
 	if err != nil {
 		return nil, invalidArgumentError(err)
@@ -199,6 +220,21 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 	if id := parent.VersionID; id != "-" {
 		q = q.Require("VersionID", id)
 	}
+
+	if parent.ProjectID != "-" && parent.ApiID != "-" && parent.VersionID != "-" {
+		if _, err := getVersion(ctx, client, parent); err != nil {
+			return nil, err
+		}
+	} else if parent.ProjectID != "-" && parent.ApiID != "-" && parent.VersionID == "-" {
+		if _, err := getApi(ctx, client, parent.Api()); err != nil {
+			return nil, err
+		}
+	} else if parent.ProjectID != "-" && parent.ApiID == "-" && parent.VersionID == "-" {
+		if _, err := getProject(ctx, client, parent.Project()); err != nil {
+			return nil, err
+		}
+	}
+
 	q = q.Require("Currency", models.IsCurrent)
 	prg, err := createFilterOperator(req.GetFilter(),
 		[]filterArg{
@@ -227,7 +263,7 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 	for _, err := it.Next(&spec); err == nil; _, err = it.Next(&spec) {
 		if prg != nil {
 			filterInputs := map[string]interface{}{
-				"name":                 spec.ResourceName(),
+				"name":                 spec.Name(),
 				"project_id":           spec.ProjectID,
 				"api_id":               spec.ApiID,
 				"version_id":           spec.VersionID,
@@ -245,19 +281,36 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 			if err != nil {
 				return nil, internalError(err)
 			}
-			out, _, err := prg.Eval(filterInputs)
-			if err != nil {
+			if out, _, err := prg.Eval(filterInputs); err != nil {
 				return nil, invalidArgumentError(err)
-			}
-			if !out.Value().(bool) {
+			} else if !out.Value().(bool) {
 				continue
 			}
 		}
-		var blob *models.Blob
+
+		var specMessage *rpc.ApiSpec
 		if req.GetView() == rpc.View_FULL {
-			blob, _ = fetchBlobForSpec(ctx, client, &spec)
+			name, err := names.ParseSpecRevision(spec.RevisionName())
+			if err != nil {
+				continue
+			}
+
+			blob, err := getSpecRevisionContents(ctx, client, name)
+			if err != nil {
+				continue
+			}
+
+			specMessage, err = spec.FullMessage(blob, spec.Name())
+			if err != nil {
+				continue
+			}
+		} else {
+			specMessage, err = spec.BasicMessage(spec.Name())
+			if err != nil {
+				continue
+			}
 		}
-		specMessage, _ := spec.Message(req.GetView(), blob, "")
+
 		specMessages = append(specMessages, specMessage)
 		if len(specMessages) == pageSize {
 			break
@@ -285,322 +338,62 @@ func (s *RegistryServer) UpdateApiSpec(ctx context.Context, req *rpc.UpdateApiSp
 	defer s.releaseStorageClient(client)
 
 	if req.GetApiSpec() == nil {
-		return nil, invalidArgumentError(errors.New("spec body is required for updates"))
+		return nil, invalidArgumentError(fmt.Errorf("invalid api_spec %+v: body must be provided", req.GetApiSpec()))
 	}
 
-	spec, userSpecifiedRevision, err := fetchSpec(ctx, client, req.GetApiSpec().GetName())
-	if req.GetAllowMissing() && client.IsNotFound(err) {
-		spec, err := models.NewSpecFromResourceName(req.ApiSpec.GetName())
-		if err != nil {
-			return nil, internalError(err)
-		}
+	name, err := names.ParseSpec(req.ApiSpec.GetName())
+	if err != nil {
+		return nil, invalidArgumentError(err)
+	}
 
-		if err := spec.Update(req.GetApiSpec(), nil); err != nil {
-			return nil, internalError(err)
-		}
-
-		return s.createSpec(ctx, client, spec, req.ApiSpec.GetContents())
+	spec, err := getSpec(ctx, client, name)
+	if req.GetAllowMissing() && isNotFound(err) {
+		return s.createSpec(ctx, name, req.GetApiSpec())
 	} else if err != nil {
-		return nil, internalError(err)
-	} else if userSpecifiedRevision != "" {
-		return nil, invalidArgumentError(errors.New("updates to specific revisions are unsupported"))
+		return nil, err
 	}
-	oldRevisionID := spec.RevisionID
-	err = spec.Update(req.GetApiSpec(), req.GetUpdateMask())
-	if err != nil {
-		return nil, internalError(err)
-	}
-	newRevisionID := spec.RevisionID
-	// if the revision changed, get the previously-current revision and mark it as non-current
-	if oldRevisionID != newRevisionID {
-		k := client.NewKey(models.SpecEntityName, spec.ResourceNameWithSpecifiedRevision(oldRevisionID))
-		currentRevision := &models.Spec{}
-		client.Get(ctx, k, currentRevision)
-		currentRevision.Currency = models.NotCurrent
-		_, err = client.Put(ctx, k, currentRevision)
-		if err != nil {
-			return nil, internalError(err)
-		}
-		spec.Currency = models.IsCurrent
-	}
-	k := client.NewKey(models.SpecEntityName, spec.ResourceNameWithRevision())
-	spec.Key = spec.ResourceNameWithRevision()
-	k, err = client.Put(ctx, k, spec)
-	if err != nil {
-		return nil, internalError(err)
-	}
-	// save a blob with the spec contents (but only if the contents were updated)
-	if req.GetApiSpec().GetContents() != nil {
-		blob := models.NewBlobForSpec(
-			spec,
-			req.GetApiSpec().GetContents())
-		_, err = client.Put(ctx,
-			client.NewKey(models.BlobEntityName, spec.ResourceNameWithRevision()),
-			blob)
-		if err != nil {
-			return nil, internalError(err)
-		}
-	}
-	s.notify(rpc.Notification_UPDATED, spec.ResourceNameWithRevision())
-	return spec.Message(rpc.View_BASIC, nil, "")
-}
 
-// ListApiSpecRevisions handles the corresponding API request.
-func (s *RegistryServer) ListApiSpecRevisions(ctx context.Context, req *rpc.ListApiSpecRevisionsRequest) (*rpc.ListApiSpecRevisionsResponse, error) {
-	client, err := s.getStorageClient(ctx)
-	if err != nil {
-		return nil, unavailableError(err)
+	// Mark the current revision as non-current so the update becomes the only current revision.
+	spec.Currency = models.NotCurrent
+	if err := saveSpecRevision(ctx, client, spec); err != nil {
+		return nil, err
 	}
-	defer s.releaseStorageClient(client)
-	targetSpec, err := models.NewSpecFromResourceName(req.GetName())
-	if err != nil {
-		return nil, internalError(err)
-	}
-	q := client.NewQuery(models.SpecEntityName)
-	q, err = q.ApplyCursor(req.GetPageToken())
-	if err != nil {
-		return nil, internalError(err)
-	}
-	q = q.Require("ProjectID", targetSpec.ProjectID)
-	q = q.Require("ApiID", targetSpec.ApiID)
-	q = q.Require("VersionID", targetSpec.VersionID)
-	q = q.Require("SpecID", targetSpec.SpecID)
-	q = q.Order("-CreateTime")
 
-	var specMessages []*rpc.ApiSpec
-	responses := &rpc.ListApiSpecRevisionsResponse{}
-	if s.weTrustTheSort {
-		var spec models.Spec
-		it := client.Run(ctx, q)
-		pageSize := boundPageSize(req.GetPageSize())
-		for _, err := it.Next(&spec); err == nil; _, err = it.Next(&spec) {
-			specMessage, _ := spec.Message(rpc.View_BASIC, nil, spec.RevisionID)
-			specMessages = append(specMessages, specMessage)
-			if len(specMessages) == pageSize {
-				break
-			}
-		}
-		if err != nil && err != iterator.Done {
-			return nil, internalError(err)
-		}
-		responses.NextPageToken, err = it.GetCursor(len(specMessages))
-		if err != nil {
-			return nil, internalError(err)
-		}
-	} else {
-		specs := make([]*models.Spec, 0)
-		it := client.Run(ctx, q)
-		for {
-			spec := &models.Spec{}
-			_, err := it.Next(spec)
-			if err != nil {
-				break
-			}
-			specs = append(specs, spec)
-		}
-		if err != nil && err != iterator.Done {
-			return nil, internalError(err)
-		}
-		sort.Slice(specs, func(i, j int) bool {
-			return specs[i].CreateTime.After(specs[j].CreateTime)
-		})
-		for _, spec := range specs {
-			specMessage, _ := spec.Message(rpc.View_BASIC, nil, spec.RevisionID)
-			specMessages = append(specMessages, specMessage)
-		}
-		responses.NextPageToken = ""
-		err = nil
+	// Apply the update to the spec - possibly changing the revision ID.
+	if err := spec.Update(req.GetApiSpec(), req.GetUpdateMask()); err != nil {
+		return nil, internalError(err)
 	}
-	responses.Specs = specMessages
-	return responses, nil
-}
 
-// DeleteApiSpecRevision handles the corresponding API request.
-func (s *RegistryServer) DeleteApiSpecRevision(ctx context.Context, req *rpc.DeleteApiSpecRevisionRequest) (*empty.Empty, error) {
-	client, err := s.getStorageClient(ctx)
-	if err != nil {
-		return nil, unavailableError(err)
+	// Save the updated/current spec. This creates a new revision or updates the previous one.
+	if err := saveSpecRevision(ctx, client, spec); err != nil {
+		return nil, err
 	}
-	defer s.releaseStorageClient(client)
-	// Delete the spec revision.
-	// First, get the revision to delete.
-	spec, _, err := fetchSpec(ctx, client, req.GetName())
-	if err != nil {
-		return nil, internalError(err)
-	}
-	k := client.NewKey(models.SpecEntityName, spec.ResourceNameWithRevision())
-	// If the one we will delete is the current revision, we need to designate a new current revision.
-	if spec.Currency == models.IsCurrent {
-		// get the most recent non-current revision and make it current
-		newKey, newCurrentRevision, err := s.fetchMostRecentNonCurrentRevisionOfSpec(ctx, client, req.GetName())
-		if err != nil {
-			log.Printf("error %+v", err)
-		}
-		if err == nil && newCurrentRevision != nil {
-			newCurrentRevision.Currency = models.IsCurrent
-			client.Put(ctx, newKey, newCurrentRevision)
-		}
-	}
-	err = client.Delete(ctx, k)
-	// Delete the blob associated with the spec
-	k2 := client.NewKey(models.BlobEntityName, spec.ResourceNameWithRevision())
-	err = client.Delete(ctx, k2)
-	s.notify(rpc.Notification_DELETED, spec.ResourceNameWithRevision())
-	return &empty.Empty{}, err
-}
 
-// TagApiSpecRevision handles the corresponding API request.
-func (s *RegistryServer) TagApiSpecRevision(ctx context.Context, req *rpc.TagApiSpecRevisionRequest) (*rpc.ApiSpec, error) {
-	client, err := s.getStorageClient(ctx)
-	if err != nil {
-		return nil, unavailableError(err)
-	}
-	defer s.releaseStorageClient(client)
-	spec, userSpecifiedRevision, err := fetchSpec(ctx, client, req.GetName())
-	if err != nil {
-		return nil, internalError(err)
-	}
-	if userSpecifiedRevision == "" {
-		log.Printf("we might not want to support tagging specs with unspecified revisions")
-	}
-	if req.GetTag() == "" {
-		return nil, invalidArgumentError(errors.New("tags cannot be empty"))
-	}
-	// save the tag
-	now := time.Now()
-	tag := &models.SpecRevisionTag{
-		ProjectID:  spec.ProjectID,
-		ApiID:      spec.ApiID,
-		VersionID:  spec.VersionID,
-		SpecID:     spec.SpecID,
-		RevisionID: spec.RevisionID,
-		Tag:        req.GetTag(),
-		CreateTime: now,
-		UpdateTime: now,
-	}
-	k := client.NewKey(models.SpecRevisionTagEntityName, tag.ResourceNameWithTag())
-	k, err = client.Put(ctx, k, tag)
-	// send a notification that the tagged spec has been updated
-	s.notify(rpc.Notification_UPDATED, spec.ResourceNameWithSpecifiedRevision(req.GetTag()))
-	// return the spec using the tag for its name
-	return spec.Message(rpc.View_BASIC, nil, req.GetTag())
-}
-
-// RollbackApiSpec handles the corresponding API request.
-func (s *RegistryServer) RollbackApiSpec(ctx context.Context, req *rpc.RollbackApiSpecRequest) (*rpc.ApiSpec, error) {
-	client, err := s.getStorageClient(ctx)
-	if err != nil {
-		return nil, unavailableError(err)
-	}
-	defer s.releaseStorageClient(client)
-	specNameWithRevision := req.GetName() + "@" + req.GetRevisionId()
-	spec, userSpecifiedRevision, err := fetchSpec(ctx, client, specNameWithRevision)
-	if err != nil {
-		// TODO: this should return NotFound if the revision was not found.
-		return nil, notFoundError(err)
-	}
-	if userSpecifiedRevision == "" {
-		return nil, invalidArgumentError(errors.New("rollbacks require a specified revision"))
-	}
-	// The previous current revision needs to be marked non-current.
-	oldKey, oldCurrent, err := fetchCurrentRevisionOfSpec(ctx, client, req.GetName())
-	if err == nil && oldCurrent != nil {
-		oldCurrent.Currency = models.NotCurrent
-		_, err = client.Put(ctx, oldKey, oldCurrent)
-		if err != nil {
-			log.Printf("oops %+v", err)
-			return nil, internalError(err)
+	// If the spec contents were updated, save a new blob.
+	implicitUpdate := req.GetUpdateMask() == nil && len(req.ApiSpec.GetContents()) > 0
+	explicitUpdate := len(fieldmaskpb.Intersect(req.GetUpdateMask(), &fieldmaskpb.FieldMask{Paths: []string{"contents"}}).GetPaths()) > 0
+	if implicitUpdate || explicitUpdate {
+		if err := saveSpecRevisionContents(ctx, client, spec, req.ApiSpec.GetContents()); err != nil {
+			return nil, err
 		}
 	}
-	// Make the selected revision the current revision by giving it a new RevisionID and saving it
-	oldBlobKey := client.NewKey(models.BlobEntityName, spec.ResourceNameWithRevision())
-	blob := &models.Blob{}
-	err = client.Get(ctx, oldBlobKey, blob)
-	if err != nil {
-		return nil, internalError(err)
-	}
-	spec.BumpRevision()
-	spec.Currency = models.IsCurrent
-	newSpecKey := client.NewKey(models.SpecEntityName, spec.ResourceNameWithRevision())
-	_, err = client.Put(ctx, newSpecKey, spec)
-	if err != nil {
-		return nil, internalError(err)
-	}
-	// Resave the blob for the current revision with the new RevisionID
-	newBlobKey := client.NewKey(models.BlobEntityName, spec.ResourceNameWithRevision())
-	blob.RevisionID = spec.RevisionID
-	_, err = client.Put(ctx, newBlobKey, blob)
-	if err != nil {
-		return nil, internalError(err)
-	}
-	// Send a notification of the new revision.
-	s.notify(rpc.Notification_UPDATED, spec.ResourceNameWithRevision())
-	return spec.Message(rpc.View_BASIC, nil, spec.RevisionID)
-}
 
-// fetchSpec gets the stored model of a Spec.
-func fetchSpec(
-	ctx context.Context,
-	client storage.Client,
-	name string,
-) (*models.Spec, string, error) {
-	spec, err := models.NewSpecFromResourceName(name)
+	message, err := spec.BasicMessage(name.String())
 	if err != nil {
-		return nil, "", err
+		return nil, internalError(err)
 	}
-	// if there's no revision, get the current revision
-	if spec.RevisionID == "" {
-		_, spec, err := fetchCurrentRevisionOfSpec(ctx, client, name)
-		if err != nil {
-			return nil, "", err
-		}
-		return spec, "", nil
-	}
-	// since a revision was specified, get the spec by revision
-	// if the revision reference is a tag, resolve the tag
-	var resourceName string
-	var revisionName string
-	specRevisionTag := &models.SpecRevisionTag{}
-	k0 := client.NewKey(models.SpecRevisionTagEntityName, spec.ResourceNameWithRevision())
-	err = client.Get(ctx, k0, specRevisionTag)
-	if client.IsNotFound(err) {
-		// if there is no tag, just use the provided revision
-		resourceName = spec.ResourceNameWithRevision()
-		revisionName = spec.RevisionID
-	} else if err != nil {
-		return nil, "", err
-	} else {
-		// if there is a tag, use the revision that the tag references
-		resourceName = specRevisionTag.ResourceNameWithRevision()
-		revisionName = specRevisionTag.Tag
-	}
-	// now that we know the revision, use it get the spec
-	k := client.NewKey(models.SpecEntityName, resourceName)
-	err = client.Get(ctx, k, spec)
-	if client.IsNotFound(err) {
-		return nil, revisionName, err
-	} else if err != nil {
-		return nil, revisionName, err
-	}
-	return spec, revisionName, nil
+
+	s.notify(rpc.Notification_UPDATED, spec.RevisionName())
+	return message, nil
 }
 
 // fetchMostRecentNonCurrentRevisionOfSpec gets the most recent revision that's not current.
-func (s *RegistryServer) fetchMostRecentNonCurrentRevisionOfSpec(
-	ctx context.Context,
-	client storage.Client,
-	name string,
-) (storage.Key, *models.Spec, error) {
-	pattern, err := models.NewSpecFromResourceName(name)
-	if err != nil {
-		return nil, nil, err
-	}
-	// note that we ignore any specified RevisionID
-	q := client.NewQuery(models.SpecEntityName)
-	q = q.Require("ProjectID", pattern.ProjectID)
-	q = q.Require("ApiID", pattern.ApiID)
-	q = q.Require("VersionID", pattern.VersionID)
-	q = q.Require("SpecID", pattern.SpecID)
+func (s *RegistryServer) fetchMostRecentNonCurrentRevisionOfSpec(ctx context.Context, client storage.Client, name names.Spec) (storage.Key, *models.Spec, error) {
+	q := client.NewQuery(storage.SpecEntityName)
+	q = q.Require("ProjectID", name.ProjectID)
+	q = q.Require("ApiID", name.ApiID)
+	q = q.Require("VersionID", name.VersionID)
+	q = q.Require("SpecID", name.SpecID)
 	q = q.Require("Currency", models.NotCurrent)
 	q = q.Order("-CreateTime")
 	it := client.Run(ctx, q)
@@ -616,8 +409,7 @@ func (s *RegistryServer) fetchMostRecentNonCurrentRevisionOfSpec(
 		specs := make([]*models.Spec, 0)
 		for {
 			spec := &models.Spec{}
-			_, err := it.Next(spec)
-			if err != nil {
+			if _, err := it.Next(spec); err != nil {
 				break
 			}
 			specs = append(specs, spec)
@@ -630,39 +422,39 @@ func (s *RegistryServer) fetchMostRecentNonCurrentRevisionOfSpec(
 	}
 }
 
-// fetchCurrentRevisionOfSpec gets the current revision.
-func fetchCurrentRevisionOfSpec(
-	ctx context.Context,
-	client storage.Client,
-	name string,
-) (storage.Key, *models.Spec, error) {
-	pattern, err := models.NewSpecFromResourceName(name)
-	if err != nil {
-		return nil, nil, err
-	}
-	// note that we ignore any specified RevisionID
-	q := client.NewQuery(models.SpecEntityName)
-	q = q.Require("ProjectID", pattern.ProjectID)
-	q = q.Require("ApiID", pattern.ApiID)
-	q = q.Require("VersionID", pattern.VersionID)
-	q = q.Require("SpecID", pattern.SpecID)
+func getSpec(ctx context.Context, client storage.Client, name names.Spec) (*models.Spec, error) {
+	q := client.NewQuery(storage.SpecEntityName)
+	q = q.Require("ProjectID", name.ProjectID)
+	q = q.Require("ApiID", name.ApiID)
+	q = q.Require("VersionID", name.VersionID)
+	q = q.Require("SpecID", name.SpecID)
 	q = q.Require("Currency", models.IsCurrent)
 	it := client.Run(ctx, q)
 	spec := &models.Spec{}
-	k, err := it.Next(spec)
-	if err != nil {
-		return nil, nil, client.NotFoundError()
+	if _, err := it.Next(spec); err != nil {
+		return nil, notFoundError(err)
 	}
-	return k, spec, nil
+	return spec, nil
 }
 
-// fetchBlobForSpec gets the blob containing the spec contents.
-func fetchBlobForSpec(
-	ctx context.Context,
-	client storage.Client,
-	spec *models.Spec) (*models.Blob, error) {
-	blob := &models.Blob{}
-	k := client.NewKey(models.BlobEntityName, spec.ResourceNameWithRevision())
-	err := client.Get(ctx, k, blob)
-	return blob, err
+func deleteSpec(ctx context.Context, client storage.Client, name names.Spec) error {
+	if err := client.DeleteChildrenOfSpec(ctx, name); err != nil {
+		return internalError(err)
+	}
+
+	k := client.NewKey(storage.SpecEntityName, name.String())
+	if err := client.Delete(ctx, k); err != nil {
+		return internalError(err)
+	}
+
+	q := client.NewQuery(storage.SpecEntityName)
+	q = q.Require("ProjectID", name.ProjectID)
+	q = q.Require("ApiID", name.ApiID)
+	q = q.Require("VersionID", name.VersionID)
+	q = q.Require("SpecID", name.SpecID)
+	if err := client.DeleteAllMatches(ctx, q); err != nil {
+		return internalError(err)
+	}
+
+	return nil
 }

--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,31 +17,70 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
+var (
+	// Example spec contents for an OpenAPI JSON spec.
+	specContents = []byte(`{"openapi": "3.0.0", "info": {"title": "My API", "version": "v1"}, "paths": {}}`)
+	// Basic spec view does not include file contents or annotations.
+	basicSpec = &rpc.ApiSpec{
+		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+		Filename:     "openapi.json",
+		Description:  "My API Spec",
+		MimeType:     "application/x.openapi;version=3.0.0",
+		SizeBytes:    int32(len(specContents)),
+		Hash:         sha256hash(specContents),
+		SourceUri:    "https://www.example.com/openapi.json",
+		RevisionTags: []string{},
+		Labels: map[string]string{
+			"label-key": "label-value",
+		},
+	}
+	// Full spec view includes annotations.
+	fullSpec = &rpc.ApiSpec{
+		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+		Filename:     "openapi.json",
+		Description:  "My API Spec",
+		MimeType:     "application/x.openapi;version=3.0.0",
+		SizeBytes:    int32(len(specContents)),
+		Hash:         sha256hash(specContents),
+		SourceUri:    "https://www.example.com/openapi.json",
+		Contents:     specContents,
+		RevisionTags: []string{},
+		Labels: map[string]string{
+			"label-key": "label-value",
+		},
+		Annotations: map[string]string{
+			"annotation-key": "annotation-value",
+		},
+	}
+)
+
+func sha256hash(bytes []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(bytes))
+}
+
 func seedSpecs(ctx context.Context, t *testing.T, s *RegistryServer, specs ...*rpc.ApiSpec) {
 	t.Helper()
 
 	for _, spec := range specs {
-		m, err := names.ParseSpec(spec.Name)
+		name, err := names.ParseSpec(spec.Name)
 		if err != nil {
 			t.Fatalf("Setup/Seeding: ParseSpec(%q) returned error: %s", spec.Name, err)
 		}
 
-		parent := fmt.Sprintf("projects/%s/apis/%s/versions/%s", m[1], m[2], m[3])
 		seedVersions(ctx, t, s, &rpc.ApiVersion{
-			Name: parent,
+			Name: name.Version().String(),
 		})
 
-		req := &rpc.CreateApiSpecRequest{
-			Parent:    parent,
-			ApiSpecId: m[4],
-			ApiSpec:   spec,
+		req := &rpc.UpdateApiSpecRequest{
+			ApiSpec:      spec,
+			AllowMissing: true,
 		}
 
-		switch _, err := s.CreateApiSpec(ctx, req); status.Code(err) {
+		switch _, err := s.UpdateApiSpec(ctx, req); status.Code(err) {
 		case codes.OK, codes.AlreadyExists:
 			// ApiSpec is now ready for use in test.
 		default:
-			t.Fatalf("Setup/Seeding: CreateApiSpec(%+v) returned error: %s", req, err)
+			t.Fatalf("Setup/Seeding: UpdateApiSpec(%+v) returned error: %s", req, err)
 		}
 	}
 }
@@ -48,33 +88,32 @@ func seedSpecs(ctx context.Context, t *testing.T, s *RegistryServer, specs ...*r
 func TestCreateApiSpec(t *testing.T) {
 	tests := []struct {
 		desc      string
+		seed      *rpc.ApiVersion
 		req       *rpc.CreateApiSpecRequest
 		want      *rpc.ApiSpec
 		extraOpts cmp.Option
 	}{
 		{
-			desc: "default parameters",
+			desc: "populated resource with default parameters",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
-				Parent: "projects/my-project/apis/my-api/versions/v1",
-				ApiSpec: &rpc.ApiSpec{
-					Description: "ApiSpec for my versions",
-				},
+				Parent:  "projects/my-project/apis/my-api/versions/v1",
+				ApiSpec: fullSpec,
 			},
-			want: &rpc.ApiSpec{
-				Description: "ApiSpec for my versions",
-			},
+			want: basicSpec,
 			// Name field is generated.
 			extraOpts: protocmp.IgnoreFields(new(rpc.ApiSpec), "name"),
 		},
 		{
 			desc: "custom identifier",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
 				Parent:    "projects/my-project/apis/my-api/versions/v1",
-				ApiSpecId: "my-version",
+				ApiSpecId: "my-spec",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
 			want: &rpc.ApiSpec{
-				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-version",
+				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 			},
 		},
 	}
@@ -83,6 +122,7 @@ func TestCreateApiSpec(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			ctx := context.Background()
 			server := defaultTestServer(t)
+			seedVersions(ctx, t, server, test.seed)
 
 			created, err := server.CreateApiSpec(ctx, test.req)
 			if err != nil {
@@ -91,7 +131,7 @@ func TestCreateApiSpec(t *testing.T) {
 
 			opts := cmp.Options{
 				protocmp.Transform(),
-				protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "revision_id", "create_time", "revision_create_time", "revision_update_time"),
 				test.extraOpts,
 			}
 
@@ -101,6 +141,10 @@ func TestCreateApiSpec(t *testing.T) {
 
 			if !strings.HasPrefix(created.GetName(), test.req.GetParent()+"/specs/") {
 				t.Errorf("CreateApiSpec(%+v) returned unexpected name %q, expected collection prefix", test.req, created.GetName())
+			}
+
+			if created.RevisionId == "" {
+				t.Errorf("CreateApiSpec(%+v) returned unexpected revision_id %q, expected non-empty ID", test.req, created.GetRevisionId())
 			}
 
 			if created.CreateTime == nil || created.RevisionCreateTime == nil || created.RevisionUpdateTime == nil {
@@ -114,6 +158,7 @@ func TestCreateApiSpec(t *testing.T) {
 			t.Run("GetApiSpec", func(t *testing.T) {
 				req := &rpc.GetApiSpecRequest{
 					Name: created.GetName(),
+					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApiSpec(ctx, req)
@@ -131,16 +176,35 @@ func TestCreateApiSpec(t *testing.T) {
 }
 
 func TestCreateApiSpecResponseCodes(t *testing.T) {
-	t.Skip("Validation rules are not implemented")
-
 	tests := []struct {
 		desc string
+		seed *rpc.ApiVersion
 		req  *rpc.CreateApiSpecRequest
 		want codes.Code
 	}{
 		{
-			desc: "short custom identifier",
+			desc: "parent not found",
 			req: &rpc.CreateApiSpecRequest{
+				Parent:  "projects/my-project/apis/my-api/versions/v1",
+				ApiSpec: fullSpec,
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "specific revision",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			req: &rpc.CreateApiSpecRequest{
+				Parent:    "projects/my-project/apis/my-api/versions/v1",
+				ApiSpecId: "my-spec@12345678",
+				ApiSpec:   &rpc.ApiSpec{},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "short custom identifier",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			req: &rpc.CreateApiSpecRequest{
+				Parent:    "projects/my-project/apis/my-api/versions/v1",
 				ApiSpecId: "abc",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -148,7 +212,9 @@ func TestCreateApiSpecResponseCodes(t *testing.T) {
 		},
 		{
 			desc: "long custom identifier",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
+				Parent:    "projects/my-project/apis/my-api/versions/v1",
 				ApiSpecId: "this-identifier-exceeds-the-sixty-three-character-maximum-length",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -156,23 +222,19 @@ func TestCreateApiSpecResponseCodes(t *testing.T) {
 		},
 		{
 			desc: "custom identifier underscores",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
+				Parent:    "projects/my-project/apis/my-api/versions/v1",
 				ApiSpecId: "underscore_identifier",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
 			want: codes.InvalidArgument,
 		},
 		{
-			desc: "customer identifier dots",
-			req: &rpc.CreateApiSpecRequest{
-				ApiSpecId: "dot.identifier",
-				ApiSpec:   &rpc.ApiSpec{},
-			},
-			want: codes.InvalidArgument,
-		},
-		{
 			desc: "customer identifier uuid format",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
+				Parent:    "projects/my-project/apis/my-api/versions/v1",
 				ApiSpecId: "072d2288-c685-42d8-9df0-5edbb2a809ea",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -225,6 +287,64 @@ func TestCreateApiSpecDuplicates(t *testing.T) {
 	})
 }
 
+func TestGetApiSpec(t *testing.T) {
+	tests := []struct {
+		desc string
+		seed *rpc.ApiSpec
+		req  *rpc.GetApiSpecRequest
+		want *rpc.ApiSpec
+	}{
+		{
+			desc: "default view",
+			seed: fullSpec,
+			req: &rpc.GetApiSpecRequest{
+				Name: fullSpec.Name,
+			},
+			want: basicSpec,
+		},
+		{
+			desc: "basic view",
+			seed: fullSpec,
+			req: &rpc.GetApiSpecRequest{
+				Name: fullSpec.Name,
+				View: rpc.View_BASIC,
+			},
+			want: basicSpec,
+		},
+		{
+			desc: "full view",
+			seed: fullSpec,
+			req: &rpc.GetApiSpecRequest{
+				Name: fullSpec.Name,
+				View: rpc.View_FULL,
+			},
+			want: fullSpec,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			seedSpecs(ctx, t, server, test.seed)
+
+			got, err := server.GetApiSpec(ctx, test.req)
+			if err != nil {
+				t.Fatalf("GetApiSpec(%+v) returned error: %s", test.req, err)
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "revision_id", "create_time", "revision_create_time", "revision_update_time"),
+			}
+
+			if !cmp.Equal(test.want, got, opts) {
+				t.Errorf("GetApiSpec(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, got, opts))
+			}
+		})
+	}
+}
+
 func TestGetApiSpecResponseCodes(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -267,6 +387,7 @@ func TestListApiSpecs(t *testing.T) {
 				{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1"},
 				{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec2"},
 				{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec3"},
+				{Name: "projects/my-project/apis/my-api/versions/v2/specs/spec1"},
 			},
 			req: &rpc.ListApiSpecsRequest{
 				Parent: "projects/my-project/apis/my-api/versions/v1",
@@ -276,6 +397,108 @@ func TestListApiSpecs(t *testing.T) {
 					{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1"},
 					{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec2"},
 					{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec3"},
+				},
+			},
+		},
+		{
+			desc: "across all versions in a specific project and api",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/my-project/apis/my-api/versions/v2/specs/my-spec"},
+				{Name: "projects/other-project/apis/my-api/versions/v1/specs/my-spec"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/my-project/apis/my-api/versions/-",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+					{Name: "projects/my-project/apis/my-api/versions/v2/specs/my-spec"},
+				},
+			},
+		},
+		{
+			desc: "across all apis and versions in a specific project",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/my-project/apis/other-api/versions/v2/specs/my-spec"},
+				{Name: "projects/other-project/apis/my-api/versions/v1/specs/my-spec"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/my-project/apis/-/versions/-",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+					{Name: "projects/my-project/apis/other-api/versions/v2/specs/my-spec"},
+				},
+			},
+		},
+		{
+			desc: "across all projects, apis, and versions",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/other-project/apis/other-api/versions/v2/specs/my-spec"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/-/apis/-/versions/-",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+					{Name: "projects/other-project/apis/other-api/versions/v2/specs/my-spec"},
+				},
+			},
+		},
+		{
+			desc: "in a specific api and version across all projects",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/other-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/my-project/apis/other-api/versions/v1/specs/my-spec"},
+				{Name: "projects/my-project/apis/my-api/versions/v2/specs/my-spec"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/-/apis/my-api/versions/v1",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+					{Name: "projects/other-project/apis/my-api/versions/v1/specs/my-spec"},
+				},
+			},
+		},
+		{
+			desc: "in a specific version across all projects and apis",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/other-project/apis/other-api/versions/v1/specs/my-spec"},
+				{Name: "projects/my-project/apis/my-api/versions/v2/specs/my-spec"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/-/apis/-/versions/v1",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+					{Name: "projects/other-project/apis/other-api/versions/v1/specs/my-spec"},
+				},
+			},
+		},
+		{
+			desc: "in all versions of a specific api across all projects",
+			seed: []*rpc.ApiSpec{
+				{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+				{Name: "projects/other-project/apis/my-api/versions/v2/specs/my-spec"},
+				{Name: "projects/my-project/apis/other-api/versions/v1/specs/my-spec"},
+			},
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/-/apis/my-api/versions/-",
+			},
+			want: &rpc.ListApiSpecsResponse{
+				ApiSpecs: []*rpc.ApiSpec{
+					{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+					{Name: "projects/other-project/apis/my-api/versions/v2/specs/my-spec"},
 				},
 			},
 		},
@@ -355,7 +578,10 @@ func TestListApiSpecs(t *testing.T) {
 			opts := cmp.Options{
 				protocmp.Transform(),
 				protocmp.IgnoreFields(new(rpc.ListApiSpecsResponse), "next_page_token"),
-				protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "revision_id", "create_time", "revision_create_time", "revision_update_time"),
+				protocmp.SortRepeated(func(a, b *rpc.ApiSpec) bool {
+					return a.GetName() < b.GetName()
+				}),
 				test.extraOpts,
 			}
 
@@ -379,6 +605,27 @@ func TestListApiSpecsResponseCodes(t *testing.T) {
 		req  *rpc.ListApiSpecsRequest
 		want codes.Code
 	}{
+		{
+			desc: "parent version not found",
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/my-project/apis/my-api/versions/v1",
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "parent api not found",
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/my-project/apis/my-api/versions/-",
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "parent project not found",
+			req: &rpc.ListApiSpecsRequest{
+				Parent: "projects/my-project/apis/-/versions/-",
+			},
+			want: codes.NotFound,
+		},
 		{
 			desc: "negative page size",
 			req: &rpc.ListApiSpecsRequest{
@@ -438,6 +685,14 @@ func TestListApiSpecsSequence(t *testing.T) {
 			t.Fatalf("ListApiSpecs(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetApiSpecs()); count != 1 {
+			t.Errorf("ListApiSpecs(%+v) returned %d specs, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApiSpecs(%+v) returned empty next_page_token, expected another page", req)
+		}
+
 		listed = append(listed, got.ApiSpecs...)
 		nextToken = got.GetNextPageToken()
 	})
@@ -456,6 +711,14 @@ func TestListApiSpecsSequence(t *testing.T) {
 		got, err := server.ListApiSpecs(ctx, req)
 		if err != nil {
 			t.Fatalf("ListApiSpecs(%+v) returned error: %s", req, err)
+		}
+
+		if count := len(got.GetApiSpecs()); count != 1 {
+			t.Errorf("ListApiSpecs(%+v) returned %d specs, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApiSpecs(%+v) returned empty next_page_token, expected another page", req)
 		}
 
 		listed = append(listed, got.ApiSpecs...)
@@ -478,6 +741,10 @@ func TestListApiSpecsSequence(t *testing.T) {
 			t.Fatalf("ListApiSpecs(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetApiSpecs()); count != 1 {
+			t.Errorf("ListApiSpecs(%+v) returned %d specs, expected exactly one", req, count)
+		}
+
 		if got.GetNextPageToken() != "" {
 			// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
 			t.Logf("ListApiSpecs(%+v) returned next_page_token, expected no next page", req)
@@ -486,9 +753,13 @@ func TestListApiSpecsSequence(t *testing.T) {
 		listed = append(listed, got.ApiSpecs...)
 	})
 
+	if t.Failed() {
+		t.Fatal("Cannot test sequence result after failure on final page")
+	}
+
 	opts := cmp.Options{
 		protocmp.Transform(),
-		protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+		protocmp.IgnoreFields(new(rpc.ApiSpec), "revision_id", "create_time", "revision_create_time", "revision_update_time"),
 		cmpopts.SortSlices(func(a, b *rpc.ApiSpec) bool {
 			return a.GetName() < b.GetName()
 		}),
@@ -509,54 +780,109 @@ func TestUpdateApiSpec(t *testing.T) {
 		want *rpc.ApiSpec
 	}{
 		{
-			desc: "default parameters",
+			desc: "populated resource with default parameters",
+			seed: fullSpec,
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: fullSpec.Name,
+				},
+			},
+			want: fullSpec,
+		},
+		{
+			desc: "allow missing updates existing resources",
 			seed: &rpc.ApiSpec{
-				Name:        "projects/my-project/apis/my-api/versions/v1",
-				Description: "ApiSpec for my APIs",
+				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Description: "My ApiSpec",
+				Filename:    "openapi.json",
 			},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{
-					Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1",
+					Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+					Description: "My Updated ApiSpec",
+				},
+				UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"description"}},
+				AllowMissing: true,
+			},
+			want: &rpc.ApiSpec{
+				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Description: "My Updated ApiSpec",
+				Filename:    "openapi.json",
+			},
+		},
+		{
+			desc: "allow missing creates missing resources",
+			seed: &rpc.ApiSpec{
+				Name: "projects/my-project/apis/my-api/versions/v1/specs/sibling-spec",
+			},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				},
+				AllowMissing: true,
+			},
+			want: &rpc.ApiSpec{
+				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+			},
+		},
+		{
+			desc: "implicit mask",
+			seed: &rpc.ApiSpec{
+				Name:        "projects/my-project/apis/my-api/versions/v1",
+				Description: "My ApiSpec",
+				Filename:    "openapi.json",
+			},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name:        "projects/my-project/apis/my-api/versions/v1",
+					Description: "My Updated ApiSpec",
 				},
 			},
 			want: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1",
-				Description: "ApiSpec for my APIs",
+				Description: "My Updated ApiSpec",
+				Filename:    "openapi.json",
 			},
 		},
 		{
 			desc: "field specific mask",
 			seed: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1",
-				Description: "ApiSpec for my APIs",
+				Description: "My ApiSpec",
+				Filename:    "openapi.json",
 			},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{
 					Name:        "projects/my-project/apis/my-api/versions/v1",
-					Description: "Ignored",
+					Description: "My Updated ApiSpec",
+					Filename:    "Ignored",
 				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"display_name"}},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"description"}},
 			},
 			want: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1",
-				Description: "ApiSpec for my APIs",
+				Description: "My Updated ApiSpec",
+				Filename:    "openapi.json",
 			},
 		},
 		{
 			desc: "full replacement wildcard mask",
 			seed: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1",
-				Description: "ApiSpec for my APIs",
+				Description: "My ApiSpec",
+				Filename:    "openapi.json",
 			},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{
-					Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1",
+					Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+					Description: "My Updated ApiSpec",
 				},
 				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
 			},
 			want: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1",
-				Description: "",
+				Description: "My Updated ApiSpec",
+				Filename:    "",
 			},
 		},
 	}
@@ -574,7 +900,7 @@ func TestUpdateApiSpec(t *testing.T) {
 
 			opts := cmp.Options{
 				protocmp.Transform(),
-				protocmp.IgnoreFields(new(rpc.ApiSpec), "create_time", "revision_create_time", "revision_update_time"),
+				protocmp.IgnoreFields(new(rpc.ApiSpec), "revision_id", "create_time", "revision_create_time", "revision_update_time"),
 			}
 
 			if !cmp.Equal(test.want, updated, opts) {
@@ -600,7 +926,7 @@ func TestUpdateApiSpec(t *testing.T) {
 	}
 }
 
-func TestUpdateApiSpecsResponseCodes(t *testing.T) {
+func TestUpdateApiSpecResponseCodes(t *testing.T) {
 	t.Skip("Update mask validation is not implemented")
 
 	tests := []struct {
@@ -611,7 +937,7 @@ func TestUpdateApiSpecsResponseCodes(t *testing.T) {
 	}{
 		{
 			desc: "resource not found",
-			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1"},
+			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{
 					Name: "projects/my-project/apis/my-api/versions/v1/specs/doesnt-exist",
@@ -620,8 +946,24 @@ func TestUpdateApiSpecsResponseCodes(t *testing.T) {
 			want: codes.NotFound,
 		},
 		{
+			desc: "specific revision",
+			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec@12345678",
+				},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "missing resource body",
+			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+			req:  &rpc.UpdateApiSpecRequest{},
+			want: codes.InvalidArgument,
+		},
+		{
 			desc: "missing resource name",
-			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1"},
+			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{},
 			},
@@ -629,10 +971,10 @@ func TestUpdateApiSpecsResponseCodes(t *testing.T) {
 		},
 		{
 			desc: "nonexistent field in mask",
-			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1"},
+			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{
-					Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1",
+					Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 				},
 				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"this field does not exist"}},
 			},
@@ -662,10 +1004,10 @@ func TestDeleteApiSpec(t *testing.T) {
 		{
 			desc: "existing version",
 			seed: &rpc.ApiSpec{
-				Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1",
+				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 			},
 			req: &rpc.DeleteApiSpecRequest{
-				Name: "projects/my-project/apis/my-api/versions/v1/specs/spec1",
+				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 			},
 		},
 	}
@@ -705,6 +1047,13 @@ func TestDeleteApiSpecResponseCodes(t *testing.T) {
 				Name: "projects/my-project/apis/my-api/versions/v1/specs/doesnt-exist",
 			},
 			want: codes.NotFound,
+		},
+		{
+			desc: "specific revision",
+			req: &rpc.DeleteApiSpecRequest{
+				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec@12345678",
+			},
+			want: codes.InvalidArgument,
 		},
 	}
 

--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/actions_status_test.go
+++ b/server/actions_status_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -252,7 +252,7 @@ func (s *RegistryServer) UpdateApiVersion(ctx context.Context, req *rpc.UpdateAp
 	}
 
 	if err := saveVersion(ctx, client, version); err != nil {
-		return nil, internalError(err)
+		return nil, err
 	}
 
 	message, err := version.Message(rpc.View_BASIC)

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -598,6 +598,14 @@ func TestListApiVersionsSequence(t *testing.T) {
 			t.Fatalf("ListApiVersions(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetApiVersions()); count != 1 {
+			t.Errorf("ListApiVersions(%+v) returned %d versions, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApiVersions(%+v) returned empty next_page_token, expected another page", req)
+		}
+
 		listed = append(listed, got.ApiVersions...)
 		nextToken = got.GetNextPageToken()
 	})
@@ -616,6 +624,14 @@ func TestListApiVersionsSequence(t *testing.T) {
 		got, err := server.ListApiVersions(ctx, req)
 		if err != nil {
 			t.Fatalf("ListApiVersions(%+v) returned error: %s", req, err)
+		}
+
+		if count := len(got.GetApiVersions()); count != 1 {
+			t.Errorf("ListApiVersions(%+v) returned %d versions, expected exactly one", req, count)
+		}
+
+		if got.GetNextPageToken() == "" {
+			t.Errorf("ListApiVersions(%+v) returned empty next_page_token, expected another page", req)
 		}
 
 		listed = append(listed, got.ApiVersions...)
@@ -638,6 +654,10 @@ func TestListApiVersionsSequence(t *testing.T) {
 			t.Fatalf("ListApiVersions(%+v) returned error: %s", req, err)
 		}
 
+		if count := len(got.GetApiVersions()); count != 1 {
+			t.Errorf("ListApiVersions(%+v) returned %d versions, expected exactly one", req, count)
+		}
+
 		if got.GetNextPageToken() != "" {
 			// TODO: This should be changed to a test error when possible. See: https://github.com/apigee/registry/issues/68
 			t.Logf("ListApiVersions(%+v) returned next_page_token, expected no next page", req)
@@ -645,6 +665,10 @@ func TestListApiVersionsSequence(t *testing.T) {
 
 		listed = append(listed, got.ApiVersions...)
 	})
+
+	if t.Failed() {
+		t.Fatal("Cannot test sequence result after failure on final page")
+	}
 
 	opts := cmp.Options{
 		protocmp.Transform(),

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/datastore/deletions.go
+++ b/server/datastore/deletions.go
@@ -63,8 +63,8 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 	entityNames := []string{
 		models.ArtifactEntityName,
 		models.BlobEntityName,
-		models.SpecEntityName,
-		models.SpecRevisionTagEntityName,
+		storage.SpecEntityName,
+		storage.SpecRevisionTagEntityName,
 		storage.VersionEntityName,
 		storage.ApiEntityName,
 	}
@@ -84,7 +84,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
-		models.SpecEntityName,
+		storage.SpecEntityName,
 		storage.VersionEntityName,
 	} {
 		q := datastore.NewQuery(entityName)
@@ -103,7 +103,7 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version names.Version) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
-		models.SpecEntityName,
+		storage.SpecEntityName,
 	} {
 		q := datastore.NewQuery(entityName)
 		q = q.KeysOnly()
@@ -119,7 +119,7 @@ func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version names.Vers
 }
 
 // DeleteChildrenOfSpec deletes all the children of a spec.
-func (c *Client) DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error {
+func (c *Client) DeleteChildrenOfSpec(ctx context.Context, spec names.Spec) error {
 	q := datastore.NewQuery(models.BlobEntityName)
 	q = q.KeysOnly()
 	q = q.Filter("ProjectID =", spec.ProjectID)

--- a/server/gorm/deletions.go
+++ b/server/gorm/deletions.go
@@ -52,8 +52,8 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 	entityNames := []string{
 		models.ArtifactEntityName,
 		models.BlobEntityName,
-		models.SpecEntityName,
-		models.SpecRevisionTagEntityName,
+		storage.SpecEntityName,
+		storage.SpecRevisionTagEntityName,
 		storage.VersionEntityName,
 		storage.ApiEntityName,
 	}
@@ -72,7 +72,7 @@ func (c *Client) DeleteChildrenOfProject(ctx context.Context, project names.Proj
 func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
-		models.SpecEntityName,
+		storage.SpecEntityName,
 		storage.VersionEntityName,
 	} {
 		q := c.NewQuery(entityName)
@@ -90,14 +90,13 @@ func (c *Client) DeleteChildrenOfApi(ctx context.Context, api names.Api) error {
 func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version names.Version) error {
 	for _, entityName := range []string{
 		models.BlobEntityName,
-		models.SpecEntityName,
+		storage.SpecEntityName,
 	} {
 		q := c.NewQuery(entityName)
 		q = q.Require("ProjectID", version.ProjectID)
 		q = q.Require("ApiID", version.ApiID)
 		q = q.Require("VersionID", version.VersionID)
-		err := c.DeleteAllMatches(ctx, q)
-		if err != nil {
+		if err := c.DeleteAllMatches(ctx, q); err != nil {
 			return err
 		}
 	}
@@ -105,7 +104,7 @@ func (c *Client) DeleteChildrenOfVersion(ctx context.Context, version names.Vers
 }
 
 // DeleteChildrenOfSpec deletes all the children of a spec.
-func (c *Client) DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error {
+func (c *Client) DeleteChildrenOfSpec(ctx context.Context, spec names.Spec) error {
 	q := c.NewQuery(models.BlobEntityName)
 	q = q.Require("ProjectID", spec.ProjectID)
 	q = q.Require("ApiID", spec.ApiID)

--- a/server/gorm/iterator.go
+++ b/server/gorm/iterator.go
@@ -32,7 +32,7 @@ type Iterator struct {
 }
 
 // GetCursor gets the cursor for the next page of results.
-func (it *Iterator) GetCursor(l int) (string, error) {
+func (it *Iterator) GetCursor(_ int) (string, error) {
 	encodedCursor := base64.StdEncoding.EncodeToString([]byte(it.Cursor))
 	return encodedCursor, nil
 }

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -17,7 +17,6 @@ package models
 import (
 	"crypto/sha256"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/apigee/registry/rpc"
@@ -26,12 +25,6 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
-
-// SpecEntityName is used to represent specs in storage.
-const SpecEntityName = "Spec"
-
-// SpecRevisionTagEntityName is used to represent tags in storage.
-const SpecRevisionTagEntityName = "SpecRevisionTag"
 
 // This was originally a boolean but gorm does not correctly update booleans from structs.
 // https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false
@@ -64,143 +57,165 @@ type Spec struct {
 	Annotations        []byte    `datastore:",noindex"` // Serialized annotations.
 }
 
-// NewSpecFromParentAndSpecID returns an initialized spec for a specified parent and ID.
-func NewSpecFromParentAndSpecID(parent string, id string) (*Spec, error) {
-	version, err := names.ParseVersion(parent)
+// NewSpec initializes a new resource.
+func NewSpec(name names.Spec, body *rpc.ApiSpec) (spec *Spec, err error) {
+	now := time.Now()
+	spec = &Spec{
+		ProjectID:          name.ProjectID,
+		ApiID:              name.ApiID,
+		VersionID:          name.VersionID,
+		SpecID:             name.SpecID,
+		Description:        body.GetDescription(),
+		FileName:           body.GetFilename(),
+		MimeType:           body.GetMimeType(),
+		SourceURI:          body.GetSourceUri(),
+		CreateTime:         now,
+		RevisionCreateTime: now,
+		RevisionUpdateTime: now,
+		Currency:           IsCurrent,
+		RevisionID:         newRevisionID(),
+	}
+
+	spec.Labels, err = bytesForMap(body.GetLabels())
 	if err != nil {
-		return nil, err
-	} else if err := names.ValidateID(id); err != nil {
 		return nil, err
 	}
 
+	spec.Annotations, err = bytesForMap(body.GetAnnotations())
+	if err != nil {
+		return nil, err
+	}
+
+	if body.GetContents() != nil {
+		spec.SizeInBytes = int32(len(body.GetContents()))
+		spec.Hash = hashForBytes(body.GetContents())
+	}
+
+	return spec, nil
+}
+
+// NewRevision returns a new revision based on the spec.
+func (s *Spec) NewRevision() *Spec {
+	now := time.Now()
 	return &Spec{
-		ProjectID: version.ProjectID,
-		ApiID:     version.ApiID,
-		VersionID: version.VersionID,
-		SpecID:    id,
-	}, nil
+		ProjectID:          s.ProjectID,
+		ApiID:              s.ApiID,
+		VersionID:          s.VersionID,
+		SpecID:             s.SpecID,
+		Description:        s.Description,
+		FileName:           s.FileName,
+		MimeType:           s.MimeType,
+		SizeInBytes:        s.SizeInBytes,
+		Hash:               s.Hash,
+		SourceURI:          s.SourceURI,
+		CreateTime:         s.CreateTime,
+		RevisionCreateTime: now,
+		RevisionUpdateTime: now,
+		Currency:           IsCurrent,
+		RevisionID:         newRevisionID(),
+	}
 }
 
-// NewSpecFromResourceName parses resource names and returns an initialized spec.
-func NewSpecFromResourceName(name string) (*Spec, error) {
-	m, err := names.ParseSpec(name)
+// Name returns the resource name of the spec.
+func (s *Spec) Name() string {
+	return names.Spec{
+		ProjectID: s.ProjectID,
+		ApiID:     s.ApiID,
+		VersionID: s.VersionID,
+		SpecID:    s.SpecID,
+	}.String()
+}
+
+// RevisionName generates the resource name of the spec revision.
+func (s *Spec) RevisionName() string {
+	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s", s.ProjectID, s.ApiID, s.VersionID, s.SpecID, s.RevisionID)
+}
+
+// FullMessage returns the full view of the spec resource as an RPC message.
+func (s *Spec) FullMessage(blob *Blob, name string) (message *rpc.ApiSpec, err error) {
+	message, err = s.BasicMessage(name)
 	if err != nil {
 		return nil, err
 	}
 
-	spec := &Spec{
-		ProjectID: m[1],
-		ApiID:     m[2],
-		VersionID: m[3],
-		SpecID:    m[4],
-	}
-
-	if strings.HasPrefix(m[5], "@") {
-		spec.RevisionID = strings.TrimPrefix(m[5], "@")
-	}
-
-	return spec, nil
-}
-
-// NewSpecFromMessage returns an initialized spec from a message.
-func NewSpecFromMessage(message *rpc.ApiSpec) (*Spec, error) {
-	spec, err := NewSpecFromResourceName(message.GetName())
+	message.Annotations, err = mapForBytes(s.Annotations)
 	if err != nil {
 		return nil, err
 	}
-	spec.Description = message.GetDescription()
-	spec.FileName = message.GetFilename()
-	return spec, nil
+
+	message.Contents = blob.Contents
+	return message, err
 }
 
-// ResourceName generates the resource name of a spec.
-func (spec *Spec) ResourceName() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s",
-		spec.ProjectID, spec.ApiID, spec.VersionID, spec.SpecID)
-}
-
-// ResourceNameWithRevision generates the resource name of a spec which includes the revision id.
-func (spec *Spec) ResourceNameWithRevision() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s",
-		spec.ProjectID, spec.ApiID, spec.VersionID, spec.SpecID, spec.RevisionID)
-}
-
-// ResourceNameWithSpecifiedRevision generates the resource name of a spec which includes the revision id.
-func (spec *Spec) ResourceNameWithSpecifiedRevision(revision string) string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s",
-		spec.ProjectID, spec.ApiID, spec.VersionID, spec.SpecID, revision)
-}
-
-// ParentResourceName generates the resource name of a spec's parent.
-func (spec *Spec) ParentResourceName() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s", spec.ProjectID, spec.ApiID, spec.VersionID)
-}
-
-// Message returns a message representing a spec.
-func (spec *Spec) Message(view rpc.View, blob *Blob, revision string) (message *rpc.ApiSpec, err error) {
-	message = &rpc.ApiSpec{}
-	if revision != "" {
-		message.Name = spec.ResourceNameWithSpecifiedRevision(revision)
-	} else {
-		message.Name = spec.ResourceName()
+// BasicMessage returns the basic view of the spec resource as an RPC message.
+func (s *Spec) BasicMessage(name string) (message *rpc.ApiSpec, err error) {
+	message = &rpc.ApiSpec{
+		Name:        name,
+		Filename:    s.FileName,
+		Description: s.Description,
+		Hash:        s.Hash,
+		SizeBytes:   s.SizeInBytes,
+		MimeType:    s.MimeType,
+		SourceUri:   s.SourceURI,
+		RevisionId:  s.RevisionID,
 	}
-	message.Filename = spec.FileName
-	message.Description = spec.Description
-	if blob != nil {
-		message.Contents = blob.Contents
-	}
-	message.Hash = spec.Hash
-	message.SizeBytes = spec.SizeInBytes
-	message.MimeType = spec.MimeType
-	message.SourceUri = spec.SourceURI
-	message.CreateTime, err = ptypes.TimestampProto(spec.CreateTime)
-	message.RevisionCreateTime, err = ptypes.TimestampProto(spec.RevisionCreateTime)
-	message.RevisionUpdateTime, err = ptypes.TimestampProto(spec.RevisionUpdateTime)
-	message.RevisionId = spec.RevisionID
-	if message.Labels, err = mapForBytes(spec.Labels); err != nil {
+
+	message.CreateTime, err = ptypes.TimestampProto(s.CreateTime)
+	if err != nil {
 		return nil, err
 	}
-	if view == rpc.View_FULL {
-		if message.Annotations, err = mapForBytes(spec.Annotations); err != nil {
-			return nil, err
-		}
+
+	message.RevisionCreateTime, err = ptypes.TimestampProto(s.RevisionCreateTime)
+	if err != nil {
+		return nil, err
 	}
+
+	message.RevisionUpdateTime, err = ptypes.TimestampProto(s.RevisionUpdateTime)
+	if err != nil {
+		return nil, err
+	}
+
+	message.Labels, err = mapForBytes(s.Labels)
+	if err != nil {
+		return nil, err
+	}
+
 	return message, err
 }
 
 // Update modifies a spec using the contents of a message.
-func (spec *Spec) Update(message *rpc.ApiSpec, mask *fieldmaskpb.FieldMask) error {
+func (s *Spec) Update(message *rpc.ApiSpec, mask *fieldmaskpb.FieldMask) error {
 	now := time.Now()
 	if activeUpdateMask(mask) {
 		for _, field := range mask.Paths {
 			switch field {
 			case "filename":
-				spec.FileName = message.GetFilename()
+				s.FileName = message.GetFilename()
 			case "description":
-				spec.Description = message.GetDescription()
+				s.Description = message.GetDescription()
 			case "contents":
 				contents := message.GetContents()
 				// Save some properties of the spec contents.
 				// The bytes of the contents are stored in a Blob.
 				hash := hashForBytes(contents)
-				if spec.Hash != hash {
-					spec.Hash = hash
-					spec.RevisionID = newRevisionID()
-					spec.CreateTime = now
+				if s.Hash != hash {
+					s.Hash = hash
+					s.RevisionID = newRevisionID()
+					s.CreateTime = now
 				}
-				spec.SizeInBytes = int32(len(contents))
+				s.SizeInBytes = int32(len(contents))
 			case "mime_type":
-				spec.MimeType = message.GetMimeType()
+				s.MimeType = message.GetMimeType()
 			case "source_uri":
-				spec.SourceURI = message.GetSourceUri()
+				s.SourceURI = message.GetSourceUri()
 			case "labels":
 				var err error
-				if spec.Labels, err = bytesForMap(message.GetLabels()); err != nil {
+				if s.Labels, err = bytesForMap(message.GetLabels()); err != nil {
 					return err
 				}
 			case "annotations":
 				var err error
-				if spec.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
+				if s.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
 					return err
 				}
 			}
@@ -208,50 +223,48 @@ func (spec *Spec) Update(message *rpc.ApiSpec, mask *fieldmaskpb.FieldMask) erro
 	} else {
 		filename := message.GetFilename()
 		if filename != "" {
-			spec.FileName = filename
+			s.FileName = filename
 		}
 		description := message.GetDescription()
 		if description != "" {
-			spec.Description = description
+			s.Description = description
 		}
 		contents := message.GetContents()
 		if contents != nil {
 			// Save some properties of the spec contents.
 			// The bytes of the contents are stored in a Blob.
 			hash := hashForBytes(contents)
-			if spec.Hash != hash {
-				spec.Hash = hash
-				spec.RevisionID = newRevisionID()
-				spec.CreateTime = now
+			if s.Hash != hash {
+				s.Hash = hash
+				s.RevisionID = newRevisionID()
+				s.RevisionCreateTime = now
 			}
-			spec.SizeInBytes = int32(len(contents))
+			s.SizeInBytes = int32(len(contents))
 		}
 		mimeType := message.GetMimeType()
 		if mimeType != "" {
-			spec.MimeType = mimeType
+			s.MimeType = mimeType
 		}
 		sourceURI := message.GetSourceUri()
 		if sourceURI != "" {
-			spec.SourceURI = sourceURI
+			s.SourceURI = sourceURI
 		}
 		var err error
-		if spec.Labels, err = bytesForMap(message.GetLabels()); err != nil {
+		if s.Labels, err = bytesForMap(message.GetLabels()); err != nil {
 			return err
 		}
-		if spec.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
+		if s.Annotations, err = bytesForMap(message.GetAnnotations()); err != nil {
 			return err
 		}
 	}
-	spec.RevisionUpdateTime = now
+	s.Currency = IsCurrent
+	s.RevisionUpdateTime = now
 	return nil
 }
 
-// BumpRevision updates the revision id for a spec and makes no other changes.
-func (spec *Spec) BumpRevision() error {
-	spec.RevisionID = newRevisionID()
-	spec.RevisionCreateTime = time.Now()
-	spec.RevisionUpdateTime = time.Now()
-	return nil
+// LabelsMap returns a map representation of stored labels.
+func (s *Spec) LabelsMap() (map[string]string, error) {
+	return mapForBytes(s.Labels)
 }
 
 func newRevisionID() string {
@@ -279,19 +292,21 @@ type SpecRevisionTag struct {
 	UpdateTime time.Time // Time of last change.
 }
 
-// ResourceNameWithTag generates a resource name which includes the tag.
-func (tag *SpecRevisionTag) ResourceNameWithTag() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s",
-		tag.ProjectID, tag.ApiID, tag.VersionID, tag.SpecID, tag.Tag)
+// NewSpecRevisionTag initializes a new revision tag from a given revision name and tag string.
+func NewSpecRevisionTag(name names.SpecRevision, tag string) *SpecRevisionTag {
+	now := time.Now()
+	return &SpecRevisionTag{
+		ProjectID:  name.ProjectID,
+		ApiID:      name.ApiID,
+		VersionID:  name.VersionID,
+		SpecID:     name.SpecID,
+		RevisionID: name.RevisionID,
+		Tag:        tag,
+		CreateTime: now,
+		UpdateTime: now,
+	}
 }
 
-// ResourceNameWithRevision generates a resource name which includes the revision id.
-func (tag *SpecRevisionTag) ResourceNameWithRevision() string {
-	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s",
-		tag.ProjectID, tag.ApiID, tag.VersionID, tag.SpecID, tag.RevisionID)
-}
-
-// LabelsMap returns a map representation of stored labels.
-func (spec *Spec) LabelsMap() (map[string]string, error) {
-	return mapForBytes(spec.Labels)
+func (t *SpecRevisionTag) String() string {
+	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s", t.ProjectID, t.ApiID, t.VersionID, t.SpecID, t.Tag)
 }

--- a/server/names/common.go
+++ b/server/names/common.go
@@ -27,7 +27,7 @@ import (
 const identifier = "([a-zA-Z0-9-_\\.]+)"
 
 // The format of a custom revision tag.
-const revisionTag = "(@[a-zA-z0-9-]+)?"
+const revisionTag = "([a-zA-z0-9-]+)"
 
 // GenerateID generates a random resource ID.
 func GenerateID() string {

--- a/server/names/spec_revision.go
+++ b/server/names/spec_revision.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var specRevisionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/apis/%s/versions/%s/specs/%s@%s$", identifier, identifier, identifier, identifier, revisionTag))
+
+// SpecRevision represents a resource name for an API spec revision.
+type SpecRevision struct {
+	ProjectID  string
+	ApiID      string
+	VersionID  string
+	SpecID     string
+	RevisionID string
+}
+
+// Spec returns the parent spec for this resource.
+func (s SpecRevision) Spec() Spec {
+	return Spec{
+		ProjectID: s.ProjectID,
+		ApiID:     s.ApiID,
+		VersionID: s.VersionID,
+		SpecID:    s.SpecID,
+	}
+}
+
+func (s SpecRevision) String() string {
+	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s", s.ProjectID, s.ApiID, s.VersionID, s.SpecID, s.RevisionID)
+}
+
+// ParseSpecRevision parses the name of a spec.
+func ParseSpecRevision(name string) (SpecRevision, error) {
+	if !specRevisionRegexp.MatchString(name) {
+		return SpecRevision{}, fmt.Errorf("invalid spec revision name %q: must match %q", name, specRevisionRegexp)
+	}
+
+	m := specRevisionRegexp.FindStringSubmatch(name)
+	revision := SpecRevision{
+		ProjectID:  m[1],
+		ApiID:      m[2],
+		VersionID:  m[3],
+		SpecID:     m[4],
+		RevisionID: m[5],
+	}
+
+	return revision, nil
+}

--- a/server/names/version.go
+++ b/server/names/version.go
@@ -50,6 +50,16 @@ func (v Version) Api() Api {
 	}
 }
 
+// Spec returns an API spec with the provided ID and this resource as its parent.
+func (v Version) Spec(id string) Spec {
+	return Spec{
+		ProjectID: v.ProjectID,
+		ApiID:     v.ApiID,
+		VersionID: v.VersionID,
+		SpecID:    id,
+	}
+}
+
 func (v Version) String() string {
 	return fmt.Sprintf("projects/%s/apis/%s/versions/%s", v.ProjectID, v.ApiID, v.VersionID)
 }

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -19,7 +19,6 @@ package storage
 import (
 	"context"
 
-	"github.com/apigee/registry/server/models"
 	"github.com/apigee/registry/server/names"
 )
 
@@ -30,6 +29,10 @@ const (
 	ApiEntityName = "Api"
 	// VersionEntityName is the storage entity name for API version resources.
 	VersionEntityName = "Version"
+	// SpecEntityName is the storage entity name for API spec resources.
+	SpecEntityName = "Spec"
+	// SpecRevisionTagEntityName is the storage entity name for API spec revision tag resources.
+	SpecRevisionTagEntityName = "SpecRevisionTag"
 )
 
 type Client interface {
@@ -46,11 +49,11 @@ type Client interface {
 	NewKey(kind, name string) Key
 	NewQuery(query string) Query
 
-	DeleteAllMatches(ctx context.Context, q Query) error
 	DeleteChildrenOfProject(ctx context.Context, project names.Project) error
 	DeleteChildrenOfApi(ctx context.Context, api names.Api) error
 	DeleteChildrenOfVersion(ctx context.Context, version names.Version) error
-	DeleteChildrenOfSpec(ctx context.Context, spec *models.Spec) error
+	DeleteAllMatches(ctx context.Context, q Query) error
+	DeleteChildrenOfSpec(ctx context.Context, spec names.Spec) error
 }
 
 type Key interface {

--- a/tests/filters_test.go
+++ b/tests/filters_test.go
@@ -201,7 +201,7 @@ func TestFilters(t *testing.T) {
 	for i := 0; i < len(testLabels); i++ {
 		req := &rpc.CreateApiSpecRequest{
 			Parent:    specParent,
-			ApiSpecId: fmt.Sprintf("%d", i),
+			ApiSpecId: fmt.Sprintf("000%d", i),
 			ApiSpec: &rpc.ApiSpec{
 				Labels: testLabels[i],
 			},


### PR DESCRIPTION
* Add tests for method behaviors
* Move revision methods into separate file
* Order revisions by revision creation time
* Check for non-existent parent resources in List/Create methods
* Check basic/full API responses in Create/Get/Update methods
* Reject negative page sizes in List requests
* Return the correct page size and token on revision listing with sqlite
* Refactor existing methods to use common helper methods