### PR TITLE
Experimenting with server test setup (for discussion only)

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,15 +15,65 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"io/ioutil"
 	"testing"
+
+	"github.com/apigee/registry/rpc"
 )
+
+var defaultServer *RegistryServer
+var dname string
+
+func init() {
+	var err error
+	dname, err = ioutil.TempDir("", "testdb-")
+	if err != nil {
+		panic(err)
+	}
+
+	defaultServer = &RegistryServer{
+		// to allow the server tests to run with Postgres
+		// (and other backends including CloudSQL Postgres),
+		// these can be set using the environment variables
+		// that are defined in config/registry.yaml and
+		// (if undefined), default to the following values:
+		database:     "sqlite3",
+		dbConfig:     fmt.Sprintf("%s/registry.db", dname),
+		loggingLevel: loggingError,
+	}
+}
+
+func deleteAllProjects(s *RegistryServer) {
+	ctx := context.Background()
+	for {
+		req := &rpc.ListProjectsRequest{PageSize: 1}
+		rsp, err := s.ListProjects(ctx, req)
+		if err != nil {
+			panic(err)
+		}
+		if len(rsp.Projects) > 0 {
+			req := &rpc.DeleteProjectRequest{
+				Name: rsp.Projects[0].Name,
+			}
+			_, err := s.DeleteProject(ctx, req)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			break
+		}
+	}
+}
 
 func defaultTestServer(t *testing.T) *RegistryServer {
 	t.Helper()
-	return &RegistryServer{
-		database:     "sqlite3",
-		dbConfig:     fmt.Sprintf("%s/registry.db", t.TempDir()),
-		loggingLevel: loggingError,
-	}
+	// if we comment out both of the following lines, tests fail
+	// because tests leave state behind when they finish
+	//os.Remove(fmt.Sprintf("%s/registry.db", dname))
+	deleteAllProjects(defaultServer)
+	// ideally (?) tests would clean up after themselves
+	// but the above could also be done in common teardown code
+	return defaultServer
 }


### PR DESCRIPTION
*Not for merging*

While playing around with the helper code in server_test.go, I found/confirmed that tests run sequentially and can share a common database if we clean up between tests, either by deleting the sqlite database file or by deleting all of the projects in the test database. If we maintain this discipline, it would be easy to test against a Postgres database (tests wouldn't require CREATE DATABASE access) and it probably also wouldn't be hard to write a proxy server that sent requests to a remote server. Let's discuss here or in #206