### PR TITLE
Get artifact contents

### DIFF
--- a/google/cloud/apigee/registry/v1/registry_service.proto
+++ b/google/cloud/apigee/registry/v1/registry_service.proto
@@ -204,7 +204,7 @@ service Registry {
   }
 
   // GetApiSpecContents returns the contents of a specified spec.
-  // (-- api-linter: core::0131::response-method-name=disabled
+  // (-- api-linter: core::0131::response-message-name=disabled
   //     aip.dev/not-precedent: Responses are arbitrary blobs of data. --)
   rpc GetApiSpecContents(GetApiSpecContentsRequest) returns (google.api.HttpBody) {
     option (google.api.http) = {
@@ -300,6 +300,25 @@ service Registry {
       }
       additional_bindings: {
         get: "/v1/{name=projects/*/apis/*/versions/*/specs/*/artifacts/*}"
+      }
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // GetArtifactContents returns the contents of a specified artifact.
+  // (-- api-linter: core::0131::response-message-name=disabled
+  //     aip.dev/not-precedent: Responses are arbitrary blobs of data. --)
+  rpc GetArtifactContents(GetArtifactContentsRequest) returns (google.api.HttpBody) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/artifacts/*/contents}"
+      additional_bindings: { 
+        get: "/v1/{name=projects/*/apis/*/artifacts/*/contents}" 
+      }
+      additional_bindings: {
+        get: "/v1/{name=projects/*/apis/*/versions/*/artifacts/*/contents}"
+      }
+      additional_bindings: {
+        get: "/v1/{name=projects/*/apis/*/versions/*/specs/*/artifacts/*/contents}"
       }
     };
     option (google.api.method_signature) = "name";
@@ -917,6 +936,18 @@ message GetArtifactRequest {
 
   // The level of detail to return (defaults to BASIC).
   View view = 2;
+}
+
+// Request message for GetArtifactContents.
+message GetArtifactContentsRequest {
+  // The name of the artifact to retrieve.
+  // Format: {parent}/artifacts/*/contents
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "registry.googleapis.com/Artifact"
+    }
+  ];
 }
 
 // Request message for CreateArtifact.

--- a/tests/crud/crud_test.go
+++ b/tests/crud/crud_test.go
@@ -206,12 +206,14 @@ func TestCRUD(t *testing.T) {
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
-		if response.GetContentType() != expectedContentType {
-			t.Errorf("Unexpected content type %q", response.GetContentType())
-		}
-		contentHash := hashForBytes(response.Data)
-		if contentHash != expectedHash {
-			t.Errorf("Contents failed to match %s != %s", contentHash, expectedHash)
+		if err == nil {
+			if response.GetContentType() != expectedContentType {
+				t.Errorf("Unexpected content type %q", response.GetContentType())
+			}
+			contentHash := hashForBytes(response.Data)
+			if contentHash != expectedHash {
+				t.Errorf("Contents failed to match %s != %s", contentHash, expectedHash)
+			}
 		}
 	}
 	// Check the contents of the created revision.
@@ -221,12 +223,14 @@ func TestCRUD(t *testing.T) {
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
-		if response.GetContentType() != expectedContentType {
-			t.Errorf("Unexpected content type %q", response.GetContentType())
-		}
-		contentHash := hashForBytes(response.Data)
-		if contentHash != expectedHash {
-			t.Errorf("Contents failed to match %s != %s", contentHash, expectedHash)
+		if err == nil {
+			if response.GetContentType() != expectedContentType {
+				t.Errorf("Unexpected content type %q", response.GetContentType())
+			}
+			contentHash := hashForBytes(response.Data)
+			if contentHash != expectedHash {
+				t.Errorf("Contents failed to match %s != %s", contentHash, expectedHash)
+			}
 		}
 	}
 	// Tag the revision.
@@ -234,7 +238,7 @@ func TestCRUD(t *testing.T) {
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
 			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision,
-			Tag: revisionTag,
+			Tag:  revisionTag,
 		}
 		_, err := registryClient.TagApiSpecRevision(ctx, req)
 		check(t, "error tagging spec %s", err)
@@ -246,12 +250,14 @@ func TestCRUD(t *testing.T) {
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
-		if response.GetContentType() != expectedContentType {
-			t.Errorf("Unexpected content type %q", response.GetContentType())
-		}
-		contentHash := hashForBytes(response.Data)
-		if contentHash != expectedHash {
-			t.Errorf("Contents failed to match %s != %s", contentHash, expectedHash)
+		if err == nil {
+			if response.GetContentType() != expectedContentType {
+				t.Errorf("Unexpected content type %q", response.GetContentType())
+			}
+			contentHash := hashForBytes(response.Data)
+			if contentHash != expectedHash {
+				t.Errorf("Contents failed to match %s != %s", contentHash, expectedHash)
+			}
 		}
 	}
 	testArtifacts(ctx, registryClient, t, "projects/test")
@@ -309,6 +315,22 @@ func testArtifacts(ctx context.Context, registryClient connection.Client, t *tes
 		}
 		if resp.GetHash() != messageHash {
 			t.Errorf("Unexpected hash value %s (expected %s)", resp.GetHash(), messageHash)
+		}
+	}
+	// Check the artifact contents.
+	{
+		req := &rpc.GetArtifactContentsRequest{
+			Name: fmt.Sprintf("%s/artifacts/sample/contents", parent),
+		}
+		resp, err := registryClient.GetArtifactContents(ctx, req)
+		check(t, "error getting artifact contents %s", err)
+		if err == nil {
+			if resp.GetContentType() != messageMimeType {
+				t.Errorf("Unexpected mime type %s (expected %s)", resp.GetContentType(), messageMimeType)
+			}
+			if bytes.Compare(resp.GetData(), messageContents) != 0 {
+				t.Errorf("Unexpected data %s (expected %s)", string(resp.GetData()), string(messageContents))
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is the second set of changes related to #133 - these add a `/contents` accessor for Artifacts.