### PR TITLE
Require custom IDs on resource creation

### DIFF
--- a/cmd/registry/cmd/export-csv_test.go
+++ b/cmd/registry/cmd/export-csv_test.go
@@ -35,14 +35,23 @@ func TestExportCSV(t *testing.T) {
 	}
 
 	const (
+		projectID = "export-csv-test-project"
 		apiID     = "my-api"
 		versionID = "v1"
 		specID    = "my-spec"
 	)
 
 	// Setup
+	err = client.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+		Name: "projects/" + projectID,
+	})
+	if err != nil {
+		t.Fatalf("Setup: Failed to delete project: %s", err)
+	}
+
 	project, err := client.CreateProject(ctx, &rpc.CreateProjectRequest{
-		Project: &rpc.Project{},
+		ProjectId: projectID,
+		Project:   &rpc.Project{},
 	})
 	if err != nil {
 		t.Fatalf("Setup: Failed to create project: %s", err)

--- a/cmd/registry/cmd/export-csv_test.go
+++ b/cmd/registry/cmd/export-csv_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/apigee/registry/rpc"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestExportCSV(t *testing.T) {
@@ -45,8 +47,8 @@ func TestExportCSV(t *testing.T) {
 	err = client.DeleteProject(ctx, &rpc.DeleteProjectRequest{
 		Name: "projects/" + projectID,
 	})
-	if err != nil {
-		t.Fatalf("Setup: Failed to delete project: %s", err)
+	if err != nil && status.Code(err) != codes.NotFound {
+		t.Fatalf("Setup: Failed to delete test project: %s", err)
 	}
 
 	project, err := client.CreateProject(ctx, &rpc.CreateProjectRequest{

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -49,10 +49,6 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 	}
 
 	name := parent.Api(req.GetApiId())
-	if name.ApiID == "" {
-		name.ApiID = names.GenerateID()
-	}
-
 	if _, err := db.GetApi(ctx, name); err == nil {
 		return nil, alreadyExistsError(fmt.Errorf("API %q already exists", name))
 	} else if !isNotFound(err) {

--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -63,11 +63,7 @@ func (s *RegistryServer) CreateArtifact(ctx context.Context, req *rpc.CreateArti
 		return nil, invalidArgumentError(err)
 	}
 
-	name := parent.Artifact(names.GenerateID())
-	if req.GetArtifactId() != "" {
-		name = parent.Artifact(req.GetArtifactId())
-	}
-
+	name := parent.Artifact(req.GetArtifactId())
 	if _, err := db.GetArtifact(ctx, name); err == nil {
 		return nil, alreadyExistsError(fmt.Errorf("artifact %q already exists", name))
 	} else if !isNotFound(err) {

--- a/server/actions_artifacts_test.go
+++ b/server/actions_artifacts_test.go
@@ -32,21 +32,6 @@ import (
 var (
 	// Example artifact contents for a JSON artifact.
 	artifactContents = []byte(`{"contents": "foo"}`)
-	// Basic artifact view does not include contents.
-	basicArtifact = &rpc.Artifact{
-		Name:      "projects/my-project/apis/my-api/versions/v1/artifacts/my-artifact",
-		MimeType:  "application/json",
-		SizeBytes: int32(len(artifactContents)),
-		Hash:      sha256hash(artifactContents),
-	}
-	// Full artifact view includes contents.
-	fullArtifact = &rpc.Artifact{
-		Name:      "projects/my-project/apis/my-api/versions/v1/artifacts/my-artifact",
-		MimeType:  "application/json",
-		SizeBytes: int32(len(artifactContents)),
-		Hash:      sha256hash(artifactContents),
-		Contents:  artifactContents,
-	}
 )
 
 func seedArtifacts(ctx context.Context, t *testing.T, s *RegistryServer, artifacts ...*rpc.Artifact) {
@@ -96,33 +81,29 @@ func seedArtifacts(ctx context.Context, t *testing.T, s *RegistryServer, artifac
 
 func TestCreateArtifact(t *testing.T) {
 	tests := []struct {
-		desc      string
-		seed      *rpc.ApiVersion
-		req       *rpc.CreateArtifactRequest
-		want      *rpc.Artifact
-		extraOpts cmp.Option
+		desc string
+		seed *rpc.Project
+		req  *rpc.CreateArtifactRequest
+		want *rpc.Artifact
 	}{
 		{
-			desc: "populated resource with default parameters",
-			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			desc: "fully populated resource",
+			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateArtifactRequest{
-				Parent:   "projects/my-project/apis/my-api/versions/v1",
-				Artifact: fullArtifact,
-			},
-			want: basicArtifact,
-			// Name field is generated.
-			extraOpts: protocmp.IgnoreFields(new(rpc.Artifact), "name"),
-		},
-		{
-			desc: "custom identifier",
-			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
-			req: &rpc.CreateArtifactRequest{
-				Parent:     "projects/my-project/apis/my-api/versions/v1",
+				Parent:     "projects/my-project",
 				ArtifactId: "my-artifact",
-				Artifact:   &rpc.Artifact{},
+				Artifact: &rpc.Artifact{
+					MimeType:  "application/json",
+					SizeBytes: int32(len(artifactContents)),
+					Hash:      sha256hash(artifactContents),
+					Contents:  artifactContents,
+				},
 			},
 			want: &rpc.Artifact{
-				Name: "projects/my-project/apis/my-api/versions/v1/artifacts/my-artifact",
+				Name:      "projects/my-project/artifacts/my-artifact",
+				MimeType:  "application/json",
+				SizeBytes: int32(len(artifactContents)),
+				Hash:      sha256hash(artifactContents),
 			},
 		},
 	}
@@ -131,7 +112,7 @@ func TestCreateArtifact(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			ctx := context.Background()
 			server := defaultTestServer(t)
-			seedVersions(ctx, t, server, test.seed)
+			seedProjects(ctx, t, server, test.seed)
 
 			created, err := server.CreateArtifact(ctx, test.req)
 			if err != nil {
@@ -141,15 +122,10 @@ func TestCreateArtifact(t *testing.T) {
 			opts := cmp.Options{
 				protocmp.Transform(),
 				protocmp.IgnoreFields(new(rpc.Artifact), "create_time", "update_time"),
-				test.extraOpts,
 			}
 
 			if !cmp.Equal(test.want, created, opts) {
 				t.Errorf("CreateArtifact(%+v) returned unexpected diff (-want +got):\n%s", test.req, cmp.Diff(test.want, created, opts))
-			}
-
-			if !strings.HasPrefix(created.GetName(), test.req.GetParent()+"/artifacts/") {
-				t.Errorf("CreateArtifact(%+v) returned unexpected name %q, expected collection prefix", test.req, created.GetName())
 			}
 
 			if created.CreateTime == nil && created.UpdateTime == nil {
@@ -188,8 +164,9 @@ func TestCreateArtifactResponseCodes(t *testing.T) {
 			desc: "parent not found",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateArtifactRequest{
-				Parent:   "projects/other-project",
-				Artifact: fullArtifact,
+				Parent:     "projects/other-project",
+				ArtifactId: "valid-id",
+				Artifact:   &rpc.Artifact{},
 			},
 			want: codes.NotFound,
 		},
@@ -197,8 +174,19 @@ func TestCreateArtifactResponseCodes(t *testing.T) {
 			desc: "missing resource body",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateArtifactRequest{
-				Parent:   "projects/my-project",
-				Artifact: nil,
+				Parent:     "projects/my-project",
+				ArtifactId: "valid-id",
+				Artifact:   nil,
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			desc: "missing custom identifier",
+			seed: &rpc.Project{Name: "projects/my-project"},
+			req: &rpc.CreateArtifactRequest{
+				Parent:     "projects/my-project",
+				ArtifactId: "",
+				Artifact:   &rpc.Artifact{},
 			},
 			want: codes.InvalidArgument,
 		},

--- a/server/actions_projects.go
+++ b/server/actions_projects.go
@@ -39,10 +39,6 @@ func (s *RegistryServer) CreateProject(ctx context.Context, req *rpc.CreateProje
 	}
 
 	name := names.Project{ProjectID: req.GetProjectId()}
-	if name.ProjectID == "" {
-		name.ProjectID = names.GenerateID()
-	}
-
 	if _, err := db.GetProject(ctx, name); err == nil {
 		return nil, alreadyExistsError(fmt.Errorf("project %q already exists", name))
 	} else if !isNotFound(err) {

--- a/server/actions_spec_revisions_test.go
+++ b/server/actions_spec_revisions_test.go
@@ -287,8 +287,9 @@ func TestListApiSpecRevisions(t *testing.T) {
 	})
 
 	createReq := &rpc.CreateApiSpecRequest{
-		Parent:  "projects/my-project/apis/my-api/versions/v1",
-		ApiSpec: &rpc.ApiSpec{},
+		Parent:    "projects/my-project/apis/my-api/versions/v1",
+		ApiSpecId: "my-spec",
+		ApiSpec:   &rpc.ApiSpec{},
 	}
 
 	firstRevision, err := server.CreateApiSpec(ctx, createReq)
@@ -400,7 +401,8 @@ func TestUpdateApiSpecRevisions(t *testing.T) {
 	})
 
 	createReq := &rpc.CreateApiSpecRequest{
-		Parent: "projects/my-project/apis/my-api/versions/v1",
+		Parent:    "projects/my-project/apis/my-api/versions/v1",
+		ApiSpecId: "my-spec",
 		ApiSpec: &rpc.ApiSpec{
 			Description: "Empty First Revision",
 		},

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -44,12 +44,7 @@ func (s *RegistryServer) CreateApiSpec(ctx context.Context, req *rpc.CreateApiSp
 		return nil, invalidArgumentError(fmt.Errorf("invalid api_spec %+v: body must be provided", req.GetApiSpec()))
 	}
 
-	name := parent.Spec(req.GetApiSpecId())
-	if name.SpecID == "" {
-		name.SpecID = names.GenerateID()
-	}
-
-	return s.createSpec(ctx, name, req.GetApiSpec())
+	return s.createSpec(ctx, parent.Spec(req.GetApiSpecId()), req.GetApiSpec())
 }
 
 func (s *RegistryServer) createSpec(ctx context.Context, name names.Spec, body *rpc.ApiSpec) (*rpc.ApiSpec, error) {

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -49,10 +49,6 @@ func (s *RegistryServer) CreateApiVersion(ctx context.Context, req *rpc.CreateAp
 	}
 
 	name := parent.Version(req.GetApiVersionId())
-	if name.VersionID == "" {
-		name.VersionID = names.GenerateID()
-	}
-
 	if _, err := db.GetVersion(ctx, name); err == nil {
 		return nil, alreadyExistsError(fmt.Errorf("API version %q already exists", name))
 	} else if !isNotFound(err) {


### PR DESCRIPTION
Fixes #70 by removing the feature entirely. If we don't want to remove the feature, much of this PR is still useful. I think it's a good idea for us to prefer using fixed IDs in our tests so we have the flexibility of removing generated IDs in the future.