### PR TITLE
Validate database configuration on startup

### DIFF
--- a/server/gorm/client.go
+++ b/server/gorm/client.go
@@ -72,6 +72,26 @@ var clientTotal int
 
 var openErrorCount int
 
+// Validate checks a database name and config string for validity.
+func Validate(gormDBName, gormConfig string) error {
+	switch gormDBName {
+	case "sqlite3":
+		if !cgoEnabled {
+			return fmt.Errorf("%s is unavailable, please recompile with CGO_ENABLED=1 or configure registry-server to use a different database", gormDBName)
+		}
+	case "postgres":
+		break
+	case "cloudsqlpostgres":
+		break
+	default:
+		return fmt.Errorf("unsupported database (%s)", gormDBName)
+	}
+	if gormConfig == "" {
+		return fmt.Errorf("dbconfig cannot be empty")
+	}
+	return nil
+}
+
 // NewClient creates a new database session.
 func NewClient(ctx context.Context, gormDBName, gormConfig string) (*Client, error) {
 	mylock()
@@ -79,10 +99,6 @@ func NewClient(ctx context.Context, gormDBName, gormConfig string) (*Client, err
 	clientTotal++
 	switch gormDBName {
 	case "sqlite3":
-		if (!cgoEnabled) {
-			myunlock()
-			return nil, fmt.Errorf("%s is unavailable. Please recompile with CGO_ENABLED=1 or use a different database.", gormDBName)
-		}
 		db, err := gorm.Open(sqlite.Open(gormConfig), config())
 		if err != nil {
 			openErrorCount++
@@ -117,7 +133,7 @@ func NewClient(ctx context.Context, gormDBName, gormConfig string) (*Client, err
 		return c, nil
 	default:
 		myunlock()
-		return nil, fmt.Errorf("Unsupported database %s", gormDBName)
+		return nil, fmt.Errorf("unsupported database %s", gormDBName)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,10 @@ var serverSerialization bool
 func RunServer(port string, config *Config) error {
 	// Construct Registry API server (request handler).
 	r := newRegistryServer(config)
+	// Check database configuration
+	if err := gorm.Validate(config.Database, config.DBConfig); err != nil {
+		return err
+	}
 	// Construct gRPC server.
 	loggingHandler := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if serverSerialization {


### PR DESCRIPTION
This moves a database configuration check to initialization, which will make it easier to recognize invalid configurations, particularly configuration to use SQLite when CGO is disabled.

Addresses #143 