### PR TITLE
Update datastore indexes for use of RevisionCreateTime in spec queries.

### DIFF
--- a/server/datastore/index.yaml
+++ b/server/datastore/index.yaml
@@ -28,6 +28,5 @@ indexes:
   - name: ProjectID
   - name: SpecID
   - name: VersionID
-  - name: Currency
-  - name: CreateTime
+  - name: RevisionCreateTime
     direction: desc

--- a/server/datastore/index.yaml
+++ b/server/datastore/index.yaml
@@ -28,8 +28,8 @@ indexes:
   - name: ProjectID
   - name: SpecID
   - name: VersionID
-  - name: CreateTime
   - name: Currency
+  - name: CreateTime
     direction: desc
 
 - kind: Spec

--- a/server/datastore/index.yaml
+++ b/server/datastore/index.yaml
@@ -28,5 +28,15 @@ indexes:
   - name: ProjectID
   - name: SpecID
   - name: VersionID
+  - name: CreateTime
+  - name: Currency
+    direction: desc
+
+- kind: Spec
+  properties:
+  - name: ApiID
+  - name: ProjectID
+  - name: SpecID
+  - name: VersionID
   - name: RevisionCreateTime
     direction: desc


### PR DESCRIPTION
This fixes datastore test failures introduced in recent changes.