### PR TITLE
 Update registry tool and graphql demo to use "/contents" accessors.

### DIFF
--- a/cmd/registry/cmd/bleve.go
+++ b/cmd/registry/cmd/bleve.go
@@ -94,14 +94,13 @@ func (task *indexSpecTask) Name() string {
 func (task *indexSpecTask) Run() error {
 	request := &rpc.GetApiSpecRequest{
 		Name: task.specName,
-		View: rpc.View_FULL,
 	}
 	spec, err := task.client.GetApiSpec(task.ctx, request)
 	if err != nil {
 		return err
 	}
 	name := spec.GetName()
-	data, err := core.GetBytesForSpec(spec)
+	data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
 	if err != nil {
 		return nil
 	}

--- a/cmd/registry/cmd/compute-descriptor.go
+++ b/cmd/registry/cmd/compute-descriptor.go
@@ -83,7 +83,6 @@ func (task *computeDescriptorTask) Name() string {
 func (task *computeDescriptorTask) Run() error {
 	request := &rpc.GetApiSpecRequest{
 		Name: task.specName,
-		View: rpc.View_FULL,
 	}
 	spec, err := task.client.GetApiSpec(task.ctx, request)
 	if err != nil {
@@ -92,7 +91,7 @@ func (task *computeDescriptorTask) Run() error {
 	name := spec.GetName()
 	relation := "descriptor"
 	log.Printf("computing %s/artifacts/%s", name, relation)
-	data, err := core.GetBytesForSpec(spec)
+	data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
 	if err != nil {
 		return nil
 	}

--- a/cmd/registry/cmd/compute-details.go
+++ b/cmd/registry/cmd/compute-details.go
@@ -104,7 +104,7 @@ func (task *computeDetailsTask) Run() error {
 	var description string
 	var request *rpc.UpdateApiRequest
 	if core.IsOpenAPIv2(spec.GetMimeType()) {
-		data, err := core.GetBytesForSpec(spec)
+		data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
 		if err != nil {
 			return nil
 		}
@@ -130,7 +130,7 @@ func (task *computeDetailsTask) Run() error {
 			},
 		}
 	} else if core.IsOpenAPIv3(spec.GetMimeType()) {
-		data, err := core.GetBytesForSpec(spec)
+		data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
 		if err != nil {
 			return nil
 		}
@@ -156,7 +156,7 @@ func (task *computeDetailsTask) Run() error {
 			},
 		}
 	} else if core.IsDiscovery(spec.GetMimeType()) {
-		data, err := core.GetBytesForSpec(spec)
+		data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
 		if err != nil {
 			return nil
 		}

--- a/cmd/registry/cmd/compute-index.go
+++ b/cmd/registry/cmd/compute-index.go
@@ -81,17 +81,20 @@ func (task *computeIndexTask) Name() string {
 func (task *computeIndexTask) Run() error {
 	request := &rpc.GetApiSpecRequest{
 		Name: task.specName,
-		View: rpc.View_FULL,
 	}
 	spec, err := task.client.GetApiSpec(task.ctx, request)
 	if err != nil {
 		return err
 	}
+	data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
+	if err != nil {
+		return nil
+	}
 	relation := "index"
 	log.Printf("computing %s/artifacts/%s", spec.Name, relation)
 	var index *rpc.Index
 	if core.IsProto(spec.GetMimeType()) && core.IsZipArchive(spec.GetMimeType()) {
-		index, err = core.NewIndexFromZippedProtos(spec.GetContents())
+		index, err = core.NewIndexFromZippedProtos(data)
 		if err != nil {
 			return fmt.Errorf("error processing protos: %s", spec.Name)
 		}

--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -92,11 +92,14 @@ func lintRelation(linter string) string {
 func (task *computeLintTask) Run() error {
 	request := &rpc.GetApiSpecRequest{
 		Name: task.specName,
-		View: rpc.View_FULL,
 	}
 	spec, err := task.client.GetApiSpec(task.ctx, request)
 	if err != nil {
 		return err
+	}	
+	data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
+	if err != nil {
+		return nil
 	}
 	var relation string
 	var lint *rpc.Lint
@@ -107,7 +110,7 @@ func (task *computeLintTask) Run() error {
 		}
 		relation = lintRelation(task.linter)
 		log.Printf("computing %s/artifacts/%s", spec.Name, relation)
-		lint, err = core.NewLintFromOpenAPI(spec.Name, spec.GetContents(), task.linter)
+		lint, err = core.NewLintFromOpenAPI(spec.Name, data, task.linter)
 		if err != nil {
 			return fmt.Errorf("error processing OpenAPI: %s (%s)", spec.Name, err.Error())
 		}
@@ -120,7 +123,7 @@ func (task *computeLintTask) Run() error {
 		}
 		relation = lintRelation(task.linter)
 		log.Printf("computing %s/artifacts/%s", spec.Name, relation)
-		lint, err = core.NewLintFromZippedProtos(spec.Name, spec.GetContents())
+		lint, err = core.NewLintFromZippedProtos(spec.Name, data)
 		if err != nil {
 			return fmt.Errorf("error processing protos: %s (%s)", spec.Name, err.Error())
 		}

--- a/cmd/registry/cmd/compute-lintstats.go
+++ b/cmd/registry/cmd/compute-lintstats.go
@@ -60,20 +60,19 @@ var computeLintStatsCmd = &cobra.Command{
 			err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
 				fmt.Printf("%s\n", spec.Name)
 				// get the lint results
-				request := rpc.GetArtifactRequest{
-					Name: spec.Name + "/artifacts/" + lintRelation(linter),
-					View: rpc.View_FULL,
+				request := rpc.GetArtifactContentsRequest{
+					Name: spec.Name + "/artifacts/" + lintRelation(linter) + "/contents",
 				}
-				artifact, err := client.GetArtifact(ctx, &request)
-				if artifact == nil {
+				contents, err := client.GetArtifactContents(ctx, &request)
+				if contents == nil {
 					return // ignore missing results
 				}
-				messageType, err := core.MessageTypeForMimeType(artifact.GetMimeType())
+				messageType, err := core.MessageTypeForMimeType(contents.GetContentType())
 				if err != nil || messageType != "google.cloud.apigee.registry.applications.v1alpha1.Lint" {
 					return // ignore unexpected message types
 				}
 				lint := &rpc.Lint{}
-				err = proto.Unmarshal(artifact.GetContents(), lint)
+				err = proto.Unmarshal(contents.GetData(), lint)
 				if err != nil {
 					log.Printf("%+v", err)
 					return

--- a/cmd/registry/cmd/compute-references.go
+++ b/cmd/registry/cmd/compute-references.go
@@ -81,7 +81,6 @@ func (task *computeReferencesTask) Name() string {
 func (task *computeReferencesTask) Run() error {
 	request := &rpc.GetApiSpecRequest{
 		Name: task.specName,
-		View: rpc.View_FULL,
 	}
 	spec, err := task.client.GetApiSpec(task.ctx, request)
 	if err != nil {
@@ -91,7 +90,11 @@ func (task *computeReferencesTask) Run() error {
 	log.Printf("computing %s/properties/%s", spec.Name, relation)
 	var references *rpc.References
 	if core.IsProto(spec.MimeType) && core.IsZipArchive(spec.MimeType) {
-		references, err = core.NewReferencesFromZippedProtos(spec.Contents)
+		data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
+		if err != nil {
+			return nil
+		}
+		references, err = core.NewReferencesFromZippedProtos(data)
 		if err != nil {
 			return fmt.Errorf("error processing protos: %s", spec.Name)
 		}

--- a/cmd/registry/cmd/upload-bulk-discovery.go
+++ b/cmd/registry/cmd/upload-bulk-discovery.go
@@ -194,15 +194,14 @@ func (task *uploadDiscoveryTask) createSpec() error {
 func (task *uploadDiscoveryTask) updateSpec() error {
 	refSpec, err := task.client.GetApiSpec(task.ctx, &rpcpb.GetApiSpecRequest{
 		Name: task.specName(),
-		View: rpc.View_FULL,
 	})
 	if err != nil && !core.NotFound(err) {
 		return err
 	}
 
-	refBytes, err := core.GUnzippedBytes(refSpec.Contents)
+	refBytes, err := core.GetBytesForSpec(task.ctx, task.client, refSpec)
 	if err != nil {
-		return err
+		return nil
 	}
 
 	docBytes, err := discovery.FetchDocumentBytes(task.path)

--- a/cmd/registry/core/list.go
+++ b/cmd/registry/core/list.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/rpc"
@@ -174,10 +175,6 @@ func ListArtifacts(ctx context.Context,
 	}
 	request := &rpc.ListArtifactsRequest{
 		Parent: parent,
-		View:   rpc.View_BASIC,
-	}
-	if getContents {
-		request.View = rpc.View_FULL
 	}
 	filter := filterFlag
 	if len(segments) == 9 && segments[8] != "-" {
@@ -196,6 +193,16 @@ func ListArtifacts(ctx context.Context,
 			break
 		} else if err != nil {
 			return err
+		}
+		if getContents {
+			req := &rpc.GetArtifactContentsRequest{
+				Name: fmt.Sprintf("%s/contents", artifact.GetName()),
+			}
+			resp, err := client.GetArtifactContents(ctx, req)
+			if err != nil {
+				return err
+			}
+			artifact.Contents = resp.GetData()
 		}
 		handler(artifact)
 	}
@@ -218,7 +225,6 @@ func ListArtifactsForParent(ctx context.Context,
 	}
 	request := &rpc.ListArtifactsRequest{
 		Parent: parent,
-		View:   rpc.View_BASIC,
 	}
 	it := client.ListArtifacts(ctx, request)
 	for {

--- a/cmd/registry/core/specs.go
+++ b/cmd/registry/core/specs.go
@@ -18,8 +18,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
 	"log"
-	"strings"
 
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
@@ -37,12 +37,13 @@ func ResourceNameOfSpec(segments []string) string {
 	return ""
 }
 
-func GetBytesForSpec(spec *rpc.ApiSpec) ([]byte, error) {
-	if strings.Contains(spec.GetMimeType(), "+gzip") {
-		return GUnzippedBytes(spec.GetContents())
-	} else {
-		return spec.GetContents(), nil
+func GetBytesForSpec(ctx context.Context, client connection.Client, spec *rpc.ApiSpec) ([]byte, error) {
+	request := &rpc.GetApiSpecContentsRequest{Name:fmt.Sprintf("%s/contents", spec.GetName())}
+	contents, err := client.GetApiSpecContents(ctx, request)
+	if err != nil {
+		return nil, err
 	}
+	return contents.Data, nil
 }
 
 func UploadBytesForSpec(ctx context.Context, client connection.Client, parent string, specID string, style string, document proto.Message) error {

--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -1,1 +1,1 @@
-config/sqlite.yaml
+sqlite.yaml

--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -1,1 +1,1 @@
-sqlite.yaml
+config/sqlite.yaml

--- a/go.mod
+++ b/go.mod
@@ -17,30 +17,40 @@ require (
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/gogo/googleapis v1.4.0
 	github.com/gogo/protobuf v1.3.1
+	github.com/golang-commonmark/html v0.0.0-20180910111043-7d7c804e1d46 // indirect
+	github.com/golang-commonmark/linkify v0.0.0-20180910111149-f05efb453a0e // indirect
+	github.com/golang-commonmark/markdown v0.0.0-20180910011815-a8f139058164 // indirect
+	github.com/golang-commonmark/mdurl v0.0.0-20180910110917-8d018c6567d6 // indirect
+	github.com/golang-commonmark/puny v0.0.0-20180910110745-050be392d8b8 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.2
+	github.com/googleapis/api-linter v1.23.0 // indirect
+	github.com/googleapis/gapic-generator-go v0.19.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/googleapis/gnostic v0.5.4
 	github.com/graphql-go/graphql v0.7.9
 	github.com/graphql-go/handler v0.2.3
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/mattn/go-runewidth v0.0.12 // indirect
 	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
 	github.com/yoheimuta/go-protoparser/v4 v4.2.1
-	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1
+	gitlab.com/golang-commonmark/linkify v0.0.0-20200225224916-64bca66f6ad3 // indirect
+	golang.org/x/net v0.0.0-20210505214959-0714010a04ed
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
-	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
+	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 // indirect
 	google.golang.org/api v0.36.0
-	google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46
+	google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2
 	google.golang.org/grpc v1.37.0
 	google.golang.org/grpc/examples v0.0.0-20210424002626-9572fd6faeae // indirect
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ github.com/googleapis/api-linter v1.16.0 h1:WAKxWrOsTVmm5thUlhrFI3yVh8QDvwHd3XXd
 github.com/googleapis/api-linter v1.16.0/go.mod h1:UKvDCDRemG5E4ELnJ+qdFXN2zmRtQWiFLD7UpYFe59Q=
 github.com/googleapis/api-linter v1.21.0 h1:1BTdOUeIL0stY68GX0lIk8peSjUzfLZir104IfoxwwE=
 github.com/googleapis/api-linter v1.21.0/go.mod h1:8Phf2nZyo3HZsquwRTaM/z8/OiYTotxJLMthoUtN5xs=
+github.com/googleapis/api-linter v1.23.0 h1:5X3mVRmDuoTc9RfGv0gJypSYqD8G2JyJlCl8O3sTIjw=
+github.com/googleapis/api-linter v1.23.0/go.mod h1:8Phf2nZyo3HZsquwRTaM/z8/OiYTotxJLMthoUtN5xs=
 github.com/googleapis/gapic-generator-go v0.16.0 h1:S1XVOuROJERt6zj1VZOO85dRoGE+5//FjZ1+SWbYzIg=
 github.com/googleapis/gapic-generator-go v0.16.0/go.mod h1:yl/RVCI7Yp1eLhTTZ7q1xSI+Jy0sCmrD7otRcch4RHM=
 github.com/googleapis/gapic-generator-go v0.18.1 h1:VHRU7rr68F+fDrFyPeeikA940cNRocRQm7kWrxIvRmw=
@@ -391,6 +393,8 @@ github.com/googleapis/gapic-generator-go v0.18.4 h1:jkDbmauSOiaGMc7Ih7quA2jO/zwh
 github.com/googleapis/gapic-generator-go v0.18.4/go.mod h1:q51Tz1Xx0dbp69606eZlk0YUc1FfujYaXTmGxb3awJw=
 github.com/googleapis/gapic-generator-go v0.18.6 h1:fcFDL9OGzA5NYV4MmFw0xXX0rG15b4L35OXFZoLSgPA=
 github.com/googleapis/gapic-generator-go v0.18.6/go.mod h1:fYMHlirmgOYB12CFmcSFtwTjNWaELd8Et+HJrNUC3oU=
+github.com/googleapis/gapic-generator-go v0.19.0 h1:jrsGHvJW/H1an8vtk0trvPHA9Gf7xgYFytvzT2ZZ9IA=
+github.com/googleapis/gapic-generator-go v0.19.0/go.mod h1:x7MhICX8fSFPk2XZtBxeJm5uqAyM1nofpZ5SXywCFVU=
 github.com/googleapis/gax-go v1.0.3 h1:9dMLqhaibYONnDRcnHdUs9P8Mw64jLlZTYlDe3leBtQ=
 github.com/googleapis/gax-go v1.0.3/go.mod h1:QyXYajJFdARxGzjwUfbDFIse7Spkw81SJ4LrBJXtlQ8=
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
@@ -1001,6 +1005,10 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 h1:4qWs8cYYH6PoEFy4dfhDFgoMGkwAcETd+MmPdCPMzUc=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
+golang.org/x/net v0.0.0-20210504132125-bbd867fde50d h1:nTDGCTeAu2LhcsHTRzjyIUbZHCJ4QePArsm27Hka0UM=
+golang.org/x/net v0.0.0-20210504132125-bbd867fde50d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210505214959-0714010a04ed h1:V9kAVxLvz1lkufatrpHuUVyJ/5tR3Ms7rk951P4mI98=
+golang.org/x/net v0.0.0-20210505214959-0714010a04ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1104,6 +1112,9 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1300,6 +1311,10 @@ google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210315173758-2651cd453018/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46 h1:f4STrQZf8jaowsiUitigvrqMCCM4QJH1A2JCSI7U1ow=
 google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
+google.golang.org/genproto v0.0.0-20210504143626-3b2ad6ccc450 h1:iSifhRHb9+Pi325BWlAfpJbuG2YXlBoHE2aEFJY/Pg8=
+google.golang.org/genproto v0.0.0-20210504143626-3b2ad6ccc450/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
+google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2 h1:pl8qT5D+48655f14yDURpIZwSPvMWuuekfAP+gxtjvk=
+google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=


### PR DESCRIPTION
This removes all dependencies on the `view` fields in Get and List methods. Contents of ApiSpecs and Artifacts are obtained using the new `/contents` accessors.