### PR TITLE
temporary workaround to fix listing artifacts with the datastore backend

### DIFF
--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -211,6 +211,9 @@ func (s *RegistryServer) ListArtifacts(ctx context.Context, req *rpc.ListArtifac
 		Artifacts: artifactMessages,
 	}
 	responses.NextPageToken, err = it.GetCursor()
+	if responses.NextPageToken == req.PageToken {
+		responses.NextPageToken = ""
+	}
 	if err != nil {
 		return nil, internalError(err)
 	}


### PR DESCRIPTION
With a recent change, calls to ListArtifacts stopped returning empty tokens when the end of a collection was reached. That will be addressd in an upcoming revision, but this temporarily fixes the problem by using the fact that the next page tokens provided by the storage backend don't change when the end of the collection has been reached. When the token that we're returning is the same as the token we received, we replace the token with an empty string.