### PR TITLE
Remove retry on unknown errors

### DIFF
--- a/gapic/grpc_service_config.json
+++ b/gapic/grpc_service_config.json
@@ -12,7 +12,6 @@
           "maxBackoff": "10s",
           "backoffMultiplier": 1.3,
           "retryableStatusCodes": [
-            "UNKNOWN",
             "UNAVAILABLE"
           ]
         }


### PR DESCRIPTION
Errors that don't have a specified status code are considered "unknown"
and shouldn't be retried because we don't have reason to believe they
will succeed in future attempts. By retrying until timeout we lose the
information provided by the unknown error, and instead see the result of
a timeout.