### PR TITLE
add full text search when using Postgres

### DIFF
--- a/cmd/registry/core/gzip.go
+++ b/cmd/registry/core/gzip.go
@@ -34,7 +34,7 @@ func GZippedBytes(input []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// GUnzippedBytes uncompresses a slice of bytes.
+// GUnzippedBytes decompresses a slice of bytes.
 func GUnzippedBytes(input []byte) ([]byte, error) {
 	buf := bytes.NewBuffer(input)
 	zr, err := gzip.NewReader(buf)

--- a/google/cloud/apigee/registry/v1/registry_service.proto
+++ b/google/cloud/apigee/registry/v1/registry_service.proto
@@ -311,8 +311,8 @@ service Registry {
   rpc GetArtifactContents(GetArtifactContentsRequest) returns (google.api.HttpBody) {
     option (google.api.http) = {
       get: "/v1/{name=projects/*/artifacts/*/contents}"
-      additional_bindings: { 
-        get: "/v1/{name=projects/*/apis/*/artifacts/*/contents}" 
+      additional_bindings: {
+        get: "/v1/{name=projects/*/apis/*/artifacts/*/contents}"
       }
       additional_bindings: {
         get: "/v1/{name=projects/*/apis/*/versions/*/artifacts/*/contents}"
@@ -381,6 +381,15 @@ service Registry {
       }
     };
     option (google.api.method_signature) = "name";
+  }
+
+  // SearchAll does a full text search across all entity types
+  // (-- api-linter: core::0136::http-uri-suffix=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  rpc SearchAll(SearchRequest) returns (SearchResponse) {
+    option (google.api.http) = {
+      get: "/v1/search"
+    };
   }
 }
 
@@ -760,8 +769,8 @@ message UpdateApiSpecRequest {
   // are set in the request message (fields set to default values are ignored).
   // If a "*" is specified, all fields are updated, including fields that are
   // unspecified/default in the request.
-  google.protobuf.FieldMask update_mask = 2;  
-  
+  google.protobuf.FieldMask update_mask = 2;
+
   // If set to true, and the spec is not found, a new spec will be created.
   // In this situation, `update_mask` is ignored.
   bool allow_missing = 3;
@@ -961,4 +970,32 @@ message DeleteArtifactRequest {
       type: "registry.googleapis.com/Artifact"
     }
   ];
+}
+
+// Request message for search
+message SearchRequest {
+  // Search query string
+  string q = 1 [(google.api.field_behavior) = REQUIRED];
+  // Page size
+  int32 page_size = 2;
+  // Page token
+  string page_token = 3;
+}
+
+// Response message for search
+message SearchResponse {
+  // Search results
+  repeated SearchResult results = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Additional message, e.g. if search is not available
+  string message = 3;
+}
+
+// Response message for search
+message SearchResult {
+  // Key of matching entity
+  string key = 1;
+  // Excerpt of matching text
+  string excerpt = 2;
 }

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -233,12 +233,5 @@ func (s *RegistryServer) updateSearchForAPI(ctx context.Context, db dao.DAO, api
 	}
 
 	// Lexeme.Key is derived from Api.Key assigned during DAO.Put
-	if x := models.NewLexemeForAPI(api); x.IsEmpty() {
-		//TODO delete Lexeme
-	} else {
-		if err := db.SaveLexeme(ctx, x); err != nil {
-			return err
-		}
-	}
-	return nil
+	return db.SaveLexemes(ctx, models.NewLexemesForAPI(api))
 }

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -233,5 +233,5 @@ func (s *RegistryServer) updateSearchForAPI(ctx context.Context, db dao.DAO, api
 	}
 
 	// Lexeme.Key is derived from Api.Key assigned during DAO.Put
-	return db.SaveLexemes(ctx, models.NewLexemesForAPI(api))
+	return db.UpdateLexemes(ctx, models.NewLexemesForAPI(api))
 }

--- a/server/actions_search.go
+++ b/server/actions_search.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/dao"
+)
+
+func (s *RegistryServer) SearchAll(ctx context.Context, in *rpc.SearchRequest) (*rpc.SearchResponse, error) {
+	if !s.searchAvailable {
+		return &rpc.SearchResponse{Message: "search is not available"}, nil
+	}
+
+	client, err := s.getStorageClient(ctx)
+	if err != nil {
+		return nil, unavailableError(err)
+	}
+	defer s.releaseStorageClient(client)
+	db := dao.NewDAO(client)
+
+	rows, err := db.ListLexemes(ctx, in.GetQ())
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*rpc.SearchResult
+	for _, row := range rows.Rows {
+		results = append(results, &rpc.SearchResult{
+			Key:     row.Key,
+			Excerpt: row.Raw,
+		})
+	}
+	return &rpc.SearchResponse{
+		Results:       results,
+		NextPageToken: "",
+	}, nil
+}

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -360,5 +360,5 @@ func (s *RegistryServer) updateSearchForSpec(ctx context.Context, db dao.DAO, sp
 	if err != nil {
 		return err
 	}
-	return db.SaveLexemes(ctx, lexemes)
+	return db.UpdateLexemes(ctx, lexemes)
 }

--- a/server/dao/lexemes.go
+++ b/server/dao/lexemes.go
@@ -38,10 +38,12 @@ func (s *LexemeRows) Append(rows *sql.Rows) error {
 	return nil
 }
 
-func (d *DAO) SaveLexemes(ctx context.Context, lexemes []*models.Lexeme) error {
+func (d *DAO) UpdateLexemes(ctx context.Context, lexemes []*models.Lexeme) error {
 	for _, x := range lexemes {
 		if x.IsEmpty() {
-			//TODO delete Lexeme
+			if err := d.DeleteLexeme(ctx, x); err != nil {
+				return err
+			}
 		} else {
 			if err := d.SaveLexeme(ctx, x); err != nil {
 				return err
@@ -51,8 +53,16 @@ func (d *DAO) SaveLexemes(ctx context.Context, lexemes []*models.Lexeme) error {
 	return nil
 }
 
+func (d *DAO) DeleteLexeme(ctx context.Context, lexeme *models.Lexeme) error {
+	k := d.NewKey(models.LexemeEntityName, lexeme.Key)
+	if err := d.Delete(ctx, k); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	return nil
+}
+
 func (d *DAO) SaveLexeme(ctx context.Context, lexeme *models.Lexeme) error {
-	k := d.NewKey(string(lexeme.Field), lexeme.Key)
+	k := d.NewKey(models.LexemeEntityName, lexeme.Key)
 	if _, err := d.Put(ctx, k, lexeme); err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}

--- a/server/dao/lexemes.go
+++ b/server/dao/lexemes.go
@@ -38,8 +38,21 @@ func (s *LexemeRows) Append(rows *sql.Rows) error {
 	return nil
 }
 
+func (d *DAO) SaveLexemes(ctx context.Context, lexemes []*models.Lexeme) error {
+	for _, x := range lexemes {
+		if x.IsEmpty() {
+			//TODO delete Lexeme
+		} else {
+			if err := d.SaveLexeme(ctx, x); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (d *DAO) SaveLexeme(ctx context.Context, lexeme *models.Lexeme) error {
-	k := d.NewKey(lexeme.Kind, lexeme.Key)
+	k := d.NewKey(string(lexeme.Field), lexeme.Key)
 	if _, err := d.Put(ctx, k, lexeme); err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
@@ -58,7 +71,7 @@ FROM (
     vector @@ q
   ORDER BY
     rank DESC
-) AS subquery_because_ts_headline_is_expensive
+) AS subquery_because_ts_headline_is_expensive_and_subquery_needs_a_name
 `
 
 func (d *DAO) ListLexemes(ctx context.Context, query string) (*LexemeRows, error) {

--- a/server/dao/lexemes.go
+++ b/server/dao/lexemes.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dao
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/apigee/registry/server/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type LexemeRows struct {
+	Rows []models.Lexeme
+}
+
+func (s *LexemeRows) Append(rows *sql.Rows) error {
+	for rows.Next() {
+		var row models.Lexeme
+		if err := rows.Scan(&row.Key, &row.Raw); err != nil {
+			return err
+		}
+		s.Rows = append(s.Rows, row)
+	}
+	return nil
+}
+
+func (d *DAO) SaveLexeme(ctx context.Context, lexeme *models.Lexeme) error {
+	k := d.NewKey(lexeme.Kind, lexeme.Key)
+	if _, err := d.Put(ctx, k, lexeme); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	return nil
+}
+
+const textSearchQuery = `
+SELECT
+  key, ts_headline(raw, q) as excerpt
+FROM (
+  SELECT
+    key, raw, ts_rank(vector, q) as rank, q
+  FROM
+    lexemes, plainto_tsquery(?) q
+  WHERE
+    vector @@ q
+  ORDER BY
+    rank DESC
+) AS subquery_because_ts_headline_is_expensive
+`
+
+func (d *DAO) ListLexemes(ctx context.Context, query string) (*LexemeRows, error) {
+	var rows LexemeRows
+  if err := d.Raw(ctx, &rows, textSearchQuery, query); err != nil {
+  	return nil, err
+	}
+	return &rows, nil
+}

--- a/server/gorm/client.go
+++ b/server/gorm/client.go
@@ -236,7 +236,7 @@ func (c *Client) Put(ctx context.Context, k storage.Key, v interface{}) (storage
 	case *models.Artifact:
 		r.Key = k.(*Key).Name
 	case *models.Lexeme:
-		r.Key = k.String()
+		r.Key = k.(*Key).Name
 	}
 	c.db.Transaction(
 		func(tx *gorm.DB) error {

--- a/server/models/api.go
+++ b/server/models/api.go
@@ -15,10 +15,12 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
+	"github.com/apigee/registry/server/storage"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -151,4 +153,21 @@ func (api *Api) Update(message *rpc.Api, mask *fieldmaskpb.FieldMask) error {
 // LabelsMap returns a map representation of stored labels.
 func (api *Api) LabelsMap() (map[string]string, error) {
 	return mapForBytes(api.Labels)
+}
+
+func NewLexemesForAPI(api *Api) []*Lexeme {
+	return []*Lexeme {
+		newLexemeForAPIField(api, fieldDisplayName, weightA, api.DisplayName),
+		newLexemeForAPIField(api, fieldDescription, weightC, api.Description),
+	}
+}
+
+func newLexemeForAPIField(api *Api, f field, w weight, text string) *Lexeme {
+	return (&Lexeme{
+		Key:       fmt.Sprintf("%s#%s", api.Key, f),
+		Kind:      storage.ApiEntityName,
+		Field:     f,
+		ProjectID: api.ProjectID,
+		Vector:    TSVector{rawText: text, weight: w},
+	}).escape()
 }

--- a/server/models/lexeme.go
+++ b/server/models/lexeme.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apigee/registry/server/storage"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type weight string
+
+const (
+	weightA weight = "A"
+	weightB weight = "B"
+	weightC weight = "C"
+	weightD weight = "D"
+)
+
+type Lexeme struct {
+	Key       string `gorm:"primaryKey"`
+	Kind      string
+	ProjectID string
+	Vector    TSVector
+	Raw       string // stores raw text for excerpting; has excerpt from search result
+}
+
+func (x Lexeme) IsEmpty() bool {
+	return x.Vector.rawText == ""
+}
+
+func NewLexemeForAPI(api *Api) *Lexeme {
+	text := api.Description
+	return &Lexeme{
+		Key:       api.Key,
+		Kind:      storage.ApiEntityName,
+		ProjectID: api.ProjectID,
+		Vector:    TSVector{rawText: text, weight: weightB},
+		Raw:       text,
+	}
+}
+
+type TSVector struct {
+	rawText string
+	weight  weight
+}
+
+func (t TSVector) GormDataType() string {
+	return "tsvector"
+}
+
+func (t TSVector) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
+	w := t.weight
+	if w == "" {
+		w = weightD
+	}
+	return clause.Expr{
+		SQL:  "setweight(to_tsvector(?), ?)",
+		Vars: []interface{}{t.rawText, w},
+	}
+}
+
+// Scan implements the sql.Scanner interface
+func (t *TSVector) Scan(v interface{}) error {
+	t.rawText = fmt.Sprintf("%+v", v)
+	return nil
+}

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -397,7 +397,7 @@ func appendAllDiscoveryMethods(list []*Lexeme, base string, spec *Spec, methods 
 	for _, m := range methods.GetAdditionalProperties() {
 		path := base + m.GetName()
 		description := m.GetValue().GetDescription()
-		list = append(list, newLexemeForSpecPath(spec, fieldMethods, weightC, path, description))
+		list = append(list, newLexemeForSpecPath(spec, fieldMethods, weightB, path, description))
 	}
 	return list
 }

--- a/server/server.go
+++ b/server/server.go
@@ -65,9 +65,10 @@ type RegistryServer struct {
 	enableNotifications bool   // configured
 	logging             string // configured
 
-	projectID      string // computed
-	weTrustTheSort bool   // computed
-	loggingLevel   int    // computed
+	projectID       string // computed
+	weTrustTheSort  bool   // computed
+	searchAvailable bool   // computed
+	loggingLevel    int    // computed
 }
 
 func newRegistryServer(config *Config) *RegistryServer {
@@ -76,6 +77,7 @@ func newRegistryServer(config *Config) *RegistryServer {
 		s.database = config.Database
 		s.dbConfig = config.DBConfig
 		s.enableNotifications = config.Notify
+		s.searchAvailable = config.Database == "postgres"
 		switch strings.ToUpper(config.Log) {
 		case "FATAL":
 			s.loggingLevel = loggingFatal

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/gorm"
+	"github.com/apigee/registry/server/models"
 	"github.com/apigee/registry/server/storage"
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
@@ -45,6 +46,10 @@ type Config struct {
 	DBConfig string `yaml:"dbconfig"`
 	Notify   bool   `yaml:"notify"`
 	Log      string `yaml:"log"`
+}
+
+func (c *Config) IsSearchAvailable() bool {
+	return c != nil && c.Database == "postgres"
 }
 
 const (
@@ -77,7 +82,10 @@ func newRegistryServer(config *Config) *RegistryServer {
 		s.database = config.Database
 		s.dbConfig = config.DBConfig
 		s.enableNotifications = config.Notify
-		s.searchAvailable = config.Database == "postgres"
+		if config.IsSearchAvailable() {
+			models.EnableLexemeStorage()
+			s.searchAvailable = true
+		}
 		switch strings.ToUpper(config.Log) {
 		case "FATAL":
 			s.loggingLevel = loggingFatal

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/apigee/registry/server/names"
 )
@@ -43,6 +44,7 @@ type Client interface {
 	Get(ctx context.Context, k Key, v interface{}) error
 	Put(ctx context.Context, k Key, v interface{}) (Key, error)
 	Delete(ctx context.Context, k Key) error
+	Raw(ctx context.Context, target RawRows, sql string, values ...interface{}) error
 	Run(ctx context.Context, q Query) Iterator
 
 	IsNotFound(err error) bool
@@ -72,4 +74,8 @@ type Query interface {
 
 type Iterator interface {
 	Next(interface{}) (Key, error)
+}
+
+type RawRows interface {
+	Append(rows *sql.Rows) error
 }


### PR DESCRIPTION
Search is primarily on descriptions for Apis and Discovery specs (including parameters, nested resource methods, and schemas including enums).

Plain text query returns matching keys with excerpt

    apg registry search-all --q "draft mode"
