### PR TITLE
Remove launch.json exception from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ rpc/*.go
 deployments/envoy/proto.pb
 
 # VSCode
-.vscode/*
-!launch.json
+.vscode/
 
 # IntelliJ
 .idea/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,0 @@
-{
-    "version": "0.2.0",
-    "configurations": []
-}


### PR DESCRIPTION
This allows custom launch configurations for each developer. Most people probably don't use custom launch configurations, but after I set one up I realized it affected the launch.json file and I didn't want to include my custom configurations with my changes.