### PR TITLE
Add a Dockerfile for a container containing the registry CLI tools.

### DIFF
--- a/containers/BUILD.sh
+++ b/containers/BUILD.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2020 Google LLC. All Rights Reserved.
+# Copyright 2021 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,20 +20,23 @@
  
 # Available platforms will depend on the local installation of Docker.
 
-# ORGANIZATION should be dockerhub organization that will host the images
+# ORGANIZATION should be the dockerhub organization that will host the images
 #ORGANIZATION=
+
+# TARGET selects one of the container groups below and adds a suffix (if set)
+#TARGET=
 
 if [[ $TARGET == "dev" ]]
 then
   # If TARGET is specified as "dev", a minimal set of containers are built.
   # Container names have the suffix "-dev".
   SUFFIX="-$TARGET"
-  CONTAINERS=("registry-server" "authz-server")
+  CONTAINERS=("registry-server" "authz-server" "registry-tools")
   PLATFORMS="linux/arm64"
 else
   # Otherwise, all containers are built.
   SUFFIX=""
-  CONTAINERS=("registry-server" "authz-server" "registry-bundle")
+  CONTAINERS=("registry-server" "authz-server" "registry-tools" "registry-bundle")
   PLATFORMS="linux/amd64,linux/arm64"
 fi
 

--- a/containers/registry-tools/Dockerfile
+++ b/containers/registry-tools/Dockerfile
@@ -1,0 +1,46 @@
+# This Dockerfile builds an image that contains the registry tool and the apg CLI.
+
+# Use the official Golang image to create a build artifact.
+# This is based on Debian and sets the GOPATH to /go.
+# https://hub.docker.com/_/golang
+FROM golang:1.15 as builder
+RUN apt-get update
+RUN apt-get install unzip
+
+# Create and change to the app directory.
+WORKDIR /app
+
+# Get protoc
+COPY ./tools/FETCH-PROTOC.sh ./
+RUN ./FETCH-PROTOC.sh
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+COPY go.* ./
+RUN go mod download
+
+# Copy local code to the container image.
+COPY . ./
+
+# Compile protos.
+RUN make protos
+
+# Build registry.
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry ./cmd/registry
+
+# Build apg.
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o apg ./cmd/apg
+
+# Use the official Alpine image for a lean production container.
+# https://hub.docker.com/_/alpine
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM alpine:3
+RUN apk update && apk upgrade
+RUN apk add --no-cache ca-certificates
+
+# Copy some commonly-needed tools into the image.
+RUN apk add --no-cache bash git
+
+# Copy binaries to the production image from the builder stage.
+COPY --from=builder /app/registry /bin/registry
+COPY --from=builder /app/apg /bin/apg


### PR DESCRIPTION
This adds a Dockerfile for building a "registry-tools" container containing the `registry` and `apg` CLIs.