### PR TITLE
update authz-server to Envoy v3 xDS API

### DIFF
--- a/cmd/authz-server/authz-client/main.go
+++ b/cmd/authz-server/authz-client/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"time"
 
-	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"google.golang.org/grpc"
 )
 

--- a/cmd/authz-server/main.go
+++ b/cmd/authz-server/main.go
@@ -40,9 +40,9 @@ import (
 
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 
-	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
-	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/googleapis/google/rpc"
 )
 

--- a/deployments/envoy/envoy.yaml
+++ b/deployments/envoy/envoy.yaml
@@ -52,6 +52,7 @@ static_resources:
                         envoy_grpc:
                           cluster_name: authz-server
                         timeout: 0.5s
+                      transport_api_version: V3
                   - name: envoy.filters.http.grpc_json_transcoder
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder


### PR DESCRIPTION
v2 support dropped in Envoy 1.18.0