### PR TITLE
Bug Fix: return error from GetBytesSpecs in compute-lint.go

### DIFF
--- a/cmd/registry/cmd/compute-lint.go
+++ b/cmd/registry/cmd/compute-lint.go
@@ -99,7 +99,7 @@ func (task *computeLintTask) Run() error {
 	}
 	data, err := core.GetBytesForSpec(task.ctx, task.client, spec)
 	if err != nil {
-		return nil
+		return err
 	}
 	var relation string
 	var lint *rpc.Lint


### PR DESCRIPTION
This is a small fix to return error in one of the cases for `compute-lint` command. 

I am not aware of any specific reason for why this was not done before, so assuming this is probably a code bug. I faced debugging issues while performing some tests. The command would return with no message and not display if there was an error or the it went through.