### PR TITLE
Remove currency field from spec model

### DIFF
--- a/server/actions_spec_revisions.go
+++ b/server/actions_spec_revisions.go
@@ -61,7 +61,7 @@ func (s *RegistryServer) ListApiSpecRevisions(ctx context.Context, req *rpc.List
 	}
 
 	for i, spec := range listing.Specs {
-		response.ApiSpecs[i], err = spec.BasicMessage(spec.Name())
+		response.ApiSpecs[i], err = spec.BasicMessage(spec.RevisionName())
 		if err != nil {
 			return nil, internalError(err)
 		}

--- a/server/actions_spec_revisions.go
+++ b/server/actions_spec_revisions.go
@@ -96,16 +96,6 @@ func (s *RegistryServer) DeleteApiSpecRevision(ctx context.Context, req *rpc.Del
 		return nil, invalidArgumentError(err)
 	}
 
-	// If the one we will delete is the current revision, we need to designate a new current revision.
-	if revision.Currency == models.IsCurrent {
-		// get the most recent non-current revision and make it current
-		newKey, newCurrentRevision, err := s.fetchMostRecentNonCurrentRevisionOfSpec(ctx, client, name.Spec())
-		if err == nil && newCurrentRevision != nil {
-			newCurrentRevision.Currency = models.IsCurrent
-			_, _ = client.Put(ctx, newKey, newCurrentRevision)
-		}
-	}
-
 	if err := db.DeleteSpecRevision(ctx, name); err != nil {
 		return nil, internalError(err)
 	}
@@ -177,17 +167,6 @@ func (s *RegistryServer) RollbackApiSpec(ctx context.Context, req *rpc.RollbackA
 	parent, err := names.ParseSpec(req.GetName())
 	if err != nil {
 		return nil, invalidArgumentError(err)
-	}
-
-	current, err := db.GetSpec(ctx, parent)
-	if err != nil {
-		return nil, err
-	}
-
-	// Mark the current revision as non-current.
-	current.Currency = models.NotCurrent
-	if err := db.SaveSpecRevision(ctx, current); err != nil {
-		return nil, err
 	}
 
 	// Get the target spec revision to use as a base for the new rollback revision.

--- a/server/actions_spec_revisions_test.go
+++ b/server/actions_spec_revisions_test.go
@@ -280,8 +280,6 @@ func TestDeleteApiSpecRevision(t *testing.T) {
 }
 
 func TestListApiSpecRevisions(t *testing.T) {
-	t.Skip("Response is not currently sorted by revision creation time")
-
 	ctx := context.Background()
 	server := defaultTestServer(t)
 	seedVersions(ctx, t, server, &rpc.ApiVersion{

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -289,12 +289,6 @@ func (s *RegistryServer) UpdateApiSpec(ctx context.Context, req *rpc.UpdateApiSp
 		return nil, err
 	}
 
-	// Mark the current revision as non-current so the update becomes the only current revision.
-	spec.Currency = models.NotCurrent
-	if err := db.SaveSpecRevision(ctx, spec); err != nil {
-		return nil, err
-	}
-
 	// Apply the update to the spec - possibly changing the revision ID.
 	if err := spec.Update(req.GetApiSpec(), req.GetUpdateMask()); err != nil {
 		return nil, internalError(err)

--- a/server/dao/dao.go
+++ b/server/dao/dao.go
@@ -15,6 +15,11 @@
 package dao
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/gob"
+	"fmt"
+
 	"github.com/apigee/registry/server/storage"
 )
 
@@ -39,4 +44,56 @@ func NewDAO(c storage.Client) DAO {
 	return DAO{
 		Client: c,
 	}
+}
+
+// token contains information to share between sequential page iterators.
+type token struct {
+	// Offset is the number of resources that should be skipped before the page begins.
+	// It should be set to the number of resources already returned.
+	Offset int32
+	// Filter is the filter string for this listing request. It should be consistent between sequential pages.
+	Filter string
+}
+
+// ValidateFilter returns an error if the new filter doesn't match the token's encoded filter.
+// When the token represents the first page, any filter is valid and no error will be returned.
+func (t token) ValidateFilter(newFilter string) error {
+	if t.Offset > 0 && newFilter != t.Filter {
+		return fmt.Errorf("new filter does not match previous filter %q", t.Filter)
+	}
+
+	return nil
+}
+
+// encodeToken converts a token struct into an opaque string that can be converted back into struct form using decodeToken().
+func encodeToken(o token) (string, error) {
+	var encoding bytes.Buffer
+
+	encoder := gob.NewEncoder(&encoding)
+	if err := encoder.Encode(o); err != nil {
+		return "", fmt.Errorf("failed to encode token: %s", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(encoding.Bytes()), nil
+}
+
+// decodeToken converts a string returned from encodeToken() back into an equivalent token struct.
+// Empty encoding strings are decoded without error to a zero-value token struct.
+func decodeToken(encoded string) (token, error) {
+	if encoded == "" {
+		return token{}, nil
+	}
+
+	decoding, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return token{}, fmt.Errorf("failed to decode token, expected base64: %s", err)
+	}
+
+	opts := token{}
+	encoder := gob.NewDecoder(bytes.NewReader(decoding))
+	if err := encoder.Decode(&opts); err != nil {
+		return token{}, fmt.Errorf("failed to decode token bytes: %s", err)
+	}
+
+	return opts, nil
 }

--- a/server/dao/spec_revisions.go
+++ b/server/dao/spec_revisions.go
@@ -31,7 +31,7 @@ func (d *DAO) ListSpecRevisions(ctx context.Context, parent names.Spec, opts Pag
 	q = q.Require("ApiID", parent.ApiID)
 	q = q.Require("VersionID", parent.VersionID)
 	q = q.Require("SpecID", parent.SpecID)
-	q = q.Order("-RevisionCreateTime")
+	q = q.Descending("RevisionCreateTime")
 	q, err := q.ApplyCursor(opts.Token)
 	if err != nil {
 		return SpecList{}, status.Error(codes.Internal, err.Error())

--- a/server/dao/specs.go
+++ b/server/dao/specs.go
@@ -51,7 +51,7 @@ var specFields = []filtering.Field{
 
 func (d *DAO) ListSpecs(ctx context.Context, parent names.Version, opts PageOptions) (SpecList, error) {
 	q := d.NewQuery(storage.SpecEntityName)
-	q = q.Order("-RevisionCreateTime")
+	q = q.Descending("RevisionCreateTime")
 	q, err := q.ApplyCursor(opts.Token)
 	if err != nil {
 		return SpecList{}, status.Errorf(codes.InvalidArgument, "invalid page token %q: %s", opts.Token, err.Error())
@@ -156,7 +156,7 @@ func (d *DAO) GetSpec(ctx context.Context, name names.Spec) (*models.Spec, error
 	q = q.Require("ApiID", name.ApiID)
 	q = q.Require("VersionID", name.VersionID)
 	q = q.Require("SpecID", name.SpecID)
-	q = q.Order("-RevisionCreateTime")
+	q = q.Descending("RevisionCreateTime")
 
 	it := d.Run(ctx, q)
 	spec := &models.Spec{}

--- a/server/dao/specs.go
+++ b/server/dao/specs.go
@@ -51,7 +51,7 @@ var specFields = []filtering.Field{
 
 func (d *DAO) ListSpecs(ctx context.Context, parent names.Version, opts PageOptions) (SpecList, error) {
 	q := d.NewQuery(storage.SpecEntityName)
-	q = q.Require("Currency", models.IsCurrent)
+	q = q.Order("-RevisionCreateTime")
 	q, err := q.ApplyCursor(opts.Token)
 	if err != nil {
 		return SpecList{}, status.Errorf(codes.InvalidArgument, "invalid page token %q: %s", opts.Token, err.Error())
@@ -156,7 +156,7 @@ func (d *DAO) GetSpec(ctx context.Context, name names.Spec) (*models.Spec, error
 	q = q.Require("ApiID", name.ApiID)
 	q = q.Require("VersionID", name.VersionID)
 	q = q.Require("SpecID", name.SpecID)
-	q = q.Require("Currency", models.IsCurrent)
+	q = q.Order("-RevisionCreateTime")
 
 	it := d.Run(ctx, q)
 	spec := &models.Spec{}

--- a/server/dao/specs.go
+++ b/server/dao/specs.go
@@ -52,10 +52,19 @@ var specFields = []filtering.Field{
 func (d *DAO) ListSpecs(ctx context.Context, parent names.Version, opts PageOptions) (SpecList, error) {
 	q := d.NewQuery(storage.SpecEntityName)
 	q = q.Descending("RevisionCreateTime")
-	q, err := q.ApplyCursor(opts.Token)
+
+	token, err := decodeToken(opts.Token)
 	if err != nil {
 		return SpecList{}, status.Errorf(codes.InvalidArgument, "invalid page token %q: %s", opts.Token, err.Error())
 	}
+
+	if err := token.ValidateFilter(opts.Filter); err != nil {
+		return SpecList{}, status.Errorf(codes.InvalidArgument, "invalid filter %q: %s", opts.Filter, err)
+	} else {
+		token.Filter = opts.Filter
+	}
+
+	q = q.ApplyOffset(token.Offset)
 
 	if id := parent.ProjectID; id != "-" {
 		q = q.Require("ProjectID", id)
@@ -93,6 +102,8 @@ func (d *DAO) ListSpecs(ctx context.Context, parent names.Version, opts PageOpti
 
 	spec := new(models.Spec)
 	for _, err = it.Next(spec); err == nil; _, err = it.Next(spec) {
+		token.Offset++
+
 		specMap, err := specMap(*spec)
 		if err != nil {
 			return response, status.Error(codes.Internal, err.Error())
@@ -115,7 +126,7 @@ func (d *DAO) ListSpecs(ctx context.Context, parent names.Version, opts PageOpti
 	}
 
 	if err == nil {
-		response.Token, err = it.GetCursor()
+		response.Token, err = encodeToken(token)
 		if err != nil {
 			return response, status.Error(codes.Internal, err.Error())
 		}

--- a/server/gorm/client.go
+++ b/server/gorm/client.go
@@ -256,7 +256,9 @@ func (c *Client) Run(ctx context.Context, q storage.Query) storage.Iterator {
 	mylock()
 	defer myunlock()
 
-	op := c.db.Where("key > ?", q.(*Query).Cursor)
+	// Filtering is currently implemented by skipping iterator elements that don't match the filter criteria.
+	// If the 1000 returned elements don't fill a page, then another query will need to be ran for more results.
+	op := c.db.Offset(q.(*Query).Offset).Limit(1000)
 	for _, r := range q.(*Query).Requirements {
 		op = op.Where(r.Name+" = ?", r.Value)
 	}

--- a/server/gorm/client.go
+++ b/server/gorm/client.go
@@ -255,13 +255,17 @@ func (c *Client) Delete(ctx context.Context, k storage.Key) error {
 func (c *Client) Run(ctx context.Context, q storage.Query) storage.Iterator {
 	mylock()
 	defer myunlock()
-	cursor := q.(*Query).Cursor
 
-	op := c.db.Where("key > ?", cursor)
+	op := c.db.Where("key > ?", q.(*Query).Cursor)
 	for _, r := range q.(*Query).Requirements {
 		op = op.Where(r.Name+" = ?", r.Value)
 	}
-	op = op.Order("key")
+
+	if order := q.(*Query).Order; order != "" {
+		op = op.Order(order)
+	} else {
+		op = op.Order("key")
+	}
 
 	switch q.(*Query).Kind {
 	case "Project":

--- a/server/gorm/query.go
+++ b/server/gorm/query.go
@@ -19,8 +19,6 @@ import (
 	"log"
 
 	"github.com/apigee/registry/server/storage"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Query represents a query in a storage provider.
@@ -42,15 +40,6 @@ func (c *Client) NewQuery(kind string) storage.Query {
 	return &Query{
 		Kind: kind,
 	}
-}
-
-// internalError returns an error that wraps an internal server error.
-func internalError(err error) error {
-	if err == nil {
-		return nil
-	}
-	// TODO: selectively mask error details depending on caller privileges
-	return status.Error(codes.Internal, err.Error())
 }
 
 // Filter adds a general filter to a query.

--- a/server/gorm/query.go
+++ b/server/gorm/query.go
@@ -52,8 +52,6 @@ func (q *Query) Require(name string, value interface{}) storage.Query {
 		name = "version_id"
 	case "SpecID":
 		name = "spec_id"
-	case "Currency":
-		name = "currency"
 	default:
 		log.Fatalf("UNEXPECTED REQUIRE TYPE: %s", name)
 	}

--- a/server/gorm/query.go
+++ b/server/gorm/query.go
@@ -27,6 +27,7 @@ import (
 type Query struct {
 	Kind         string
 	Cursor       string
+	Order        string
 	Requirements []*Requirement
 }
 
@@ -78,8 +79,12 @@ func (q *Query) Require(name string, value interface{}) storage.Query {
 	return q
 }
 
-func (q *Query) Order(value string) storage.Query {
-	// ordering is ignored
+func (q *Query) Descending(field string) storage.Query {
+	switch field {
+	case "RevisionCreateTime":
+		q.Order = "revision_create_time desc"
+	}
+
 	return q
 }
 

--- a/server/gorm/query.go
+++ b/server/gorm/query.go
@@ -15,7 +15,6 @@
 package gorm
 
 import (
-	"encoding/base64"
 	"log"
 
 	"github.com/apigee/registry/server/storage"
@@ -24,7 +23,7 @@ import (
 // Query represents a query in a storage provider.
 type Query struct {
 	Kind         string
-	Cursor       string
+	Offset       int
 	Order        string
 	Requirements []*Requirement
 }
@@ -40,12 +39,6 @@ func (c *Client) NewQuery(kind string) storage.Query {
 	return &Query{
 		Kind: kind,
 	}
-}
-
-// Filter adds a general filter to a query.
-func (q *Query) Filter(name string, value interface{}) storage.Query {
-	log.Fatalf("Unsupported filter %s %+v", name, value)
-	return q
 }
 
 // Require adds a filter to a query that requires a field to have a specified value.
@@ -77,12 +70,7 @@ func (q *Query) Descending(field string) storage.Query {
 	return q
 }
 
-// ApplyCursor configures a query to start from a specified cursor.
-func (q *Query) ApplyCursor(encodedCursor string) (storage.Query, error) {
-	decodedCursor, err := base64.StdEncoding.DecodeString(encodedCursor)
-	if err != nil {
-		return q, err
-	}
-	q.Cursor = string(decodedCursor)
-	return q, nil
+func (q *Query) ApplyOffset(offset int32) storage.Query {
+	q.Offset = int(offset)
+	return q
 }

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -38,7 +38,6 @@ const (
 // Spec is the storage-side representation of a spec.
 type Spec struct {
 	Key                string    `gorm:"primaryKey"`
-	Currency           int32     // IsCurrent for the current revision of the spec.
 	ProjectID          string    // Uniquely identifies a project.
 	ApiID              string    // Uniquely identifies an api within a project.
 	VersionID          string    // Uniquely identifies a version within a api.
@@ -72,7 +71,6 @@ func NewSpec(name names.Spec, body *rpc.ApiSpec) (spec *Spec, err error) {
 		CreateTime:         now,
 		RevisionCreateTime: now,
 		RevisionUpdateTime: now,
-		Currency:           IsCurrent,
 		RevisionID:         newRevisionID(),
 	}
 
@@ -111,7 +109,6 @@ func (s *Spec) NewRevision() *Spec {
 		CreateTime:         s.CreateTime,
 		RevisionCreateTime: now,
 		RevisionUpdateTime: now,
-		Currency:           IsCurrent,
 		RevisionID:         newRevisionID(),
 	}
 }
@@ -239,7 +236,6 @@ func (s *Spec) Update(message *rpc.ApiSpec, mask *fieldmaskpb.FieldMask) error {
 			return err
 		}
 	}
-	s.Currency = IsCurrent
 	s.RevisionUpdateTime = now
 	return nil
 }

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -26,15 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-// This was originally a boolean but gorm does not correctly update booleans from structs.
-// https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false
-const (
-	// NotCurrent indicates that a revision is NOT the current revision of a spec
-	NotCurrent = 1
-	// IsCurrent indicates that a revision is the current revision of a spec
-	IsCurrent = 2
-)
-
 // Spec is the storage-side representation of a spec.
 type Spec struct {
 	Key                string    `gorm:"primaryKey"`

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -63,13 +63,11 @@ type Key interface {
 }
 
 type Query interface {
-	Filter(filter string, value interface{}) Query
 	Require(name string, value interface{}) Query
 	Descending(field string) Query
-	ApplyCursor(cursorStr string) (Query, error)
+	ApplyOffset(int32) Query
 }
 
 type Iterator interface {
 	Next(interface{}) (Key, error)
-	GetCursor() (string, error)
 }

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -56,6 +56,8 @@ type Client interface {
 	DeleteChildrenOfVersion(ctx context.Context, version names.Version) error
 	DeleteAllMatches(ctx context.Context, q Query) error
 	DeleteChildrenOfSpec(ctx context.Context, spec names.Spec) error
+
+	GetRecentSpecRevisions(ctx context.Context, offset int32, projectID, apiID, versionID string) Iterator
 }
 
 type Key interface {

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -65,7 +65,7 @@ type Key interface {
 type Query interface {
 	Filter(filter string, value interface{}) Query
 	Require(name string, value interface{}) Query
-	Order(order string) Query
+	Descending(field string) Query
 	ApplyCursor(cursorStr string) (Query, error)
 }
 

--- a/tests/demo/demo_test.go
+++ b/tests/demo/demo_test.go
@@ -242,27 +242,24 @@ func TestDemo(t *testing.T) {
 			t.Errorf("Incorrect revision count: %d (if this is zero, be sure that all indexes are built)", len(revisionIDs))
 		}
 	}
-	t.Run("ListApiSpecRevisions ordering", func(t *testing.T) {
-		t.Skip("SQLite database used for testing is not currently sorting by revision creation time")
-		if len(revisionIDs) > 0 {
-			req := &rpc.GetApiSpecRequest{
-				Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + revisionIDs[len(revisionIDs)-1],
-			}
-			spec, err := registryClient.GetApiSpec(ctx, req)
-			check(t, "error getting spec %s", err)
-			// compute the hash of the original file
-			buf, err := readAndGZipFile("petstore/1.0.0/openapi.yaml@r0")
-			check(t, "error reading spec", err)
-			if hash := hashForBytes(buf.Bytes()); spec.GetHash() != hash {
-				t.Errorf("Hash mismatch %s != %s", spec.GetHash(), hash)
-			}
+	if len(revisionIDs) > 0 {
+		req := &rpc.GetApiSpecRequest{
+			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + revisionIDs[len(revisionIDs)-1],
 		}
-	})
+		spec, err := registryClient.GetApiSpec(ctx, req)
+		check(t, "error getting spec %s", err)
+		// compute the hash of the original file
+		buf, err := readAndGZipFile("petstore/1.0.0/openapi.yaml@r0")
+		check(t, "error reading spec", err)
+		if hash := hashForBytes(buf.Bytes()); spec.GetHash() != hash {
+			t.Errorf("Hash mismatch %s != %s", spec.GetHash(), hash)
+		}
+	}
 	// List specs; there should be only one.
 	{
 		specs = listAllSpecs(ctx, registryClient)
 		if len(specs) != 1 {
-			t.Errorf("Incorrect spec count: %d", len(specs))
+			t.Errorf("Incorrect spec count %d, expected exactly one:\n%+v", len(specs), specs)
 		}
 	}
 	// tag a spec revision


### PR DESCRIPTION
This change removes the "Currency" field from API spec models. Instead, the revision creation time is used to determine which spec revision is current. To achieve this, two major changes were necessary as prerequisites. Fixes #98.

1. Pagination using limit/offset instead of primary key.

Pagination using the primary key as a cursor only works if the query is ordered by key. We want to paginate spec revisions in order of their creation time and other resources in order by key, so a general purpose solution like limit/offset made the most sense. 

Note: Previously our iterators would read the entire table into memory and only iterate until a page is ready to return or the entire table has been read. Now the iterator can indicate it's "done" before the entire table has been read.

In the case where a consumer makes a list request with a filter that is restrictive enough to iterate over 1000 (an arbitrary choice) resources without filling the requested page size, the server will incorrectly think the entire table has been read. This can be patched to the previous behavior by increasing the limit to a number larger than any reasonable table size, or permanently fixed by updating iterators to read more resources if they are available.

2. Bypassing the query interface to perform a "complicated" SQL query for ListSpecs.

The query interface provides an abstraction that makes it too difficult to perform a complicated query like the one required to list the most recent revision of each spec. It might be better to remove that abstraction entirely now that we only support SQL databases through gorm. 