### PR TITLE
Remove verbosity flag from Makefile test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ protos:
 
 test:
 	go clean -testcache
-	go test -v ./...
+	go test ./...
 
 clean:
 	rm -rf \


### PR DESCRIPTION
Printing log and test pass information makes it difficult to find test
failures now that we have a large suite of tests. Verbosity is rarely
useful in running tests, but can still be achieved manually if desired.