### PR TITLE
Remove support for view arguments to Get and List methods.

### DIFF
--- a/google/cloud/apigee/registry/v1/registry_models.proto
+++ b/google/cloud/apigee/registry/v1/registry_models.proto
@@ -109,8 +109,6 @@ message Api {
   // Annotation keys and values are less restricted than those of labels, but
   // should be generally used for small values of broad interest. Larger, topic-
   // specific metadata should be stored in Artifacts.
-  //
-  // Annotations are returned only when the FULL view is requested.
   map<string, string> annotations = 10;
 }
 
@@ -164,8 +162,6 @@ message ApiVersion {
   // Annotation keys and values are less restricted than those of labels, but
   // should be generally used for small values of broad interest. Larger, topic-
   // specific metadata should be stored in Artifacts.
-  //
-  // Annotations are returned only when the FULL view is requested.
   map<string, string> annotations = 8;
 }
 
@@ -233,9 +229,9 @@ message ApiSpec {
   // change after the spec is retrieved.
   string source_uri = 11;
 
-  // The contents of the spec. Returned only when the FULL view is
-  // requested.
-  bytes contents = 12;
+  // The contents of the spec. Specified when specs are created or updated.
+  // To access the contents of a spec, use GetApiSpecContents.
+  bytes contents = 12 [(google.api.field_behavior) = INPUT_ONLY];
 
   // The revision tags associated with this revision.
   repeated string revision_tags = 13
@@ -260,8 +256,6 @@ message ApiSpec {
   // Annotation keys and values are less restricted than those of labels, but
   // should be generally used for small values of broad interest. Larger, topic-
   // specific metadata should be stored in Artifacts.
-  //
-  // Annotations are returned only when the FULL view is requested.
   map<string, string> annotations = 15;
 }
 
@@ -270,10 +264,9 @@ message ApiSpec {
 // directly on the resource. Since artifacts are stored separately from parent
 // resources, they should generally be used for metadata that is needed
 // infrequently, i.e. not for display in primary views of the resource but
-// perhaps displayed or downloaded upon request. The view field of the
-// ListArtifactsRequest message allows artifacts to be quickly enumerated
-// and checked for presence without downloading their (potentially-large)
-// contents.
+// perhaps displayed or downloaded upon request. The ListArtifacts method
+// allows artifacts to be quickly enumerated and checked for presence without
+// downloading their (potentially-large) contents.
 message Artifact {
   option (google.api.resource) = {
     type: "registry.googleapis.com/Artifact"
@@ -306,20 +299,7 @@ message Artifact {
   // A SHA-256 hash of the artifact's contents
   string hash = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // The contents of the artifact. Returned only when the FULL view is
-  // requested.
-  bytes contents = 7;
-}
-
-// Views of Resources.
-enum View {
-  // The default / unset value.
-  // The API will default to the BASIC view.
-  VIEW_UNSPECIFIED = 0;
-
-  // Include everything but the resource annotations and contents.
-  BASIC = 1;
-
-  // Include everything.
-  FULL = 2;
+  // The contents of the artifact. Specified when artifacts are created.
+  // To access the contents of an artifact, use GetArtifactContents.
+  bytes contents = 7 [(google.api.field_behavior) = INPUT_ONLY];
 }

--- a/google/cloud/apigee/registry/v1/registry_models.proto
+++ b/google/cloud/apigee/registry/v1/registry_models.proto
@@ -229,7 +229,8 @@ message ApiSpec {
   // change after the spec is retrieved.
   string source_uri = 11;
 
-  // The contents of the spec. Specified when specs are created or updated.
+  // The contents of the spec.
+  // Provided by API callers when specs are created or updated.
   // To access the contents of a spec, use GetApiSpecContents.
   bytes contents = 12 [(google.api.field_behavior) = INPUT_ONLY];
 
@@ -299,7 +300,8 @@ message Artifact {
   // A SHA-256 hash of the artifact's contents
   string hash = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // The contents of the artifact. Specified when artifacts are created.
+  // The contents of the artifact.
+  // Provided by API callers when artifacts are created or replaced.
   // To access the contents of an artifact, use GetArtifactContents.
   bytes contents = 7 [(google.api.field_behavior) = INPUT_ONLY];
 }

--- a/google/cloud/apigee/registry/v1/registry_service.proto
+++ b/google/cloud/apigee/registry/v1/registry_service.proto
@@ -690,7 +690,7 @@ message ListApiSpecsRequest {
   string page_token = 3;
 
   // An expression that can be used to filter the list. Filters use the Common
-  // Expression Language and can refer to all message fields.
+  // Expression Language and can refer to all message fields except contents.
   string filter = 4;
 }
 
@@ -884,7 +884,7 @@ message ListArtifactsRequest {
   string page_token = 3;
 
   // An expression that can be used to filter the list. Filters use the Common
-  // Expression Language and can refer to all message fields.
+  // Expression Language and can refer to all message fields except contents.
   string filter = 4;
 }
 

--- a/google/cloud/apigee/registry/v1/registry_service.proto
+++ b/google/cloud/apigee/registry/v1/registry_service.proto
@@ -500,12 +500,8 @@ message ListApisRequest {
   string page_token = 3;
 
   // An expression that can be used to filter the list. Filters use the Common
-  // Expression Language and can refer to all message fields that are included
-  // in the BASIC view.
+  // Expression Language and can refer to all message fields.
   string filter = 4;
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 5;
 }
 
 // Response message for ListApis.
@@ -526,9 +522,6 @@ message GetApiRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = { type: "registry.googleapis.com/Api" }
   ];
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 2;
 }
 
 // Request message for CreateApi.
@@ -600,12 +593,8 @@ message ListApiVersionsRequest {
   string page_token = 3;
 
   // An expression that can be used to filter the list. Filters use the Common
-  // Expression Language and can refer to all message fields that are included
-  // in the BASIC view.
+  // Expression Language and can refer to all message fields.
   string filter = 4;
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 5;
 }
 
 // Response message for ListApiVersions.
@@ -628,9 +617,6 @@ message GetApiVersionRequest {
       type: "registry.googleapis.com/ApiVersion"
     }
   ];
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 2;
 }
 
 // Request message for CreateApiVersion.
@@ -704,12 +690,8 @@ message ListApiSpecsRequest {
   string page_token = 3;
 
   // An expression that can be used to filter the list. Filters use the Common
-  // Expression Language and can refer to all message fields that are included
-  // in the BASIC view.
+  // Expression Language and can refer to all message fields.
   string filter = 4;
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 5;
 }
 
 // Response message for ListApiSpecs.
@@ -732,9 +714,6 @@ message GetApiSpecRequest {
       type: "registry.googleapis.com/ApiSpec"
     }
   ];
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 2;
 }
 
 // Request message for GetApiSpecContents.
@@ -905,12 +884,8 @@ message ListArtifactsRequest {
   string page_token = 3;
 
   // An expression that can be used to filter the list. Filters use the Common
-  // Expression Language and can refer to all message fields that are included
-  // in the BASIC view.
+  // Expression Language and can refer to all message fields.
   string filter = 4;
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 5;
 }
 
 // Response message for ListArtifacts.
@@ -933,9 +908,6 @@ message GetArtifactRequest {
       type: "registry.googleapis.com/Artifact"
     }
   ];
-
-  // The level of detail to return (defaults to BASIC).
-  View view = 2;
 }
 
 // Request message for GetArtifactContents.

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -72,7 +72,7 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 		return nil, err
 	}
 
-	message, err := api.Message(rpc.View_BASIC)
+	message, err := api.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}
@@ -127,7 +127,7 @@ func (s *RegistryServer) GetApi(ctx context.Context, req *rpc.GetApiRequest) (*r
 		return nil, err
 	}
 
-	message, err := api.Message(req.GetView())
+	message, err := api.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}
@@ -172,7 +172,7 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 	}
 
 	for i, api := range listing.Apis {
-		response.Apis[i], err = api.Message(req.GetView())
+		response.Apis[i], err = api.Message()
 		if err != nil {
 			return nil, internalError(err)
 		}
@@ -212,7 +212,7 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 		return nil, err
 	}
 
-	message, err := api.Message(rpc.View_BASIC)
+	message, err := api.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -31,17 +31,6 @@ import (
 )
 
 var (
-	// Basic API view does not include annotations.
-	basicApi = &rpc.Api{
-		Name:               "projects/my-project/apis/my-api",
-		DisplayName:        "My Api",
-		Description:        "Api for my versions",
-		Availability:       "GENERAL",
-		RecommendedVersion: "v1",
-		Labels: map[string]string{
-			"label-key": "label-value",
-		},
-	}
 	// Full API view includes annotations.
 	fullApi = &rpc.Api{
 		Name:               "projects/my-project/apis/my-api",
@@ -104,7 +93,7 @@ func TestCreateApi(t *testing.T) {
 				Parent: "projects/my-project",
 				Api:    fullApi,
 			},
-			want: basicApi,
+			want: fullApi,
 			// Name field is generated.
 			extraOpts: protocmp.IgnoreFields(new(rpc.Api), "name"),
 		},
@@ -158,7 +147,6 @@ func TestCreateApi(t *testing.T) {
 			t.Run("GetApi", func(t *testing.T) {
 				req := &rpc.GetApiRequest{
 					Name: created.GetName(),
-					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApi(ctx, req)
@@ -319,24 +307,6 @@ func TestGetApi(t *testing.T) {
 			seed: fullApi,
 			req: &rpc.GetApiRequest{
 				Name: fullApi.Name,
-			},
-			want: basicApi,
-		},
-		{
-			desc: "basic view",
-			seed: fullApi,
-			req: &rpc.GetApiRequest{
-				Name: fullApi.Name,
-				View: rpc.View_BASIC,
-			},
-			want: basicApi,
-		},
-		{
-			desc: "full view",
-			seed: fullApi,
-			req: &rpc.GetApiRequest{
-				Name: fullApi.Name,
-				View: rpc.View_FULL,
 			},
 			want: fullApi,
 		},
@@ -754,7 +724,7 @@ func TestUpdateApi(t *testing.T) {
 					Name: fullApi.Name,
 				},
 			},
-			want: basicApi,
+			want: fullApi,
 		},
 		{
 			desc: "implicit mask",
@@ -841,7 +811,6 @@ func TestUpdateApi(t *testing.T) {
 			t.Run("GetApi", func(t *testing.T) {
 				req := &rpc.GetApiRequest{
 					Name: updated.GetName(),
-					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApi(ctx, req)

--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -162,27 +162,9 @@ func (s *RegistryServer) GetArtifact(ctx context.Context, req *rpc.GetArtifactRe
 		return nil, err
 	}
 
-	var message *rpc.Artifact
-	switch req.GetView() {
-	case rpc.View_FULL:
-		blob, err := db.GetArtifactContents(ctx, name)
-		if err != nil {
-			return nil, err
-		}
-
-		message, err = artifact.FullMessage(blob)
-		if err != nil {
-			return nil, internalError(err)
-		}
-
-	case rpc.View_BASIC, rpc.View_VIEW_UNSPECIFIED:
-		message, err = artifact.BasicMessage()
-		if err != nil {
-			return nil, internalError(err)
-		}
-
-	default:
-		return nil, invalidArgumentError(fmt.Errorf("unknown view type %v", req.GetView()))
+	message, err := artifact.BasicMessage()
+	if err != nil {
+		return nil, internalError(err)
 	}
 
 	return message, nil
@@ -277,31 +259,9 @@ func (s *RegistryServer) ListArtifacts(ctx context.Context, req *rpc.ListArtifac
 	}
 
 	for i, artifact := range listing.Artifacts {
-		switch req.GetView() {
-		case rpc.View_FULL:
-			name, err := names.ParseArtifact(artifact.Name())
-			if err != nil {
-				return nil, internalError(err)
-			}
-
-			blob, err := db.GetArtifactContents(ctx, name)
-			if err != nil {
-				return nil, internalError(err)
-			}
-
-			response.Artifacts[i], err = artifact.FullMessage(blob)
-			if err != nil {
-				return nil, internalError(err)
-			}
-
-		case rpc.View_BASIC, rpc.View_VIEW_UNSPECIFIED:
-			response.Artifacts[i], err = artifact.BasicMessage()
-			if err != nil {
-				return nil, internalError(err)
-			}
-
-		default:
-			return nil, invalidArgumentError(fmt.Errorf("unknown view type %v", req.GetView()))
+		response.Artifacts[i], err = artifact.BasicMessage()
+		if err != nil {
+			return nil, internalError(err)
 		}
 	}
 

--- a/server/actions_artifacts_test.go
+++ b/server/actions_artifacts_test.go
@@ -160,7 +160,6 @@ func TestCreateArtifact(t *testing.T) {
 			t.Run("GetArtifact", func(t *testing.T) {
 				req := &rpc.GetArtifactRequest{
 					Name: created.GetName(),
-					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetArtifact(ctx, req)
@@ -323,24 +322,6 @@ func TestGetArtifact(t *testing.T) {
 				Name: fullArtifact.Name,
 			},
 			want: basicArtifact,
-		},
-		{
-			desc: "basic view",
-			seed: fullArtifact,
-			req: &rpc.GetArtifactRequest{
-				Name: fullArtifact.Name,
-				View: rpc.View_BASIC,
-			},
-			want: basicArtifact,
-		},
-		{
-			desc: "full view",
-			seed: fullArtifact,
-			req: &rpc.GetArtifactRequest{
-				Name: fullArtifact.Name,
-				View: rpc.View_FULL,
-			},
-			want: fullArtifact,
 		},
 	}
 

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -197,20 +197,19 @@ func (s *RegistryServer) GetApiSpecContents(ctx context.Context, req *rpc.GetApi
 	db := dao.NewDAO(client)
 	var specName = strings.TrimSuffix(req.GetName(), "/contents")
 	var spec *models.Spec
+	var revisionName names.SpecRevision
 	if name, err := names.ParseSpec(specName); err == nil {
 		if spec, err = db.GetSpec(ctx, name); err != nil {
 			return nil, err
 		}
+		revisionName = name.Revision(spec.RevisionID)
 	} else if name, err := names.ParseSpecRevision(specName); err == nil {
 		if spec, err = db.GetSpecRevision(ctx, name); err != nil {
 			return nil, err
 		}
+		revisionName = name
 	} else {
 		return nil, invalidArgumentError(fmt.Errorf("invalid resource name %q, must be an API spec or revision", specName))
-	}
-	revisionName, err := names.ParseSpecRevision(spec.RevisionName())
-	if err != nil {
-		return nil, err
 	}
 	blob, err := db.GetSpecRevisionContents(ctx, revisionName)
 	if err != nil {

--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -34,21 +34,7 @@ import (
 var (
 	// Example spec contents for an OpenAPI JSON spec.
 	specContents = []byte(`{"openapi": "3.0.0", "info": {"title": "My API", "version": "v1"}, "paths": {}}`)
-	// Basic spec view does not include file contents or annotations.
-	basicSpec = &rpc.ApiSpec{
-		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
-		Filename:     "openapi.json",
-		Description:  "My API Spec",
-		MimeType:     "application/x.openapi;version=3.0.0",
-		SizeBytes:    int32(len(specContents)),
-		Hash:         sha256hash(specContents),
-		SourceUri:    "https://www.example.com/openapi.json",
-		RevisionTags: []string{},
-		Labels: map[string]string{
-			"label-key": "label-value",
-		},
-	}
-	// Full spec view includes annotations.
+	// Full spec view.
 	fullSpec = &rpc.ApiSpec{
 		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 		Filename:     "openapi.json",
@@ -58,6 +44,23 @@ var (
 		Hash:         sha256hash(specContents),
 		SourceUri:    "https://www.example.com/openapi.json",
 		Contents:     specContents,
+		RevisionTags: []string{},
+		Labels: map[string]string{
+			"label-key": "label-value",
+		},
+		Annotations: map[string]string{
+			"annotation-key": "annotation-value",
+		},
+	}
+	// Returned specs exclude contents.
+	returnedSpec = &rpc.ApiSpec{
+		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+		Filename:     "openapi.json",
+		Description:  "My API Spec",
+		MimeType:     "application/x.openapi;version=3.0.0",
+		SizeBytes:    int32(len(specContents)),
+		Hash:         sha256hash(specContents),
+		SourceUri:    "https://www.example.com/openapi.json",
 		RevisionTags: []string{},
 		Labels: map[string]string{
 			"label-key": "label-value",
@@ -114,7 +117,7 @@ func TestCreateApiSpec(t *testing.T) {
 				Parent:  "projects/my-project/apis/my-api/versions/v1",
 				ApiSpec: fullSpec,
 			},
-			want: basicSpec,
+			want: returnedSpec,
 			// Name field is generated.
 			extraOpts: protocmp.IgnoreFields(new(rpc.ApiSpec), "name"),
 		},
@@ -172,7 +175,6 @@ func TestCreateApiSpec(t *testing.T) {
 			t.Run("GetApiSpec", func(t *testing.T) {
 				req := &rpc.GetApiSpecRequest{
 					Name: created.GetName(),
-					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApiSpec(ctx, req)
@@ -344,25 +346,7 @@ func TestGetApiSpec(t *testing.T) {
 			req: &rpc.GetApiSpecRequest{
 				Name: fullSpec.Name,
 			},
-			want: basicSpec,
-		},
-		{
-			desc: "basic view",
-			seed: fullSpec,
-			req: &rpc.GetApiSpecRequest{
-				Name: fullSpec.Name,
-				View: rpc.View_BASIC,
-			},
-			want: basicSpec,
-		},
-		{
-			desc: "full view",
-			seed: fullSpec,
-			req: &rpc.GetApiSpecRequest{
-				Name: fullSpec.Name,
-				View: rpc.View_FULL,
-			},
-			want: fullSpec,
+			want: returnedSpec,
 		},
 	}
 
@@ -842,7 +826,7 @@ func TestUpdateApiSpec(t *testing.T) {
 					Name: fullSpec.Name,
 				},
 			},
-			want: fullSpec,
+			want: returnedSpec,
 		},
 		{
 			desc: "allow missing updates existing resources",

--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -34,7 +34,24 @@ import (
 var (
 	// Example spec contents for an OpenAPI JSON spec.
 	specContents = []byte(`{"openapi": "3.0.0", "info": {"title": "My API", "version": "v1"}, "paths": {}}`)
-	// Full spec view.
+	// Basic spec view does not include file contents.
+	basicSpec = &rpc.ApiSpec{
+		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+		Filename:     "openapi.json",
+		Description:  "My API Spec",
+		MimeType:     "application/x.openapi;version=3.0.0",
+		SizeBytes:    int32(len(specContents)),
+		Hash:         sha256hash(specContents),
+		SourceUri:    "https://www.example.com/openapi.json",
+		RevisionTags: []string{},
+		Labels: map[string]string{
+			"label-key": "label-value",
+		},
+		Annotations: map[string]string{
+			"annotation-key": "annotation-value",
+		},
+	}
+	// Full spec view includes contents.
 	fullSpec = &rpc.ApiSpec{
 		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 		Filename:     "openapi.json",
@@ -44,23 +61,6 @@ var (
 		Hash:         sha256hash(specContents),
 		SourceUri:    "https://www.example.com/openapi.json",
 		Contents:     specContents,
-		RevisionTags: []string{},
-		Labels: map[string]string{
-			"label-key": "label-value",
-		},
-		Annotations: map[string]string{
-			"annotation-key": "annotation-value",
-		},
-	}
-	// Returned specs exclude contents.
-	returnedSpec = &rpc.ApiSpec{
-		Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
-		Filename:     "openapi.json",
-		Description:  "My API Spec",
-		MimeType:     "application/x.openapi;version=3.0.0",
-		SizeBytes:    int32(len(specContents)),
-		Hash:         sha256hash(specContents),
-		SourceUri:    "https://www.example.com/openapi.json",
 		RevisionTags: []string{},
 		Labels: map[string]string{
 			"label-key": "label-value",
@@ -117,7 +117,7 @@ func TestCreateApiSpec(t *testing.T) {
 				Parent:  "projects/my-project/apis/my-api/versions/v1",
 				ApiSpec: fullSpec,
 			},
-			want: returnedSpec,
+			want: basicSpec,
 			// Name field is generated.
 			extraOpts: protocmp.IgnoreFields(new(rpc.ApiSpec), "name"),
 		},
@@ -346,7 +346,7 @@ func TestGetApiSpec(t *testing.T) {
 			req: &rpc.GetApiSpecRequest{
 				Name: fullSpec.Name,
 			},
-			want: returnedSpec,
+			want: basicSpec,
 		},
 	}
 
@@ -826,7 +826,7 @@ func TestUpdateApiSpec(t *testing.T) {
 					Name: fullSpec.Name,
 				},
 			},
-			want: returnedSpec,
+			want: basicSpec,
 		},
 		{
 			desc: "allow missing updates existing resources",

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -72,7 +72,7 @@ func (s *RegistryServer) CreateApiVersion(ctx context.Context, req *rpc.CreateAp
 		return nil, err
 	}
 
-	message, err := version.Message(rpc.View_BASIC)
+	message, err := version.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}
@@ -127,7 +127,7 @@ func (s *RegistryServer) GetApiVersion(ctx context.Context, req *rpc.GetApiVersi
 		return nil, err
 	}
 
-	message, err := version.Message(req.GetView())
+	message, err := version.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}
@@ -172,7 +172,7 @@ func (s *RegistryServer) ListApiVersions(ctx context.Context, req *rpc.ListApiVe
 	}
 
 	for i, version := range listing.Versions {
-		response.ApiVersions[i], err = version.Message(req.GetView())
+		response.ApiVersions[i], err = version.Message()
 		if err != nil {
 			return nil, internalError(err)
 		}
@@ -212,7 +212,7 @@ func (s *RegistryServer) UpdateApiVersion(ctx context.Context, req *rpc.UpdateAp
 		return nil, err
 	}
 
-	message, err := version.Message(rpc.View_BASIC)
+	message, err := version.Message()
 	if err != nil {
 		return nil, internalError(err)
 	}

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -30,17 +30,7 @@ import (
 )
 
 var (
-	// Basic version view does not include annotations.
-	basicVersion = &rpc.ApiVersion{
-		Name:        "projects/my-project/apis/my-api/versions/my-version",
-		DisplayName: "My Api",
-		Description: "Api for my versions",
-		State:       "PRODUCTION",
-		Labels: map[string]string{
-			"label-key": "label-value",
-		},
-	}
-	// Full version view includes annotations.
+	// Full version view.
 	fullVersion = &rpc.ApiVersion{
 		Name:        "projects/my-project/apis/my-api/versions/my-version",
 		DisplayName: "My Api",
@@ -101,7 +91,7 @@ func TestCreateApiVersion(t *testing.T) {
 				Parent:     "projects/my-project/apis/my-api",
 				ApiVersion: fullVersion,
 			},
-			want: basicVersion,
+			want: fullVersion,
 			// Name field is generated.
 			extraOpts: protocmp.IgnoreFields(new(rpc.ApiVersion), "name"),
 		},
@@ -155,7 +145,6 @@ func TestCreateApiVersion(t *testing.T) {
 			t.Run("GetApiVersion", func(t *testing.T) {
 				req := &rpc.GetApiVersionRequest{
 					Name: created.GetName(),
-					View: rpc.View_BASIC,
 				}
 
 				got, err := server.GetApiVersion(ctx, req)
@@ -316,24 +305,6 @@ func TestGetApiVersion(t *testing.T) {
 			seed: fullVersion,
 			req: &rpc.GetApiVersionRequest{
 				Name: fullVersion.Name,
-			},
-			want: basicVersion,
-		},
-		{
-			desc: "basic view",
-			seed: fullVersion,
-			req: &rpc.GetApiVersionRequest{
-				Name: fullVersion.Name,
-				View: rpc.View_BASIC,
-			},
-			want: basicVersion,
-		},
-		{
-			desc: "full view",
-			seed: fullVersion,
-			req: &rpc.GetApiVersionRequest{
-				Name: fullVersion.Name,
-				View: rpc.View_FULL,
 			},
 			want: fullVersion,
 		},

--- a/server/models/api.go
+++ b/server/models/api.go
@@ -74,7 +74,7 @@ func (api *Api) Name() string {
 }
 
 // Message returns a message representing an api.
-func (api *Api) Message(view rpc.View) (message *rpc.Api, err error) {
+func (api *Api) Message() (message *rpc.Api, err error) {
 	message = &rpc.Api{
 		Name:               api.Name(),
 		DisplayName:        api.DisplayName,
@@ -98,11 +98,9 @@ func (api *Api) Message(view rpc.View) (message *rpc.Api, err error) {
 		return nil, err
 	}
 
-	if view == rpc.View_FULL {
-		message.Annotations, err = mapForBytes(api.Annotations)
-		if err != nil {
-			return nil, err
-		}
+	message.Annotations, err = mapForBytes(api.Annotations)
+	if err != nil {
+		return nil, err
 	}
 
 	return message, nil

--- a/server/models/artifact.go
+++ b/server/models/artifact.go
@@ -80,17 +80,6 @@ func (artifact *Artifact) Name() string {
 	}
 }
 
-// FullMessage returns the full view of the artifact resource as an RPC message.
-func (artifact *Artifact) FullMessage(blob *Blob) (message *rpc.Artifact, err error) {
-	message, err = artifact.BasicMessage()
-	if err != nil {
-		return nil, err
-	}
-
-	message.Contents = blob.Contents
-	return message, nil
-}
-
 // BasicMessage returns the basic view of the artifact resource as an RPC message.
 func (artifact *Artifact) BasicMessage() (message *rpc.Artifact, err error) {
 	message = &rpc.Artifact{

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -131,22 +131,6 @@ func (s *Spec) RevisionName() string {
 	return fmt.Sprintf("projects/%s/apis/%s/versions/%s/specs/%s@%s", s.ProjectID, s.ApiID, s.VersionID, s.SpecID, s.RevisionID)
 }
 
-// FullMessage returns the full view of the spec resource as an RPC message.
-func (s *Spec) FullMessage(blob *Blob, name string) (message *rpc.ApiSpec, err error) {
-	message, err = s.BasicMessage(name)
-	if err != nil {
-		return nil, err
-	}
-
-	message.Annotations, err = mapForBytes(s.Annotations)
-	if err != nil {
-		return nil, err
-	}
-
-	message.Contents = blob.Contents
-	return message, nil
-}
-
 // BasicMessage returns the basic view of the spec resource as an RPC message.
 func (s *Spec) BasicMessage(name string) (message *rpc.ApiSpec, err error) {
 	message = &rpc.ApiSpec{
@@ -176,6 +160,11 @@ func (s *Spec) BasicMessage(name string) (message *rpc.ApiSpec, err error) {
 	}
 
 	message.Labels, err = mapForBytes(s.Labels)
+	if err != nil {
+		return nil, err
+	}
+
+	message.Annotations, err = mapForBytes(s.Annotations)
 	if err != nil {
 		return nil, err
 	}

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -75,7 +75,7 @@ func (v *Version) Name() string {
 }
 
 // Message returns a message representing a version.
-func (v *Version) Message(view rpc.View) (message *rpc.ApiVersion, err error) {
+func (v *Version) Message() (message *rpc.ApiVersion, err error) {
 	message = &rpc.ApiVersion{
 		Name:        v.Name(),
 		DisplayName: v.DisplayName,
@@ -98,11 +98,9 @@ func (v *Version) Message(view rpc.View) (message *rpc.ApiVersion, err error) {
 		return nil, err
 	}
 
-	if view == rpc.View_FULL {
-		message.Annotations, err = mapForBytes(v.Annotations)
-		if err != nil {
-			return nil, err
-		}
+	message.Annotations, err = mapForBytes(v.Annotations)
+	if err != nil {
+		return nil, err
 	}
 
 	return message, nil

--- a/tests/crud/crud_test.go
+++ b/tests/crud/crud_test.go
@@ -151,7 +151,6 @@ func TestCRUD(t *testing.T) {
 	{
 		req := &rpc.GetApiRequest{
 			Name: "projects/test/apis/sample",
-			View: rpc.View_FULL,
 		}
 		api, err := registryClient.GetApi(ctx, req)
 		check(t, "error getting api %s", err)
@@ -166,7 +165,6 @@ func TestCRUD(t *testing.T) {
 	{
 		req := &rpc.GetApiVersionRequest{
 			Name: "projects/test/apis/sample/versions/1.0.0",
-			View: rpc.View_FULL,
 		}
 		version, err := registryClient.GetApiVersion(ctx, req)
 		check(t, "error getting version %s", err)
@@ -182,7 +180,6 @@ func TestCRUD(t *testing.T) {
 	{
 		req := &rpc.GetApiSpecRequest{
 			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml",
-			View: rpc.View_FULL,
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)


### PR DESCRIPTION
This completely removes the view argument from Get and List methods. Now annotations are always returned and contents are never returned. The contents fields of both ApiSpecs and Artifacts are accessible using the GetApiSpecContents and GetArtifactContents methods, which also provide direct access to contents (with no protobuf message wrapping) through transcoded HTTP calls.