### PR TITLE
quick (temporary) fix for changes in gapic-generator-go

### DIFF
--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -76,7 +76,7 @@ rm -rf gapic/github.com
 cat >> gapic/registry_client.go <<END
 
 func (c *RegistryClient) GrpcClient() rpcpb.RegistryClient {
-	return c.registryClient
+	return c.internalClient.(*registryGRPCClient).registryClient
 }
 END
 


### PR DESCRIPTION
Recent changes to gapic-generator-go break a hacky patch that was added to support the graphql demo. I think we should remove that patch and possibly also the graphql demo, but since the change breaks CI, this quick change fixes the CI problems so we can keep our tests clean to avoid blocking other work.