### PR TITLE
Refactor cobra commands into functional constructors

### DIFF
--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	var (
 		filter    string
 		overwrite bool
@@ -40,7 +40,6 @@ func Command() *cobra.Command {
 		Short: "Annotate resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())

--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -30,21 +30,16 @@ import (
 )
 
 func Command() *cobra.Command {
+	var (
+		filter    string
+		overwrite bool
+	)
+
 	cmd := &cobra.Command{
 		Use:   "annotate RESOURCE KEY_1=VAL_1 ... KEY_N=VAL_N",
 		Short: "Annotate resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			flagset := cmd.LocalFlags()
-			filter, err := flagset.GetString("filter")
-			if err != nil {
-				log.Fatalf("Failed to get filter string from flags: %s", err)
-			}
-			overwrite, err := flagset.GetBool("overwrite")
-			if err != nil {
-				log.Fatalf("Failed to get overwrite boolean from flags: %s", err)
-			}
-
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -85,8 +80,9 @@ func Command() *cobra.Command {
 			core.WaitGroup().Wait()
 		},
 	}
-	cmd.Flags().String("filter", "", "Filter selected resources")
-	cmd.Flags().Bool("overwrite", false, "Overwrite existing annotations")
+
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing annotations")
 	return cmd
 }
 

--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -29,13 +29,10 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-const annotateFieldName = "annotations"
-const annotateCommandName = "annotate"
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s RESOURCE KEY_1=VAL_1 ... KEY_N=VAL_N", annotateCommandName),
-		Short: fmt.Sprintf("%s resources in the API Registry", strings.Title(annotateCommandName)),
+		Use:   "annotate RESOURCE KEY_1=VAL_1 ... KEY_N=VAL_N",
+		Short: "Annotate resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			flagset := cmd.LocalFlags()
@@ -176,7 +173,7 @@ type annotateApiTask struct {
 }
 
 func (task *annotateApiTask) String() string {
-	return annotateCommandName + " " + task.api.Name
+	return "annotate " + task.api.Name
 }
 
 func (task *annotateApiTask) Run(ctx context.Context) error {
@@ -189,7 +186,7 @@ func (task *annotateApiTask) Run(ctx context.Context) error {
 		&rpc.UpdateApiRequest{
 			Api: task.api,
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{annotateFieldName},
+				Paths: []string{"annotations"},
 			},
 		})
 	return err
@@ -202,7 +199,7 @@ type annotateVersionTask struct {
 }
 
 func (task *annotateVersionTask) String() string {
-	return annotateCommandName + " " + task.version.Name
+	return "annotate " + task.version.Name
 }
 
 func (task *annotateVersionTask) Run(ctx context.Context) error {
@@ -215,7 +212,7 @@ func (task *annotateVersionTask) Run(ctx context.Context) error {
 		&rpc.UpdateApiVersionRequest{
 			ApiVersion: task.version,
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{annotateFieldName},
+				Paths: []string{"annotations"},
 			},
 		})
 	return err
@@ -228,7 +225,7 @@ type annotateSpecTask struct {
 }
 
 func (task *annotateSpecTask) String() string {
-	return annotateCommandName + " " + task.spec.Name
+	return "annotate " + task.spec.Name
 }
 
 func (task *annotateSpecTask) Run(ctx context.Context) error {
@@ -241,7 +238,7 @@ func (task *annotateSpecTask) Run(ctx context.Context) error {
 		&rpc.UpdateApiSpecRequest{
 			ApiSpec: task.spec,
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{annotateFieldName},
+				Paths: []string{"annotations"},
 			},
 		})
 	return err

--- a/cmd/registry/cmd/annotate/annotate_test.go
+++ b/cmd/registry/cmd/annotate/annotate_test.go
@@ -110,7 +110,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for APIs.
 	for _, tc := range testCases {
-		cmd := Command()
+		cmd := Command(ctx)
 		cmd.SetArgs(append([]string{apiName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -128,7 +128,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for versions.
 	for _, tc := range testCases {
-		cmd := Command()
+		cmd := Command(ctx)
 		cmd.SetArgs(append([]string{versionName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -146,7 +146,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for specs.
 	for _, tc := range testCases {
-		cmd := Command()
+		cmd := Command(ctx)
 		cmd.SetArgs(append([]string{specName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)

--- a/cmd/registry/cmd/annotate/annotate_test.go
+++ b/cmd/registry/cmd/annotate/annotate_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestAnnotate(t *testing.T) {
-	var err error
-
 	const (
 		projectID   = "annotate-test"
 		projectName = "projects/" + projectID

--- a/cmd/registry/cmd/compute/bleve.go
+++ b/cmd/registry/cmd/compute/bleve.go
@@ -25,10 +25,11 @@ import (
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
 	"github.com/blevesearch/bleve"
-	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
-	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
+
+	oas2 "github.com/googleapis/gnostic/openapiv2"
+	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
 const (
@@ -103,7 +104,7 @@ func (task *indexSpecTask) Run(ctx context.Context) error {
 	}
 	var message proto.Message
 	if core.IsOpenAPIv2(spec.GetMimeType()) {
-		document, err := openapi_v2.ParseDocument(data)
+		document, err := oas2.ParseDocument(data)
 		if err != nil {
 			return fmt.Errorf("errors parsing %s", name)
 		}
@@ -116,7 +117,7 @@ func (task *indexSpecTask) Run(ctx context.Context) error {
 		document.SecurityDefinitions = nil
 		message = document
 	} else if core.IsOpenAPIv3(spec.GetMimeType()) {
-		document, err := openapi_v3.ParseDocument(data)
+		document, err := oas3.ParseDocument(data)
 		if err != nil {
 			return fmt.Errorf("errors parsing %s", name)
 		}

--- a/cmd/registry/cmd/compute/bleve.go
+++ b/cmd/registry/cmd/compute/bleve.go
@@ -32,10 +32,6 @@ import (
 	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
-const (
-	bleveDir = "registry.bleve"
-)
-
 var bleveFilter string
 var bleveMutex sync.Mutex
 
@@ -134,6 +130,7 @@ func (task *indexSpecTask) Run(ctx context.Context) error {
 	bleveMutex.Lock()
 	defer bleveMutex.Unlock()
 	// Open the index, creating a new one if necessary.
+	const bleveDir = "registry.bleve"
 	index, err := bleve.Open(bleveDir)
 	if err != nil {
 		mapping := bleve.NewIndexMapping()

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -23,12 +23,13 @@ import (
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	discovery "github.com/googleapis/gnostic/discovery"
-	metrics "github.com/googleapis/gnostic/metrics"
-	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
-	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
+
+	discovery "github.com/googleapis/gnostic/discovery"
+	metrics "github.com/googleapis/gnostic/metrics"
+	oas2 "github.com/googleapis/gnostic/openapiv2"
+	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
 var computeComplexityCmd = &cobra.Command{
@@ -92,7 +93,7 @@ func (task *computeComplexityTask) Run(ctx context.Context) error {
 		if err != nil {
 			return nil
 		}
-		document, err := openapi_v2.ParseDocument(data)
+		document, err := oas2.ParseDocument(data)
 		if err != nil {
 			return fmt.Errorf("invalid OpenAPI: %s", spec.Name)
 		}
@@ -102,7 +103,7 @@ func (task *computeComplexityTask) Run(ctx context.Context) error {
 		if err != nil {
 			return nil
 		}
-		document, err := openapi_v3.ParseDocument(data)
+		document, err := oas3.ParseDocument(data)
 		if err != nil {
 			return fmt.Errorf("invalid OpenAPI: %s", spec.Name)
 		}
@@ -130,7 +131,7 @@ func (task *computeComplexityTask) Run(ctx context.Context) error {
 		return fmt.Errorf("we don't know how to summarize %s", spec.Name)
 	}
 	subject := spec.GetName()
-	messageData, err := proto.Marshal(complexity)
+	messageData, _ := proto.Marshal(complexity)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("gnostic.metrics.Complexity"),

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -32,7 +32,7 @@ import (
 	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
-func complexityCommand() *cobra.Command {
+func complexityCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "complexity",
 		Short: "Compute complexity metrics of API specs",
@@ -43,7 +43,6 @@ func complexityCommand() *cobra.Command {
 				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
 
-			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -38,6 +38,11 @@ func complexityCommand() *cobra.Command {
 		Short: "Compute complexity metrics of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -54,7 +59,7 @@ func complexityCommand() *cobra.Command {
 			name := args[0]
 			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
 				// Iterate through a collection of specs and summarize each.
-				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, m, filter, func(spec *rpc.ApiSpec) {
 					taskQueue <- &computeComplexityTask{
 						client:   client,
 						specName: spec.Name,

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -18,8 +18,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var computeFilter string
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compute",
@@ -36,7 +34,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(searchIndexCommand())
 	cmd.AddCommand(vocabularyCommand())
 
-	// TODO: Remove the global state.
-	cmd.PersistentFlags().StringVar(&computeFilter, "filter", "", "filter compute arguments")
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	cmd.PersistentFlags().String("something", "", "desc")
 	return cmd
 }

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -26,15 +26,15 @@ func Command() *cobra.Command {
 		Short: "Compute properties of resources in the API Registry",
 	}
 
-	cmd.AddCommand(computeBleveCmd)
-	cmd.AddCommand(computeComplexityCmd)
-	cmd.AddCommand(computeDescriptorCmd)
-	cmd.AddCommand(computeDetailsCmd)
-	cmd.AddCommand(computeIndexCmd)
-	cmd.AddCommand(computeLintCmd)
-	cmd.AddCommand(computeLintStatsCmd)
-	cmd.AddCommand(computeReferencesCmd)
-	cmd.AddCommand(computeVocabularyCmd)
+	cmd.AddCommand(complexityCommand())
+	cmd.AddCommand(descriptorCommand())
+	cmd.AddCommand(detailsCommand())
+	cmd.AddCommand(indexCommand())
+	cmd.AddCommand(lintCommand())
+	cmd.AddCommand(lintStatsCommand())
+	cmd.AddCommand(referencesCommand())
+	cmd.AddCommand(searchIndexCommand())
+	cmd.AddCommand(vocabularyCommand())
 
 	// TODO: Remove the global state.
 	cmd.PersistentFlags().StringVar(&computeFilter, "filter", "", "filter compute arguments")

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -15,24 +15,26 @@
 package compute
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compute",
 		Short: "Compute properties of resources in the API Registry",
 	}
 
-	cmd.AddCommand(complexityCommand())
-	cmd.AddCommand(descriptorCommand())
-	cmd.AddCommand(detailsCommand())
-	cmd.AddCommand(indexCommand())
-	cmd.AddCommand(lintCommand())
-	cmd.AddCommand(lintStatsCommand())
-	cmd.AddCommand(referencesCommand())
-	cmd.AddCommand(searchIndexCommand())
-	cmd.AddCommand(vocabularyCommand())
+	cmd.AddCommand(complexityCommand(ctx))
+	cmd.AddCommand(descriptorCommand(ctx))
+	cmd.AddCommand(detailsCommand(ctx))
+	cmd.AddCommand(indexCommand(ctx))
+	cmd.AddCommand(lintCommand(ctx))
+	cmd.AddCommand(lintStatsCommand(ctx))
+	cmd.AddCommand(referencesCommand(ctx))
+	cmd.AddCommand(searchIndexCommand(ctx))
+	cmd.AddCommand(vocabularyCommand(ctx))
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	cmd.PersistentFlags().String("something", "", "desc")

--- a/cmd/registry/cmd/compute/descriptor.go
+++ b/cmd/registry/cmd/compute/descriptor.go
@@ -37,6 +37,11 @@ func descriptorCommand() *cobra.Command {
 		Short: "Compute descriptors of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -52,7 +57,7 @@ func descriptorCommand() *cobra.Command {
 			// Generate tasks.
 			name := args[0]
 			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, m, filter, func(spec *rpc.ApiSpec) {
 					taskQueue <- &computeDescriptorTask{
 						client:   client,
 						specName: spec.Name,

--- a/cmd/registry/cmd/compute/descriptor.go
+++ b/cmd/registry/cmd/compute/descriptor.go
@@ -31,7 +31,7 @@ import (
 	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
-func descriptorCommand() *cobra.Command {
+func descriptorCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "descriptor",
 		Short: "Compute descriptors of API specs",
@@ -42,7 +42,6 @@ func descriptorCommand() *cobra.Command {
 				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
 
-			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())

--- a/cmd/registry/cmd/compute/descriptor.go
+++ b/cmd/registry/cmd/compute/descriptor.go
@@ -23,11 +23,12 @@ import (
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	discovery_v1 "github.com/googleapis/gnostic/discovery"
-	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
-	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
+
+	discovery "github.com/googleapis/gnostic/discovery"
+	oas2 "github.com/googleapis/gnostic/openapiv2"
+	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
 var computeDescriptorCmd = &cobra.Command{
@@ -94,19 +95,19 @@ func (task *computeDescriptorTask) Run(ctx context.Context) error {
 	var document proto.Message
 	if core.IsOpenAPIv2(spec.GetMimeType()) {
 		typeURL = "gnostic.openapiv2.Document"
-		document, err = openapi_v2.ParseDocument(data)
+		document, err = oas2.ParseDocument(data)
 		if err != nil {
 			return err
 		}
 	} else if core.IsOpenAPIv3(spec.GetMimeType()) {
 		typeURL = "gnostic.openapiv3.Document"
-		document, err = openapi_v3.ParseDocument(data)
+		document, err = oas3.ParseDocument(data)
 		if err != nil {
 			return err
 		}
 	} else if core.IsDiscovery(spec.GetMimeType()) {
 		typeURL = "gnostic.discoveryv1.Document"
-		document, err = discovery_v1.ParseDocument(data)
+		document, err = discovery.ParseDocument(data)
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/cmd/compute/details.go
+++ b/cmd/registry/cmd/compute/details.go
@@ -24,11 +24,12 @@ import (
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	discovery_v1 "github.com/googleapis/gnostic/discovery"
-	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
-	openapi_v3 "github.com/googleapis/gnostic/openapiv3"
 	"github.com/spf13/cobra"
 	"google.golang.org/genproto/protobuf/field_mask"
+
+	discovery "github.com/googleapis/gnostic/discovery"
+	oas2 "github.com/googleapis/gnostic/openapiv2"
+	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
 var computeDetailsCmd = &cobra.Command{
@@ -102,7 +103,7 @@ func (task *computeDetailsTask) Run(ctx context.Context) error {
 		if err != nil {
 			return nil
 		}
-		document, err := openapi_v2.ParseDocument(data)
+		document, err := oas2.ParseDocument(data)
 		if document == nil && err != nil {
 			return fmt.Errorf("invalid OpenAPI v2: %s", spec.Name)
 		}
@@ -128,7 +129,7 @@ func (task *computeDetailsTask) Run(ctx context.Context) error {
 		if err != nil {
 			return nil
 		}
-		document, err := openapi_v3.ParseDocument(data)
+		document, err := oas3.ParseDocument(data)
 		if document == nil && err != nil {
 			return fmt.Errorf("invalid OpenAPI v3: %s", spec.Name)
 		}
@@ -154,7 +155,7 @@ func (task *computeDetailsTask) Run(ctx context.Context) error {
 		if err != nil {
 			return nil
 		}
-		document, err := discovery_v1.ParseDocument(data)
+		document, err := discovery.ParseDocument(data)
 		if document == nil && err != nil {
 			return fmt.Errorf("invalid Discovery document: %s", spec.Name)
 		}

--- a/cmd/registry/cmd/compute/details.go
+++ b/cmd/registry/cmd/compute/details.go
@@ -32,7 +32,7 @@ import (
 	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
-func detailsCommand() *cobra.Command {
+func detailsCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "details",
 		Short: "Compute details about APIs from information in their specs.",
@@ -43,7 +43,6 @@ func detailsCommand() *cobra.Command {
 				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
 
-			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())

--- a/cmd/registry/cmd/compute/details.go
+++ b/cmd/registry/cmd/compute/details.go
@@ -96,9 +96,8 @@ func (task *computeDetailsTask) Run(ctx context.Context) error {
 		return nil
 	}
 	spec := specs[len(specs)-1]
-	var err error
 	m = names.SpecRegexp().FindStringSubmatch(spec.Name)
-	spec, err = core.GetSpec(ctx, task.client, m, true, nil)
+	spec, err := core.GetSpec(ctx, task.client, m, true, nil)
 	if err != nil {
 		return nil
 	}

--- a/cmd/registry/cmd/compute/details.go
+++ b/cmd/registry/cmd/compute/details.go
@@ -38,6 +38,11 @@ func detailsCommand() *cobra.Command {
 		Short: "Compute details about APIs from information in their specs.",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -54,7 +59,7 @@ func detailsCommand() *cobra.Command {
 			name := args[0]
 			if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
 				// Iterate through a collection of specs and summarize each.
-				err = core.ListAPIs(ctx, client, m, computeFilter, func(api *rpc.Api) {
+				err = core.ListAPIs(ctx, client, m, filter, func(api *rpc.Api) {
 					taskQueue <- &computeDetailsTask{
 						client:  client,
 						apiName: api.Name,

--- a/cmd/registry/cmd/compute/index.go
+++ b/cmd/registry/cmd/compute/index.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func indexCommand() *cobra.Command {
+func indexCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "index",
 		Short: "Compute indexes of API specs",
@@ -38,7 +38,6 @@ func indexCommand() *cobra.Command {
 				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
 
-			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())

--- a/cmd/registry/cmd/compute/index.go
+++ b/cmd/registry/cmd/compute/index.go
@@ -96,7 +96,7 @@ func (task *computeIndexTask) Run(ctx context.Context) error {
 		return fmt.Errorf("we don't know how to compute the index of %s", spec.Name)
 	}
 	subject := spec.GetName()
-	messageData, err := proto.Marshal(index)
+	messageData, _ := proto.Marshal(index)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.Index"),

--- a/cmd/registry/cmd/compute/index.go
+++ b/cmd/registry/cmd/compute/index.go
@@ -33,6 +33,11 @@ func indexCommand() *cobra.Command {
 		Short: "Compute indexes of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -49,7 +54,7 @@ func indexCommand() *cobra.Command {
 			name := args[0]
 			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
 				// Iterate through a collection of specs and summarize each.
-				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, m, filter, func(spec *rpc.ApiSpec) {
 					taskQueue <- &computeIndexTask{
 						client:   client,
 						specName: spec.Name,

--- a/cmd/registry/cmd/compute/index.go
+++ b/cmd/registry/cmd/compute/index.go
@@ -27,40 +27,42 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var computeIndexCmd = &cobra.Command{
-	Use:   "index",
-	Short: "Compute indexes of API specs",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		// Initialize task queue.
-		taskQueue := make(chan core.Task, 1024)
-		workerCount := 64
-		for i := 0; i < workerCount; i++ {
-			core.WaitGroup().Add(1)
-			go core.Worker(ctx, taskQueue)
-		}
-		// Generate tasks.
-		name := args[0]
-		if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-			// Iterate through a collection of specs and summarize each.
-			err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
-				taskQueue <- &computeIndexTask{
-					client:   client,
-					specName: spec.Name,
-				}
-			})
+func indexCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "index",
+		Short: "Compute indexes of API specs",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			close(taskQueue)
-			core.WaitGroup().Wait()
-		}
-	},
+			// Initialize task queue.
+			taskQueue := make(chan core.Task, 1024)
+			workerCount := 64
+			for i := 0; i < workerCount; i++ {
+				core.WaitGroup().Add(1)
+				go core.Worker(ctx, taskQueue)
+			}
+			// Generate tasks.
+			name := args[0]
+			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
+				// Iterate through a collection of specs and summarize each.
+				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+					taskQueue <- &computeIndexTask{
+						client:   client,
+						specName: spec.Name,
+					}
+				})
+				if err != nil {
+					log.Fatalf("%s", err.Error())
+				}
+				close(taskQueue)
+				core.WaitGroup().Wait()
+			}
+		},
+	}
 }
 
 type computeIndexTask struct {

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func lintCommand() *cobra.Command {
+func lintCommand(ctx context.Context) *cobra.Command {
 	var linter string
 	cmd := &cobra.Command{
 		Use:   "lint",

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -128,7 +128,7 @@ func (task *computeLintTask) Run(ctx context.Context) error {
 		return fmt.Errorf("we don't know how to lint %s", spec.Name)
 	}
 	subject := spec.GetName()
-	messageData, err := proto.Marshal(lint)
+	messageData, _ := proto.Marshal(lint)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.Lint"),

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -72,7 +72,6 @@ func lintCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&linter, "linter", "", "The linter to use (aip|spectral|gnostic)")
-	cmd.MarkFlagRequired("linter")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -62,7 +62,7 @@ var computeLintStatsCmd = &cobra.Command{
 				request := rpc.GetArtifactContentsRequest{
 					Name: spec.Name + "/artifacts/" + lintRelation(linter) + "/contents",
 				}
-				contents, err := client.GetArtifactContents(ctx, &request)
+				contents, _ := client.GetArtifactContents(ctx, &request)
 				if contents == nil {
 					return // ignore missing results
 				}
@@ -82,7 +82,7 @@ var computeLintStatsCmd = &cobra.Command{
 					// store the lintstats artifact
 					subject := spec.GetName()
 					relation := lintStatsRelation(linter)
-					messageData, err := proto.Marshal(lintStats)
+					messageData, _ := proto.Marshal(lintStats)
 					artifact := &rpc.Artifact{
 						Name:     subject + "/artifacts/" + relation,
 						MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.LintStats"),
@@ -134,7 +134,7 @@ var computeLintStatsCmd = &cobra.Command{
 					// store the lintstats artifact
 					subject := project.GetName()
 					relation := lintStatsRelation(linter)
-					messageData, err := proto.Marshal(lintstats)
+					messageData, _ := proto.Marshal(lintstats)
 					artifact := &rpc.Artifact{
 						Name:     subject + "/artifacts/" + relation,
 						MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.LintStats"),

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -28,130 +28,131 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func init() {
-	computeLintStatsCmd.Flags().String("linter", "", "name of linter associated with these lintstats (aip, spectral, gnostic)")
-}
-
 func lintStatsRelation(linter string) string {
 	return "lintstats-" + linter
 }
 
-var computeLintStatsCmd = &cobra.Command{
-	Use:   "lintstats",
-	Short: "Compute summaries of linter runs",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		linter, err := cmd.LocalFlags().GetString("linter")
-		if err != nil || linter == "" {
-			log.Fatalf("Please specify a linter with the --linter flag")
-		}
+func lintStatsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lintstats",
+		Short: "Compute summaries of linter runs",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			linter, err := cmd.LocalFlags().GetString("linter")
+			if err != nil || linter == "" {
+				log.Fatalf("Please specify a linter with the --linter flag")
+			}
 
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
 
-		// Generate tasks.
-		name := args[0]
-		if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-			// Iterate through a collection of specs and evaluate each.
-			err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
-				fmt.Printf("%s\n", spec.Name)
-				// get the lint results
-				request := rpc.GetArtifactContentsRequest{
-					Name: spec.Name + "/artifacts/" + lintRelation(linter) + "/contents",
-				}
-				contents, _ := client.GetArtifactContents(ctx, &request)
-				if contents == nil {
-					return // ignore missing results
-				}
-				messageType, err := core.MessageTypeForMimeType(contents.GetContentType())
-				if err != nil || messageType != "google.cloud.apigee.registry.applications.v1alpha1.Lint" {
-					return // ignore unexpected message types
-				}
-				lint := &rpc.Lint{}
-				err = proto.Unmarshal(contents.GetData(), lint)
-				if err != nil {
-					log.Printf("%+v", err)
-					return
-				}
-				// generate the stats from the result by counting problems
-				lintStats := computeLintStats(lint)
-				{
-					// store the lintstats artifact
-					subject := spec.GetName()
-					relation := lintStatsRelation(linter)
-					messageData, _ := proto.Marshal(lintStats)
-					artifact := &rpc.Artifact{
-						Name:     subject + "/artifacts/" + relation,
-						MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.LintStats"),
-						Contents: messageData,
+			// Generate tasks.
+			name := args[0]
+			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
+				// Iterate through a collection of specs and evaluate each.
+				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+					fmt.Printf("%s\n", spec.Name)
+					// get the lint results
+					request := rpc.GetArtifactContentsRequest{
+						Name: spec.Name + "/artifacts/" + lintRelation(linter) + "/contents",
 					}
-					err = core.SetArtifact(ctx, client, artifact)
+					contents, _ := client.GetArtifactContents(ctx, &request)
+					if contents == nil {
+						return // ignore missing results
+					}
+					messageType, err := core.MessageTypeForMimeType(contents.GetContentType())
+					if err != nil || messageType != "google.cloud.apigee.registry.applications.v1alpha1.Lint" {
+						return // ignore unexpected message types
+					}
+					lint := &rpc.Lint{}
+					err = proto.Unmarshal(contents.GetData(), lint)
 					if err != nil {
 						log.Printf("%+v", err)
 						return
 					}
-				}
-			})
-			if err != nil {
-				log.Fatalf("%s", err.Error())
-			}
-		}
-		if m := names.ProjectRegexp().FindStringSubmatch(name); m != nil {
-			// Iterate through a collection of projects and evaluate each.
-			err = core.ListProjects(ctx, client, m, computeFilter, func(project *rpc.Project) {
-				// Create a top-level list of problem counts for the project
-				problemCounts := make([]*rpc.LintProblemCount, 0)
-				// get the lintstats for each spec in the project
-				pattern := project.Name + "/apis/-/versions/-/specs/-/artifacts/" + lintStatsRelation(linter)
-				if m2 := names.ArtifactRegexp().FindStringSubmatch(pattern); m2 != nil {
-					err = core.ListArtifacts(ctx, client, m2, "", true, func(artifact *rpc.Artifact) {
-						log.Printf("%+v", artifact.Name)
-						// get the lintstats artifact value
-						messageType, err := core.MessageTypeForMimeType(artifact.GetMimeType())
-						if err != nil || messageType != "google.cloud.apigee.registry.applications.v1alpha1.LintStats" {
-							return // ignore unexpected message types
+					// generate the stats from the result by counting problems
+					lintStats := computeLintStats(lint)
+					{
+						// store the lintstats artifact
+						subject := spec.GetName()
+						relation := lintStatsRelation(linter)
+						messageData, _ := proto.Marshal(lintStats)
+						artifact := &rpc.Artifact{
+							Name:     subject + "/artifacts/" + relation,
+							MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.LintStats"),
+							Contents: messageData,
 						}
-						lintstats := &rpc.LintStats{}
-						err = proto.Unmarshal(artifact.GetContents(), lintstats)
+						err = core.SetArtifact(ctx, client, artifact)
 						if err != nil {
 							log.Printf("%+v", err)
 							return
 						}
-						// merge the lintstats into the problemCounts slice
-						problemCounts = mergeLintStats(problemCounts, lintstats)
-					})
-				}
-				// sort results in decreasing order of count
-				sort.Slice(problemCounts, func(i, j int) bool {
-					return problemCounts[i].Count > problemCounts[j].Count
+					}
 				})
-				// store the summary in the lintstats artifact
-				lintstats := &rpc.LintStats{ProblemCounts: problemCounts}
-				{
-					// store the lintstats artifact
-					subject := project.GetName()
-					relation := lintStatsRelation(linter)
-					messageData, _ := proto.Marshal(lintstats)
-					artifact := &rpc.Artifact{
-						Name:     subject + "/artifacts/" + relation,
-						MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.LintStats"),
-						Contents: messageData,
-					}
-					err = core.SetArtifact(ctx, client, artifact)
-					if err != nil {
-						log.Printf("%+v", err)
-						return
-					}
+				if err != nil {
+					log.Fatalf("%s", err.Error())
 				}
-			})
-			if err != nil {
-				log.Fatalf("%s", err.Error())
 			}
-		}
-	},
+			if m := names.ProjectRegexp().FindStringSubmatch(name); m != nil {
+				// Iterate through a collection of projects and evaluate each.
+				err = core.ListProjects(ctx, client, m, computeFilter, func(project *rpc.Project) {
+					// Create a top-level list of problem counts for the project
+					problemCounts := make([]*rpc.LintProblemCount, 0)
+					// get the lintstats for each spec in the project
+					pattern := project.Name + "/apis/-/versions/-/specs/-/artifacts/" + lintStatsRelation(linter)
+					if m2 := names.ArtifactRegexp().FindStringSubmatch(pattern); m2 != nil {
+						err = core.ListArtifacts(ctx, client, m2, "", true, func(artifact *rpc.Artifact) {
+							log.Printf("%+v", artifact.Name)
+							// get the lintstats artifact value
+							messageType, err := core.MessageTypeForMimeType(artifact.GetMimeType())
+							if err != nil || messageType != "google.cloud.apigee.registry.applications.v1alpha1.LintStats" {
+								return // ignore unexpected message types
+							}
+							lintstats := &rpc.LintStats{}
+							err = proto.Unmarshal(artifact.GetContents(), lintstats)
+							if err != nil {
+								log.Printf("%+v", err)
+								return
+							}
+							// merge the lintstats into the problemCounts slice
+							problemCounts = mergeLintStats(problemCounts, lintstats)
+						})
+					}
+					// sort results in decreasing order of count
+					sort.Slice(problemCounts, func(i, j int) bool {
+						return problemCounts[i].Count > problemCounts[j].Count
+					})
+					// store the summary in the lintstats artifact
+					lintstats := &rpc.LintStats{ProblemCounts: problemCounts}
+					{
+						// store the lintstats artifact
+						subject := project.GetName()
+						relation := lintStatsRelation(linter)
+						messageData, _ := proto.Marshal(lintstats)
+						artifact := &rpc.Artifact{
+							Name:     subject + "/artifacts/" + relation,
+							MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.LintStats"),
+							Contents: messageData,
+						}
+						err = core.SetArtifact(ctx, client, artifact)
+						if err != nil {
+							log.Printf("%+v", err)
+							return
+						}
+					}
+				})
+				if err != nil {
+					log.Fatalf("%s", err.Error())
+				}
+			}
+		},
+	}
+
+	cmd.Flags().String("linter", "", "name of linter associated with these lintstats (aip, spectral, gnostic)")
+	return cmd
 }
 
 func computeLintStats(lint *rpc.Lint) *rpc.LintStats {

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -32,7 +32,7 @@ func lintStatsRelation(linter string) string {
 	return "lintstats-" + linter
 }
 
-func lintStatsCommand() *cobra.Command {
+func lintStatsCommand(ctx context.Context) *cobra.Command {
 	var linter string
 	cmd := &cobra.Command{
 		Use:   "lintstats",

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -96,7 +96,7 @@ func (task *computeReferencesTask) Run(ctx context.Context) error {
 		return fmt.Errorf("we don't know how to compute references for %s of type %s", spec.Name, spec.MimeType)
 	}
 	subject := spec.Name
-	messageData, err := proto.Marshal(references)
+	messageData, _ := proto.Marshal(references)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.References"),

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -33,6 +33,11 @@ func referencesCommand() *cobra.Command {
 		Short: "Compute references of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -49,7 +54,7 @@ func referencesCommand() *cobra.Command {
 			name := args[0]
 			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
 				// Iterate through a collection of specs and compute references for each
-				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, m, filter, func(spec *rpc.ApiSpec) {
 					taskQueue <- &computeReferencesTask{
 						client:   client,
 						specName: spec.Name,

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func referencesCommand() *cobra.Command {
+func referencesCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "references",
 		Short: "Compute references of API specs",

--- a/cmd/registry/cmd/compute/search-index.go
+++ b/cmd/registry/cmd/compute/search-index.go
@@ -34,7 +34,7 @@ import (
 
 var bleveMutex sync.Mutex
 
-func searchIndexCommand() *cobra.Command {
+func searchIndexCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "search-index",
 		Short: "Compute a local search index of specs (experimental)",

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -33,40 +33,42 @@ import (
 	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
-var computeVocabularyCmd = &cobra.Command{
-	Use:   "vocabulary",
-	Short: "Compute vocabularies of API specs",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		// Initialize task queue.
-		taskQueue := make(chan core.Task, 1024)
-		workerCount := 64
-		for i := 0; i < workerCount; i++ {
-			core.WaitGroup().Add(1)
-			go core.Worker(ctx, taskQueue)
-		}
-		// Generate tasks.
-		name := args[0]
-		if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-			// Iterate through a collection of specs and summarize each.
-			err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
-				taskQueue <- &computeVocabularyTask{
-					client:   client,
-					specName: spec.Name,
-				}
-			})
+func vocabularyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "vocabulary",
+		Short: "Compute vocabularies of API specs",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			close(taskQueue)
-			core.WaitGroup().Wait()
-		}
-	},
+			// Initialize task queue.
+			taskQueue := make(chan core.Task, 1024)
+			workerCount := 64
+			for i := 0; i < workerCount; i++ {
+				core.WaitGroup().Add(1)
+				go core.Worker(ctx, taskQueue)
+			}
+			// Generate tasks.
+			name := args[0]
+			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
+				// Iterate through a collection of specs and summarize each.
+				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+					taskQueue <- &computeVocabularyTask{
+						client:   client,
+						specName: spec.Name,
+					}
+				})
+				if err != nil {
+					log.Fatalf("%s", err.Error())
+				}
+				close(taskQueue)
+				core.WaitGroup().Wait()
+			}
+		},
+	}
 }
 
 type computeVocabularyTask struct {

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -33,7 +33,7 @@ import (
 	oas3 "github.com/googleapis/gnostic/openapiv3"
 )
 
-func vocabularyCommand() *cobra.Command {
+func vocabularyCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "vocabulary",
 		Short: "Compute vocabularies of API specs",

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -39,6 +39,11 @@ func vocabularyCommand() *cobra.Command {
 		Short: "Compute vocabularies of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -55,7 +60,7 @@ func vocabularyCommand() *cobra.Command {
 			name := args[0]
 			if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
 				// Iterate through a collection of specs and summarize each.
-				err = core.ListSpecs(ctx, client, m, computeFilter, func(spec *rpc.ApiSpec) {
+				err = core.ListSpecs(ctx, client, m, filter, func(spec *rpc.ApiSpec) {
 					taskQueue <- &computeVocabularyTask{
 						client:   client,
 						specName: spec.Name,

--- a/cmd/registry/cmd/controller/controller.go
+++ b/cmd/registry/cmd/controller/controller.go
@@ -15,16 +15,18 @@
 package controller
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controller",
 		Short: "Manage the state of the registry (experimental)",
 	}
 
-	cmd.AddCommand(updateCommand())
+	cmd.AddCommand(updateCommand(ctx))
 
 	return cmd
 }

--- a/cmd/registry/cmd/controller/controller.go
+++ b/cmd/registry/cmd/controller/controller.go
@@ -24,7 +24,7 @@ func Command() *cobra.Command {
 		Short: "Manage the state of the registry (experimental)",
 	}
 
-	cmd.AddCommand(controllerUpdateCmd)
+	cmd.AddCommand(updateCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/controller/update.go
+++ b/cmd/registry/cmd/controller/update.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func updateCommand() *cobra.Command {
+func updateCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "update FILENAME",
 		Short: "Generate a list of commands to update the registry state (experimental)",

--- a/cmd/registry/cmd/controller/update.go
+++ b/cmd/registry/cmd/controller/update.go
@@ -31,8 +31,6 @@ func updateCommand() *cobra.Command {
 		Short: "Generate a list of commands to update the registry state (experimental)",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-
 			manifestPath := args[0]
 			if manifestPath == "" {
 				log.Fatal("Please provide manifest_path")

--- a/cmd/registry/cmd/controller/update_test.go
+++ b/cmd/registry/cmd/controller/update_test.go
@@ -185,6 +185,7 @@ func TestControllerUpdate(t *testing.T) {
 
 	// Call the controller update command
 	cmd := Command()
+	t.Logf("%+v", cmd.PersistentFlags())
 	args := []string{"update", "../../controller/test/manifest_e2e.yaml"}
 	cmd.SetArgs(args)
 	if err = cmd.Execute(); err != nil {

--- a/cmd/registry/cmd/controller/update_test.go
+++ b/cmd/registry/cmd/controller/update_test.go
@@ -33,10 +33,10 @@ import (
 
 func readAndGZipFile(t *testing.T, filename string) (*bytes.Buffer, error) {
 	t.Helper()
-	fileBytes, err := ioutil.ReadFile(filename)
+	fileBytes, _ := ioutil.ReadFile(filename)
 	var buf bytes.Buffer
 	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
-	_, err = zw.Write(fileBytes)
+	_, err := zw.Write(fileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func TestControllerUpdate(t *testing.T) {
 	got := make([]string, 0)
 	listPattern := "projects/controller-demo/apis/petstore/versions/-/specs/-/artifacts/-"
 	segments := names.ArtifactRegexp().FindStringSubmatch(listPattern)
-	err = core.ListArtifacts(ctx, client, segments, "", false,
+	_ = core.ListArtifacts(ctx, client, segments, "", false,
 		func(artifact *rpc.Artifact) {
 			got = append(got, artifact.Name)
 		},

--- a/cmd/registry/cmd/controller/update_test.go
+++ b/cmd/registry/cmd/controller/update_test.go
@@ -184,7 +184,7 @@ func TestControllerUpdate(t *testing.T) {
 	}
 
 	// Call the controller update command
-	cmd := Command()
+	cmd := Command(ctx)
 	t.Logf("%+v", cmd.PersistentFlags())
 	args := []string{"update", "../../controller/test/manifest_e2e.yaml"}
 	cmd.SetArgs(args)

--- a/cmd/registry/cmd/count/count.go
+++ b/cmd/registry/cmd/count/count.go
@@ -18,8 +18,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var countFilter string
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "count",
@@ -28,7 +26,5 @@ func Command() *cobra.Command {
 
 	cmd.AddCommand(versionsCommand())
 
-	// TODO: Remove the global state.
-	cmd.PersistentFlags().StringVar(&countFilter, "filter", "", "filter count arguments")
 	return cmd
 }

--- a/cmd/registry/cmd/count/count.go
+++ b/cmd/registry/cmd/count/count.go
@@ -26,7 +26,7 @@ func Command() *cobra.Command {
 		Short: "Count quantities in the API Registry",
 	}
 
-	cmd.AddCommand(countVersionsCmd)
+	cmd.AddCommand(versionsCommand())
 
 	// TODO: Remove the global state.
 	cmd.PersistentFlags().StringVar(&countFilter, "filter", "", "filter count arguments")

--- a/cmd/registry/cmd/count/count.go
+++ b/cmd/registry/cmd/count/count.go
@@ -15,16 +15,18 @@
 package count
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "count",
 		Short: "Count quantities in the API Registry",
 	}
 
-	cmd.AddCommand(versionsCommand())
+	cmd.AddCommand(versionsCommand(ctx))
 
 	return cmd
 }

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -28,12 +28,12 @@ import (
 )
 
 func versionsCommand() *cobra.Command {
-	return &cobra.Command{
+	var filter string
+	cmd := &cobra.Command{
 		Use:   "versions",
 		Short: "Count the number of versions of specified APIs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -50,7 +50,7 @@ func versionsCommand() *cobra.Command {
 			name := args[0]
 			if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
 				// Iterate through a collection of APIs and count the number of versions of each.
-				err = core.ListAPIs(ctx, client, m, countFilter, func(api *rpc.Api) {
+				err = core.ListAPIs(ctx, client, m, filter, func(api *rpc.Api) {
 					taskQueue <- &countVersionsTask{
 						client:  client,
 						apiName: api.Name,
@@ -64,6 +64,9 @@ func versionsCommand() *cobra.Command {
 			}
 		},
 	}
+
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
+	return cmd
 }
 
 type countVersionsTask struct {

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -27,41 +27,43 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-var countVersionsCmd = &cobra.Command{
-	Use:   "versions",
-	Short: "Count the number of versions of specified APIs",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+func versionsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "versions",
+		Short: "Count the number of versions of specified APIs",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
 
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		// Initialize task queue.
-		taskQueue := make(chan core.Task, 1024)
-		workerCount := 64
-		for i := 0; i < workerCount; i++ {
-			core.WaitGroup().Add(1)
-			go core.Worker(ctx, taskQueue)
-		}
-		// Generate tasks.
-		name := args[0]
-		if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
-			// Iterate through a collection of APIs and count the number of versions of each.
-			err = core.ListAPIs(ctx, client, m, countFilter, func(api *rpc.Api) {
-				taskQueue <- &countVersionsTask{
-					client:  client,
-					apiName: api.Name,
-				}
-			})
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			close(taskQueue)
-			core.WaitGroup().Wait()
-		}
-	},
+			// Initialize task queue.
+			taskQueue := make(chan core.Task, 1024)
+			workerCount := 64
+			for i := 0; i < workerCount; i++ {
+				core.WaitGroup().Add(1)
+				go core.Worker(ctx, taskQueue)
+			}
+			// Generate tasks.
+			name := args[0]
+			if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
+				// Iterate through a collection of APIs and count the number of versions of each.
+				err = core.ListAPIs(ctx, client, m, countFilter, func(api *rpc.Api) {
+					taskQueue <- &countVersionsTask{
+						client:  client,
+						apiName: api.Name,
+					}
+				})
+				if err != nil {
+					log.Fatalf("%s", err.Error())
+				}
+				close(taskQueue)
+				core.WaitGroup().Wait()
+			}
+		},
+	}
 }
 
 type countVersionsTask struct {

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func versionsCommand() *cobra.Command {
+func versionsCommand(ctx context.Context) *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "versions",

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -27,9 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deleteFilter string
-
 func Command() *cobra.Command {
+	var filter string
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete resources from the API Registry",
@@ -49,7 +48,7 @@ func Command() *cobra.Command {
 				go core.Worker(ctx, taskQueue)
 			}
 
-			err = matchAndHandleDeleteCmd(ctx, client, taskQueue, args[0])
+			err = matchAndHandleDeleteCmd(ctx, client, taskQueue, args[0], filter)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
@@ -59,8 +58,7 @@ func Command() *cobra.Command {
 		},
 	}
 
-	// TODO: Remove the global state.
-	cmd.Flags().StringVar(&deleteFilter, "filter", "", "Filter resources to delete")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
 	return cmd
 }
 
@@ -95,15 +93,16 @@ func matchAndHandleDeleteCmd(
 	client connection.Client,
 	taskQueue chan core.Task,
 	name string,
+	filter string,
 ) error {
 	if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
-		return deleteAPIs(ctx, client, m, deleteFilter, taskQueue)
+		return deleteAPIs(ctx, client, m, filter, taskQueue)
 	} else if m := names.VersionRegexp().FindStringSubmatch(name); m != nil {
-		return deleteVersions(ctx, client, m, deleteFilter, taskQueue)
+		return deleteVersions(ctx, client, m, filter, taskQueue)
 	} else if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-		return deleteSpecs(ctx, client, m, deleteFilter, taskQueue)
+		return deleteSpecs(ctx, client, m, filter, taskQueue)
 	} else if m := names.ArtifactRegexp().FindStringSubmatch(name); m != nil {
-		return deleteArtifacts(ctx, client, m, deleteFilter, taskQueue)
+		return deleteArtifacts(ctx, client, m, filter, taskQueue)
 	} else {
 		return fmt.Errorf("unsupported resource name: see the 'apg registry delete-' subcommands for alternatives")
 	}

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "delete",

--- a/cmd/registry/cmd/export/csv.go
+++ b/cmd/registry/cmd/export/csv.go
@@ -34,65 +34,67 @@ type exportCSVRow struct {
 	ContentsPath string
 }
 
-var exportCsvCmd = &cobra.Command{
-	Use:   "csv [--filter expression] parent ...",
-	Short: "Export API specs to a CSV file",
-	Args: func(cmd *cobra.Command, args []string) error {
-		for _, parent := range args {
-			if re := names.VersionRegexp(); !re.MatchString(parent) {
-				return fmt.Errorf("invalid parent argument %q: must match %q", parent, re)
-			}
-		}
-
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		filter, err := cmd.Flags().GetString("filter")
-		if err != nil {
-			log.Fatalf("Failed to get filter string from flags: %s", err)
-		}
-
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("Failed to create client: %s", err)
-		}
-
-		rows := make([]exportCSVRow, 0)
-		for _, parent := range args {
-			err := core.ListSpecs(ctx, client, names.VersionRegexp().FindStringSubmatch(parent), filter, func(spec *rpc.ApiSpec) {
-				if !names.SpecRegexp().MatchString(spec.GetName()) {
-					log.Printf("Failed to parse spec name %q: skipping spec row", spec.GetName())
-					return
+func csvCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "csv [--filter expression] parent ...",
+		Short: "Export API specs to a CSV file",
+		Args: func(cmd *cobra.Command, args []string) error {
+			for _, parent := range args {
+				if re := names.VersionRegexp(); !re.MatchString(parent) {
+					return fmt.Errorf("invalid parent argument %q: must match %q", parent, re)
 				}
+			}
 
-				m := names.SpecRegexp().FindStringSubmatch(spec.GetName())
-				rows = append(rows, exportCSVRow{
-					ApiID:        m[2],
-					VersionID:    m[3],
-					SpecID:       m[4],
-					ContentsPath: fmt.Sprintf("$APG_REGISTRY_ADDRESS/%s/contents", spec.GetName()),
-				})
-			})
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.Fatalf("Failed to list specs: %s", err)
+				log.Fatalf("Failed to get filter string from flags: %s", err)
 			}
-		}
 
-		w := csv.NewWriter(cmd.OutOrStdout())
-		if err := w.Write([]string{"api_id", "version_id", "spec_id", "contents_path"}); err != nil {
-			log.Fatalf("Failed to write CSV header: %s", err)
-		}
-
-		for _, row := range rows {
-			if err := w.Write([]string{row.ApiID, row.VersionID, row.SpecID, row.ContentsPath}); err != nil {
-				log.Fatalf("Failed to write CSV row %v: %s", row, err)
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("Failed to create client: %s", err)
 			}
-		}
 
-		w.Flush()
-		if err := w.Error(); err != nil {
-			log.Fatalf("Error occured while flushing writes to output: %s", err)
-		}
-	},
+			rows := make([]exportCSVRow, 0)
+			for _, parent := range args {
+				err := core.ListSpecs(ctx, client, names.VersionRegexp().FindStringSubmatch(parent), filter, func(spec *rpc.ApiSpec) {
+					if !names.SpecRegexp().MatchString(spec.GetName()) {
+						log.Printf("Failed to parse spec name %q: skipping spec row", spec.GetName())
+						return
+					}
+
+					m := names.SpecRegexp().FindStringSubmatch(spec.GetName())
+					rows = append(rows, exportCSVRow{
+						ApiID:        m[2],
+						VersionID:    m[3],
+						SpecID:       m[4],
+						ContentsPath: fmt.Sprintf("$APG_REGISTRY_ADDRESS/%s/contents", spec.GetName()),
+					})
+				})
+				if err != nil {
+					log.Fatalf("Failed to list specs: %s", err)
+				}
+			}
+
+			w := csv.NewWriter(cmd.OutOrStdout())
+			if err := w.Write([]string{"api_id", "version_id", "spec_id", "contents_path"}); err != nil {
+				log.Fatalf("Failed to write CSV header: %s", err)
+			}
+
+			for _, row := range rows {
+				if err := w.Write([]string{row.ApiID, row.VersionID, row.SpecID, row.ContentsPath}); err != nil {
+					log.Fatalf("Failed to write CSV row %v: %s", row, err)
+				}
+			}
+
+			w.Flush()
+			if err := w.Error(); err != nil {
+				log.Fatalf("Error occured while flushing writes to output: %s", err)
+			}
+		},
+	}
 }

--- a/cmd/registry/cmd/export/csv.go
+++ b/cmd/registry/cmd/export/csv.go
@@ -34,7 +34,7 @@ type exportCSVRow struct {
 	ContentsPath string
 }
 
-func csvCommand() *cobra.Command {
+func csvCommand(ctx context.Context) *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "csv [--filter expression] parent ...",

--- a/cmd/registry/cmd/export/csv.go
+++ b/cmd/registry/cmd/export/csv.go
@@ -35,7 +35,8 @@ type exportCSVRow struct {
 }
 
 func csvCommand() *cobra.Command {
-	return &cobra.Command{
+	var filter string
+	cmd := &cobra.Command{
 		Use:   "csv [--filter expression] parent ...",
 		Short: "Export API specs to a CSV file",
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -48,11 +49,6 @@ func csvCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			filter, err := cmd.Flags().GetString("filter")
-			if err != nil {
-				log.Fatalf("Failed to get filter string from flags: %s", err)
-			}
-
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -97,4 +93,7 @@ func csvCommand() *cobra.Command {
 			}
 		},
 	}
+
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
+	return cmd
 }

--- a/cmd/registry/cmd/export/csv_test.go
+++ b/cmd/registry/cmd/export/csv_test.go
@@ -87,7 +87,7 @@ func TestExportCSV(t *testing.T) {
 	}
 
 	// Execute
-	cmd := Command()
+	cmd := Command(ctx)
 	out := bytes.NewBuffer(make([]byte, 0))
 	args := []string{"csv", version.GetName()}
 	cmd.SetOutput(out)

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -18,8 +18,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var exportFilter string
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
@@ -30,7 +28,5 @@ func Command() *cobra.Command {
 	cmd.AddCommand(sheetCommand())
 	cmd.AddCommand(yamlCommand())
 
-	// TODO: Remove the global state.
-	cmd.PersistentFlags().StringVar(&exportFilter, "filter", "", "filter export arguments")
 	return cmd
 }

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -15,18 +15,20 @@
 package export
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export resources from the API Registry",
 	}
 
-	cmd.AddCommand(csvCommand())
-	cmd.AddCommand(sheetCommand())
-	cmd.AddCommand(yamlCommand())
+	cmd.AddCommand(csvCommand(ctx))
+	cmd.AddCommand(sheetCommand(ctx))
+	cmd.AddCommand(yamlCommand(ctx))
 
 	return cmd
 }

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -26,9 +26,9 @@ func Command() *cobra.Command {
 		Short: "Export resources from the API Registry",
 	}
 
-	cmd.AddCommand(exportCsvCmd)
-	cmd.AddCommand(exportSheetCmd)
-	cmd.AddCommand(exportYAMLCmd)
+	cmd.AddCommand(csvCommand())
+	cmd.AddCommand(sheetCommand())
+	cmd.AddCommand(yamlCommand())
 
 	// TODO: Remove the global state.
 	cmd.PersistentFlags().StringVar(&exportFilter, "filter", "", "filter export arguments")

--- a/cmd/registry/cmd/export/sheet.go
+++ b/cmd/registry/cmd/export/sheet.go
@@ -26,9 +26,10 @@ import (
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	metrics "github.com/googleapis/gnostic/metrics"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
+
+	metrics "github.com/googleapis/gnostic/metrics"
 )
 
 var sheetArtifactName string
@@ -74,7 +75,7 @@ var exportSheetCmd = &cobra.Command{
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			path, err = core.ExportVocabularyToSheet(ctx, inputs[0].Name, vocabulary)
+			path, _ = core.ExportVocabularyToSheet(ctx, inputs[0].Name, vocabulary)
 			log.Printf("exported vocabulary %s to %s", inputs[0].Name, path)
 			if sheetArtifactName == "" {
 				sheetArtifactName = inputs[0].Name + "-sheet"
@@ -85,14 +86,14 @@ var exportSheetCmd = &cobra.Command{
 				log.Fatalf("please specify exactly one version history to export")
 				return
 			}
-			path, err = core.ExportVersionHistoryToSheet(ctx, inputNames[0], inputs[0])
+			path, _ = core.ExportVersionHistoryToSheet(ctx, inputNames[0], inputs[0])
 			log.Printf("exported version history %s to %s", inputs[0].Name, path)
 			if sheetArtifactName == "" {
 				sheetArtifactName = inputs[0].Name + "-sheet"
 			}
 			saveSheetPath(ctx, client, path, sheetArtifactName)
 		} else if messageType == "gnostic.metrics.Complexity" {
-			path, err = core.ExportComplexityToSheet(ctx, "Complexity", inputs)
+			path, _ = core.ExportComplexityToSheet(ctx, "Complexity", inputs)
 			log.Printf("exported complexity to %s", path)
 			saveSheetPath(ctx, client, path, sheetArtifactName)
 		} else if messageType == "google.cloud.apigee.registry.applications.v1alpha1.Index" {
@@ -103,7 +104,7 @@ var exportSheetCmd = &cobra.Command{
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			path, err = core.ExportIndexToSheet(ctx, inputs[0].Name, index)
+			path, _ = core.ExportIndexToSheet(ctx, inputs[0].Name, index)
 			log.Printf("exported index %s to %s", inputs[0].Name, path)
 			if sheetArtifactName == "" {
 				sheetArtifactName = inputs[0].Name + "-sheet"
@@ -113,14 +114,6 @@ var exportSheetCmd = &cobra.Command{
 			log.Fatalf("Unknown message type: %s", messageType)
 		}
 	},
-}
-
-func versionNameOfArtifactName(artifactName string) string {
-	n := artifactName
-	for i := 0; i < 4; i++ {
-		n = filepath.Dir(n)
-	}
-	return n
 }
 
 func collectInputArtifacts(ctx context.Context, client connection.Client, args []string, filter string) ([]string, []*rpc.Artifact) {
@@ -148,10 +141,6 @@ func isInt64Artifact(artifact *rpc.Artifact) bool {
 	return err == nil
 }
 
-func messageTypeURL(artifact *rpc.Artifact) string {
-	return artifact.GetMimeType()
-}
-
 func getVocabulary(artifact *rpc.Artifact) (*metrics.Vocabulary, error) {
 	messageType, err := core.MessageTypeForMimeType(artifact.GetMimeType())
 	if err == nil && messageType == "gnostic.metrics.Vocabulary" {
@@ -173,7 +162,7 @@ func getIndex(artifact *rpc.Artifact) (*rpc.Index, error) {
 			if err != nil {
 				return nil, err
 			}
-			err = proto.Unmarshal(value, index)
+			_ = proto.Unmarshal(value, index)
 		}
 		return index, err
 	}

--- a/cmd/registry/cmd/export/sheet.go
+++ b/cmd/registry/cmd/export/sheet.go
@@ -32,7 +32,7 @@ import (
 	metrics "github.com/googleapis/gnostic/metrics"
 )
 
-func sheetCommand() *cobra.Command {
+func sheetCommand(ctx context.Context) *cobra.Command {
 	var (
 		filter   string
 		artifact string

--- a/cmd/registry/cmd/export/yaml.go
+++ b/cmd/registry/cmd/export/yaml.go
@@ -31,44 +31,46 @@ func check(err error) {
 	}
 }
 
-var exportYAMLCmd = &cobra.Command{
-	Use:   "yaml",
-	Short: "Export a subtree of the registry to a YAML file",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
+func yamlCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "yaml",
+		Short: "Export a subtree of the registry to a YAML file",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
 
-		var name string
-		if len(args) > 0 {
-			name = args[0]
-		}
+			var name string
+			if len(args) > 0 {
+				name = args[0]
+			}
 
-		if m := names.ProjectRegexp().FindStringSubmatch(name); m != nil {
-			_, err := core.GetProject(ctx, client, m, func(message *rpc.Project) {
-				core.ExportYAMLForProject(ctx, client, message)
-			})
-			check(err)
-		} else if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
-			_, err = core.GetAPI(ctx, client, m, func(message *rpc.Api) {
-				core.ExportYAMLForAPI(ctx, client, message)
-			})
-			check(err)
-		} else if m := names.VersionRegexp().FindStringSubmatch(name); m != nil {
-			_, err = core.GetVersion(ctx, client, m, func(message *rpc.ApiVersion) {
-				core.ExportYAMLForVersion(ctx, client, message)
-			})
-			check(err)
-		} else if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-			_, err = core.GetSpec(ctx, client, m, false, func(message *rpc.ApiSpec) {
-				core.ExportYAMLForSpec(ctx, client, message)
-			})
-			check(err)
-		} else {
-			log.Fatalf("Unsupported entity %+s", name)
-		}
-	},
+			if m := names.ProjectRegexp().FindStringSubmatch(name); m != nil {
+				_, err := core.GetProject(ctx, client, m, func(message *rpc.Project) {
+					core.ExportYAMLForProject(ctx, client, message)
+				})
+				check(err)
+			} else if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
+				_, err = core.GetAPI(ctx, client, m, func(message *rpc.Api) {
+					core.ExportYAMLForAPI(ctx, client, message)
+				})
+				check(err)
+			} else if m := names.VersionRegexp().FindStringSubmatch(name); m != nil {
+				_, err = core.GetVersion(ctx, client, m, func(message *rpc.ApiVersion) {
+					core.ExportYAMLForVersion(ctx, client, message)
+				})
+				check(err)
+			} else if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
+				_, err = core.GetSpec(ctx, client, m, false, func(message *rpc.ApiSpec) {
+					core.ExportYAMLForSpec(ctx, client, message)
+				})
+				check(err)
+			} else {
+				log.Fatalf("Unsupported entity %+s", name)
+			}
+		},
+	}
 }

--- a/cmd/registry/cmd/export/yaml.go
+++ b/cmd/registry/cmd/export/yaml.go
@@ -31,7 +31,7 @@ func check(err error) {
 	}
 }
 
-func yamlCommand() *cobra.Command {
+func yamlCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "yaml",
 		Short: "Export a subtree of the registry to a YAML file",

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -69,7 +69,6 @@ func Command() *cobra.Command {
 		},
 	}
 
-	// TODO: Remove the global state.
-	cmd.Flags().BoolVar(&getContents, "contents", false, "Get item contents (if applicable).")
+	cmd.Flags().BoolVar(&getContents, "contents", false, "Include resource contents if available")
 	return cmd
 }

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	var getContents bool
 	cmd := &cobra.Command{
 		Use:   "get",

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -24,9 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var getContents bool
-
 func Command() *cobra.Command {
+	var getContents bool
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get resources from the API Registry",

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -27,8 +27,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var indexFilter string
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "index",
@@ -37,8 +35,6 @@ func Command() *cobra.Command {
 
 	cmd.AddCommand(unionCommand())
 
-	// TODO: Remove the global state.
-	cmd.PersistentFlags().StringVar(&indexFilter, "filter", "", "filter index arguments")
 	return cmd
 }
 

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -35,7 +35,7 @@ func Command() *cobra.Command {
 		Short: "Operate on API indexes in the API Registry",
 	}
 
-	cmd.AddCommand(indexUnionCmd)
+	cmd.AddCommand(unionCommand())
 
 	// TODO: Remove the global state.
 	cmd.PersistentFlags().StringVar(&indexFilter, "filter", "", "filter index arguments")

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -27,13 +27,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "index",
 		Short: "Operate on API indexes in the API Registry",
 	}
 
-	cmd.AddCommand(unionCommand())
+	cmd.AddCommand(unionCommand(ctx))
 
 	return cmd
 }

--- a/cmd/registry/cmd/index/union.go
+++ b/cmd/registry/cmd/index/union.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func unionCommand() *cobra.Command {
+func unionCommand(ctx context.Context) *cobra.Command {
 	var (
 		filter string
 		output string

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	var (
 		filter    string
 		overwrite bool

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -29,13 +29,10 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-const labelFieldName = "labels"
-const labelCommandName = "label"
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s RESOURCE KEY_1=VAL_1 ... KEY_N=VAL_N", labelCommandName),
-		Short: fmt.Sprintf("%s resources in the API Registry", strings.Title(labelCommandName)),
+		Use:   "label RESOURCE KEY_1=VAL_1 ... KEY_N=VAL_N",
+		Short: "Label resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			flagset := cmd.LocalFlags()
@@ -178,7 +175,7 @@ type labelApiTask struct {
 }
 
 func (task *labelApiTask) String() string {
-	return labelCommandName + " " + task.api.Name
+	return "label " + task.api.Name
 }
 
 func (task *labelApiTask) Run(ctx context.Context) error {
@@ -191,7 +188,7 @@ func (task *labelApiTask) Run(ctx context.Context) error {
 		&rpc.UpdateApiRequest{
 			Api: task.api,
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{labelFieldName},
+				Paths: []string{"labels"},
 			},
 		})
 	return err
@@ -204,7 +201,7 @@ type labelVersionTask struct {
 }
 
 func (task *labelVersionTask) String() string {
-	return labelCommandName + " " + task.version.Name
+	return "label " + task.version.Name
 }
 
 func (task *labelVersionTask) Run(ctx context.Context) error {
@@ -217,7 +214,7 @@ func (task *labelVersionTask) Run(ctx context.Context) error {
 		&rpc.UpdateApiVersionRequest{
 			ApiVersion: task.version,
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{labelFieldName},
+				Paths: []string{"labels"},
 			},
 		})
 	return err
@@ -230,7 +227,7 @@ type labelSpecTask struct {
 }
 
 func (task *labelSpecTask) String() string {
-	return labelCommandName + " " + task.spec.Name
+	return "label " + task.spec.Name
 }
 
 func (task *labelSpecTask) Run(ctx context.Context) error {
@@ -243,7 +240,7 @@ func (task *labelSpecTask) Run(ctx context.Context) error {
 		&rpc.UpdateApiSpecRequest{
 			ApiSpec: task.spec,
 			UpdateMask: &field_mask.FieldMask{
-				Paths: []string{labelFieldName},
+				Paths: []string{"labels"},
 			},
 		})
 	return err

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -30,22 +30,16 @@ import (
 )
 
 func Command() *cobra.Command {
+	var (
+		filter    string
+		overwrite bool
+	)
+
 	cmd := &cobra.Command{
 		Use:   "label RESOURCE KEY_1=VAL_1 ... KEY_N=VAL_N",
 		Short: "Label resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			flagset := cmd.LocalFlags()
-			filter, err := flagset.GetString("filter")
-			if err != nil {
-				log.Fatalf("Failed to get filter string from flags: %s", err)
-			}
-			overwrite := false
-			overwrite, err = flagset.GetBool("overwrite")
-			if err != nil {
-				log.Fatalf("Failed to get overwrite boolean from flags: %s", err)
-			}
-
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -87,8 +81,8 @@ func Command() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("filter", "", "Filter selected resources")
-	cmd.Flags().Bool("overwrite", false, "Overwrite existing labels")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing labels")
 	return cmd
 }
 

--- a/cmd/registry/cmd/label/label_test.go
+++ b/cmd/registry/cmd/label/label_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestLabel(t *testing.T) {
-	var err error
-
 	const (
 		projectID   = "label-test"
 		projectName = "projects/" + projectID

--- a/cmd/registry/cmd/label/label_test.go
+++ b/cmd/registry/cmd/label/label_test.go
@@ -110,7 +110,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for APIs.
 	for _, tc := range testCases {
-		cmd := Command()
+		cmd := Command(ctx)
 		cmd.SetArgs(append([]string{apiName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -128,7 +128,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for versions.
 	for _, tc := range testCases {
-		cmd := Command()
+		cmd := Command(ctx)
 		cmd.SetArgs(append([]string{versionName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -146,7 +146,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for specs.
 	for _, tc := range testCases {
-		cmd := Command()
+		cmd := Command(ctx)
 		cmd.SetArgs(append([]string{specName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -25,9 +25,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listFilter string
-
 func Command() *cobra.Command {
+	var filter string
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List resources in the API Registry",
@@ -38,15 +37,14 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			err = matchAndHandleListCmd(ctx, client, args[0])
+			err = matchAndHandleListCmd(ctx, client, args[0], filter)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
 		},
 	}
 
-	// TODO: Remove the global state.
-	cmd.Flags().StringVar(&listFilter, "filter", "", "Filter option to send with list calls")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
 	return cmd
 }
 
@@ -54,32 +52,33 @@ func matchAndHandleListCmd(
 	ctx context.Context,
 	client connection.Client,
 	name string,
+	filter string,
 ) error {
 
 	// First try to match collection names.
 	if m := names.ProjectsRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListProjects(ctx, client, m, listFilter, core.PrintProject)
+		return core.ListProjects(ctx, client, m, filter, core.PrintProject)
 	} else if m := names.ApisRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListAPIs(ctx, client, m, listFilter, core.PrintAPI)
+		return core.ListAPIs(ctx, client, m, filter, core.PrintAPI)
 	} else if m := names.VersionsRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListVersions(ctx, client, m, listFilter, core.PrintVersion)
+		return core.ListVersions(ctx, client, m, filter, core.PrintVersion)
 	} else if m := names.SpecsRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListSpecs(ctx, client, m, listFilter, core.PrintSpec)
+		return core.ListSpecs(ctx, client, m, filter, core.PrintSpec)
 	} else if m := names.ArtifactsRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListArtifacts(ctx, client, m, listFilter, false, core.PrintArtifact)
+		return core.ListArtifacts(ctx, client, m, filter, false, core.PrintArtifact)
 	}
 
 	// Then try to match resource names.
 	if m := names.ProjectRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListProjects(ctx, client, m, listFilter, core.PrintProject)
+		return core.ListProjects(ctx, client, m, filter, core.PrintProject)
 	} else if m := names.ApiRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListAPIs(ctx, client, m, listFilter, core.PrintAPI)
+		return core.ListAPIs(ctx, client, m, filter, core.PrintAPI)
 	} else if m := names.VersionRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListVersions(ctx, client, m, listFilter, core.PrintVersion)
+		return core.ListVersions(ctx, client, m, filter, core.PrintVersion)
 	} else if m := names.SpecRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListSpecs(ctx, client, m, listFilter, core.PrintSpec)
+		return core.ListSpecs(ctx, client, m, filter, core.PrintSpec)
 	} else if m := names.ArtifactRegexp().FindStringSubmatch(name); m != nil {
-		return core.ListArtifacts(ctx, client, m, listFilter, false, core.PrintArtifact)
+		return core.ListArtifacts(ctx, client, m, filter, false, core.PrintArtifact)
 	}
 
 	// If nothing matched, return an error.

--- a/cmd/registry/cmd/root.go
+++ b/cmd/registry/cmd/root.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/apigee/registry/cmd/registry/cmd/annotate"
 	"github.com/apigee/registry/cmd/registry/cmd/compute"
 	"github.com/apigee/registry/cmd/registry/cmd/controller"
@@ -30,24 +32,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "registry",
 		Short: "A simple and eclectic utility for working with the API Registry",
 	}
 
-	cmd.AddCommand(annotate.Command())
-	cmd.AddCommand(compute.Command())
-	cmd.AddCommand(controller.Command())
-	cmd.AddCommand(delete.Command())
-	cmd.AddCommand(export.Command())
-	cmd.AddCommand(get.Command())
-	cmd.AddCommand(index.Command())
-	cmd.AddCommand(label.Command())
-	cmd.AddCommand(list.Command())
-	cmd.AddCommand(search.Command())
-	cmd.AddCommand(upload.Command())
-	cmd.AddCommand(vocabulary.Command())
+	cmd.AddCommand(annotate.Command(ctx))
+	cmd.AddCommand(compute.Command(ctx))
+	cmd.AddCommand(controller.Command(ctx))
+	cmd.AddCommand(delete.Command(ctx))
+	cmd.AddCommand(export.Command(ctx))
+	cmd.AddCommand(get.Command(ctx))
+	cmd.AddCommand(index.Command(ctx))
+	cmd.AddCommand(label.Command(ctx))
+	cmd.AddCommand(list.Command(ctx))
+	cmd.AddCommand(search.Command(ctx))
+	cmd.AddCommand(upload.Command(ctx))
+	cmd.AddCommand(vocabulary.Command(ctx))
 
 	return cmd
 }

--- a/cmd/registry/cmd/search/search.go
+++ b/cmd/registry/cmd/search/search.go
@@ -15,6 +15,7 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -24,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "search",
 		Short: "Search a local index of specs in the API Registry (experimental)",

--- a/cmd/registry/cmd/search/search.go
+++ b/cmd/registry/cmd/search/search.go
@@ -25,12 +25,11 @@ import (
 )
 
 func Command() *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "search",
 		Short: "Search a local index of specs in the API Registry (experimental)",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-
 			// open an existing index
 			index, err := bleve.Open("registry.bleve")
 			if err != nil {
@@ -51,6 +50,4 @@ func Command() *cobra.Command {
 			fmt.Println(searchResults)
 		},
 	}
-
-	return cmd
 }

--- a/cmd/registry/cmd/upload/bulk/bulk.go
+++ b/cmd/registry/cmd/upload/bulk/bulk.go
@@ -28,5 +28,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(openAPICommand())
 	cmd.AddCommand(protosCommand())
 
+	cmd.PersistentFlags().String("project_id", "", "Project ID to use for each upload")
+	cmd.MarkFlagRequired("project_id")
 	return cmd
 }

--- a/cmd/registry/cmd/upload/bulk/bulk.go
+++ b/cmd/registry/cmd/upload/bulk/bulk.go
@@ -15,18 +15,20 @@
 package bulk
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bulk",
 		Short: "Bulk-upload API specs of selected styles",
 	}
 
-	cmd.AddCommand(discoveryCommand())
-	cmd.AddCommand(openAPICommand())
-	cmd.AddCommand(protosCommand())
+	cmd.AddCommand(discoveryCommand(ctx))
+	cmd.AddCommand(openAPICommand(ctx))
+	cmd.AddCommand(protosCommand(ctx))
 
 	cmd.PersistentFlags().String("project_id", "", "Project ID to use for each upload")
 	cmd.MarkFlagRequired("project_id")

--- a/cmd/registry/cmd/upload/bulk/bulk.go
+++ b/cmd/registry/cmd/upload/bulk/bulk.go
@@ -24,9 +24,9 @@ func Command() *cobra.Command {
 		Short: "Bulk-upload API specs of selected styles",
 	}
 
-	cmd.AddCommand(uploadBulkDiscoveryCmd)
-	cmd.AddCommand(uploadBulkOpenAPICmd)
-	cmd.AddCommand(uploadBulkProtosCmd)
+	cmd.AddCommand(discoveryCommand())
+	cmd.AddCommand(openAPICommand())
+	cmd.AddCommand(protosCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -33,15 +33,11 @@ func discoveryCommand() *cobra.Command {
 		Use:   "discovery",
 		Short: "Bulk-upload API Discovery documents from the Google API Discovery service",
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			projectID, err := flagset.GetString("project_id")
+			projectID, err := cmd.Flags().GetString("project_id")
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			if projectID == "" {
-				log.Fatalf("Please specify a project_id")
-			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -77,7 +73,6 @@ func discoveryCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("project_id", "", "Project id.")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -83,7 +83,6 @@ type uploadDiscoveryTask struct {
 	apiID     string
 	versionID string
 	specID    string
-	document  *discovery.Document
 }
 
 func (task *uploadDiscoveryTask) String() string {

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-func discoveryCommand() *cobra.Command {
+func discoveryCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "discovery",
 		Short: "Bulk-upload API Discovery documents from the Google API Discovery service",

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -22,7 +22,6 @@ import (
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
-	rpcpb "github.com/apigee/registry/rpc"
 	discovery "github.com/googleapis/gnostic/discovery"
 	"github.com/nsf/jsondiff"
 	"github.com/spf13/cobra"
@@ -114,13 +113,13 @@ func (task *uploadDiscoveryTask) Run(ctx context.Context) error {
 }
 
 func (task *uploadDiscoveryTask) createAPI(ctx context.Context) error {
-	if _, err := task.client.GetApi(ctx, &rpcpb.GetApiRequest{
+	if _, err := task.client.GetApi(ctx, &rpc.GetApiRequest{
 		Name: task.apiName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when API is found without error.
 	}
 
-	response, err := task.client.CreateApi(ctx, &rpcpb.CreateApiRequest{
+	response, err := task.client.CreateApi(ctx, &rpc.CreateApiRequest{
 		Parent: task.projectName(),
 		ApiId:  task.apiID,
 		Api: &rpc.Api{
@@ -137,16 +136,16 @@ func (task *uploadDiscoveryTask) createAPI(ctx context.Context) error {
 }
 
 func (task *uploadDiscoveryTask) createVersion(ctx context.Context) error {
-	if _, err := task.client.GetApiVersion(ctx, &rpcpb.GetApiVersionRequest{
+	if _, err := task.client.GetApiVersion(ctx, &rpc.GetApiVersionRequest{
 		Name: task.versionName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when version is found without error.
 	}
 
-	response, err := task.client.CreateApiVersion(ctx, &rpcpb.CreateApiVersionRequest{
+	response, err := task.client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
 		Parent:       task.apiName(),
 		ApiVersionId: task.versionID,
-		ApiVersion:   &rpcpb.ApiVersion{},
+		ApiVersion:   &rpc.ApiVersion{},
 	})
 	if err != nil {
 		log.Printf("error %s: %s", task.versionName(), err.Error())
@@ -163,16 +162,16 @@ func (task *uploadDiscoveryTask) createSpec(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := task.client.GetApiSpec(ctx, &rpcpb.GetApiSpecRequest{
+	if _, err := task.client.GetApiSpec(ctx, &rpc.GetApiSpecRequest{
 		Name: task.specName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when spec is found without error.
 	}
 
-	response, err := task.client.CreateApiSpec(ctx, &rpcpb.CreateApiSpecRequest{
+	response, err := task.client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
 		Parent:    task.versionName(),
 		ApiSpecId: task.specID,
-		ApiSpec: &rpcpb.ApiSpec{
+		ApiSpec: &rpc.ApiSpec{
 			MimeType:  core.DiscoveryMimeType("+gzip"),
 			Filename:  "discovery.json",
 			Contents:  contents,
@@ -189,7 +188,7 @@ func (task *uploadDiscoveryTask) createSpec(ctx context.Context) error {
 }
 
 func (task *uploadDiscoveryTask) updateSpec(ctx context.Context) error {
-	refSpec, err := task.client.GetApiSpec(ctx, &rpcpb.GetApiSpecRequest{
+	refSpec, err := task.client.GetApiSpec(ctx, &rpc.GetApiSpecRequest{
 		Name: task.specName(),
 	})
 	if err != nil && !core.NotFound(err) {
@@ -216,8 +215,8 @@ func (task *uploadDiscoveryTask) updateSpec(ctx context.Context) error {
 		return err
 	}
 
-	response, err := task.client.UpdateApiSpec(ctx, &rpcpb.UpdateApiSpecRequest{
-		ApiSpec: &rpcpb.ApiSpec{
+	response, err := task.client.UpdateApiSpec(ctx, &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
 			Name:     task.specName(),
 			Contents: docZipped,
 		},

--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
-	rpcpb "github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/rpc"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -184,16 +184,16 @@ func (task *uploadOpenAPITask) populateFields() error {
 }
 
 func (task *uploadOpenAPITask) createAPI(ctx context.Context) error {
-	if _, err := task.client.GetApi(ctx, &rpcpb.GetApiRequest{
+	if _, err := task.client.GetApi(ctx, &rpc.GetApiRequest{
 		Name: task.apiName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when API is found without error.
 	}
 
-	response, err := task.client.CreateApi(ctx, &rpcpb.CreateApiRequest{
+	response, err := task.client.CreateApi(ctx, &rpc.CreateApiRequest{
 		Parent: task.projectName(),
 		ApiId:  task.apiID,
-		Api: &rpcpb.Api{
+		Api: &rpc.Api{
 			DisplayName: task.apiID,
 		},
 	})
@@ -207,16 +207,16 @@ func (task *uploadOpenAPITask) createAPI(ctx context.Context) error {
 }
 
 func (task *uploadOpenAPITask) createVersion(ctx context.Context) error {
-	if _, err := task.client.GetApiVersion(ctx, &rpcpb.GetApiVersionRequest{
+	if _, err := task.client.GetApiVersion(ctx, &rpc.GetApiVersionRequest{
 		Name: task.versionName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when version is found without error.
 	}
 
-	response, err := task.client.CreateApiVersion(ctx, &rpcpb.CreateApiVersionRequest{
+	response, err := task.client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
 		Parent:       task.apiName(),
 		ApiVersionId: task.versionID,
-		ApiVersion:   &rpcpb.ApiVersion{},
+		ApiVersion:   &rpc.ApiVersion{},
 	})
 	if err != nil {
 		log.Printf("error %s: %s", task.versionName(), err.Error())
@@ -233,16 +233,16 @@ func (task *uploadOpenAPITask) createSpec(ctx context.Context) error {
 		return err
 	}
 
-	if _, err = task.client.GetApiSpec(ctx, &rpcpb.GetApiSpecRequest{
+	if _, err = task.client.GetApiSpec(ctx, &rpc.GetApiSpecRequest{
 		Name: task.specName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when spec is found without error.
 	}
 
-	request := &rpcpb.CreateApiSpecRequest{
+	request := &rpc.CreateApiSpecRequest{
 		Parent:    task.versionName(),
 		ApiSpecId: task.fileName(),
-		ApiSpec: &rpcpb.ApiSpec{
+		ApiSpec: &rpc.ApiSpec{
 			MimeType: core.OpenAPIMimeType("+gzip", task.version),
 			Filename: task.fileName(),
 			Contents: contents,
@@ -268,15 +268,15 @@ func (task *uploadOpenAPITask) updateSpec(ctx context.Context) error {
 		return err
 	}
 
-	spec, err := task.client.GetApiSpec(ctx, &rpcpb.GetApiSpecRequest{
+	spec, err := task.client.GetApiSpec(ctx, &rpc.GetApiSpecRequest{
 		Name: task.specName(),
 	})
 	if err != nil && !core.NotFound(err) {
 		return err
 	}
 
-	request := &rpcpb.UpdateApiSpecRequest{
-		ApiSpec: &rpcpb.ApiSpec{
+	request := &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
 			Name:     task.specName(),
 			Contents: contents,
 		},

--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -32,23 +32,17 @@ import (
 )
 
 func openAPICommand() *cobra.Command {
+	var baseURI string
 	cmd := &cobra.Command{
 		Use:   "openapi",
 		Short: "Bulk-upload OpenAPI descriptions from a directory of specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			flagset := cmd.LocalFlags()
-			projectID, err := flagset.GetString("project_id")
+			projectID, err := cmd.Flags().GetString("project_id")
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			if projectID == "" {
-				log.Fatal("Please specify a project_id")
-			}
-			baseURI, err := flagset.GetString("base_uri")
-			if err != nil {
-				log.Fatal(err.Error())
-			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -61,8 +55,7 @@ func openAPICommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("project_id", "", "Project id.")
-	cmd.Flags().String("base_uri", "", "Base to use for setting source_uri fields of uploaded specs.")
+	cmd.Flags().StringVar(&baseURI, "base_uri", "", "Prefix to use for the source_uri field of each spec upload")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-func openAPICommand() *cobra.Command {
+func openAPICommand(ctx context.Context) *cobra.Command {
 	var baseURI string
 	cmd := &cobra.Command{
 		Use:   "openapi",

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
-	rpcpb "github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/rpc"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -148,16 +148,16 @@ func (task *uploadProtoTask) populateFields() {
 }
 
 func (task *uploadProtoTask) createAPI(ctx context.Context) error {
-	if _, err := task.client.GetApi(ctx, &rpcpb.GetApiRequest{
+	if _, err := task.client.GetApi(ctx, &rpc.GetApiRequest{
 		Name: task.apiName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when API is found without error.
 	}
 
-	response, err := task.client.CreateApi(ctx, &rpcpb.CreateApiRequest{
+	response, err := task.client.CreateApi(ctx, &rpc.CreateApiRequest{
 		Parent: task.projectName(),
 		ApiId:  task.apiID,
-		Api:    &rpcpb.Api{},
+		Api:    &rpc.Api{},
 	})
 	if err != nil {
 		log.Printf("error %s: %s", task.apiName(), err.Error())
@@ -169,16 +169,16 @@ func (task *uploadProtoTask) createAPI(ctx context.Context) error {
 }
 
 func (task *uploadProtoTask) createVersion(ctx context.Context) error {
-	if _, err := task.client.GetApiVersion(ctx, &rpcpb.GetApiVersionRequest{
+	if _, err := task.client.GetApiVersion(ctx, &rpc.GetApiVersionRequest{
 		Name: task.versionName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when version is found without error.
 	}
 
-	response, err := task.client.CreateApiVersion(ctx, &rpcpb.CreateApiVersionRequest{
+	response, err := task.client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
 		Parent:       task.apiName(),
 		ApiVersionId: task.versionID,
-		ApiVersion:   &rpcpb.ApiVersion{},
+		ApiVersion:   &rpc.ApiVersion{},
 	})
 	if err != nil {
 		log.Printf("error %s: %s", task.versionName(), err.Error())
@@ -195,16 +195,16 @@ func (task *uploadProtoTask) createSpec(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := task.client.GetApiSpec(ctx, &rpcpb.GetApiSpecRequest{
+	if _, err := task.client.GetApiSpec(ctx, &rpc.GetApiSpecRequest{
 		Name: task.specName(),
 	}); !core.NotFound(err) {
 		return err // Returns nil when spec is found without error.
 	}
 
-	request := &rpcpb.CreateApiSpecRequest{
+	request := &rpc.CreateApiSpecRequest{
 		Parent:    task.versionName(),
 		ApiSpecId: task.fileName(),
-		ApiSpec: &rpcpb.ApiSpec{
+		ApiSpec: &rpc.ApiSpec{
 			MimeType: core.ProtobufMimeType("+zip"),
 			Filename: task.fileName(),
 			Contents: contents,
@@ -230,15 +230,15 @@ func (task *uploadProtoTask) updateSpec(ctx context.Context) error {
 		return err
 	}
 
-	spec, err := task.client.GetApiSpec(ctx, &rpcpb.GetApiSpecRequest{
+	spec, err := task.client.GetApiSpec(ctx, &rpc.GetApiSpecRequest{
 		Name: task.specName(),
 	})
 	if err != nil && !core.NotFound(err) {
 		return err
 	}
 
-	request := &rpcpb.UpdateApiSpecRequest{
-		ApiSpec: &rpcpb.ApiSpec{
+	request := &rpc.UpdateApiSpecRequest{
+		ApiSpec: &rpc.ApiSpec{
 			Name:     task.specName(),
 			Contents: contents,
 		},

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-func protosCommand() *cobra.Command {
+func protosCommand(ctx context.Context) *cobra.Command {
 	var baseURI string
 	cmd := &cobra.Command{
 		Use:   "protos",

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -32,24 +32,17 @@ import (
 )
 
 func protosCommand() *cobra.Command {
+	var baseURI string
 	cmd := &cobra.Command{
 		Use:   "protos",
 		Short: "Bulk-upload Protocol Buffer descriptions from a directory of specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			projectID, err := flagset.GetString("project_id")
+			projectID, err := cmd.Flags().GetString("project_id")
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			if projectID == "" {
-				log.Fatalf("Please specify a project_id")
-			}
-			baseURI, err := flagset.GetString("base_uri")
-			if err != nil {
-				log.Fatal(err.Error())
-			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -62,8 +55,7 @@ func protosCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("project_id", "", "Project id.")
-	cmd.Flags().String("base_uri", "", "Base to use for setting source_uri fields of uploaded specs.")
+	cmd.Flags().StringVar(&baseURI, "base_uri", "", "Prefix to use for the source_uri field of each proto upload")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func csvCommand() *cobra.Command {
+func csvCommand(ctx context.Context) *cobra.Command {
 	var (
 		projectID string
 		delimiter string

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
-	rpcpb "github.com/apigee/registry/rpc"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -182,10 +181,10 @@ type uploadSpecTask struct {
 }
 
 func (t uploadSpecTask) Run(ctx context.Context) error {
-	api, err := t.client.CreateApi(ctx, &rpcpb.CreateApiRequest{
+	api, err := t.client.CreateApi(ctx, &rpc.CreateApiRequest{
 		Parent: fmt.Sprintf("projects/%s", t.projectID),
 		ApiId:  t.apiID,
-		Api:    &rpcpb.Api{},
+		Api:    &rpc.Api{},
 	})
 
 	switch status.Code(err) {
@@ -199,10 +198,10 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure API exists: %s", err)
 	}
 
-	version, err := t.client.CreateApiVersion(ctx, &rpcpb.CreateApiVersionRequest{
+	version, err := t.client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
 		Parent:       api.GetName(),
 		ApiVersionId: t.versionID,
-		ApiVersion:   &rpcpb.ApiVersion{},
+		ApiVersion:   &rpc.ApiVersion{},
 	})
 
 	switch status.Code(err) {
@@ -226,10 +225,10 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		return err
 	}
 
-	spec, err := t.client.CreateApiSpec(ctx, &rpcpb.CreateApiSpecRequest{
+	spec, err := t.client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
 		Parent:    version.GetName(),
 		ApiSpecId: t.specID,
-		ApiSpec: &rpcpb.ApiSpec{
+		ApiSpec: &rpc.ApiSpec{
 			// TODO: How do we choose a mime type?
 			MimeType: core.OpenAPIMimeType("+gzip", "3.0.0"),
 			Contents: compressed,

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -33,21 +33,17 @@ import (
 )
 
 func csvCommand() *cobra.Command {
+	var (
+		projectID string
+		delimiter string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "csv file --project_id=value [--delimiter=value]",
 		Short: "Upload API specs from a CSV file",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			flagset := cmd.LocalFlags()
-			projectID, err := flagset.GetString("project_id")
-			if err != nil {
-				log.Fatalf("Failed to get project_id string from flags: %s", err)
-			}
-
-			delimiter, err := flagset.GetString("delimiter")
-			if err != nil {
-				log.Fatalf("Failed to get delimiter string from flags: %s", err)
-			} else if len(delimiter) != 1 {
+			if len(delimiter) != 1 {
 				log.Fatalf("Invalid delimiter %q: must be exactly one character", delimiter)
 			}
 
@@ -94,9 +90,9 @@ func csvCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("project_id", "", "Project id.")
+	cmd.Flags().StringVar(&projectID, "project_id", "", "Project ID to use for each upload")
 	cmd.MarkFlagRequired("project_id")
-	cmd.Flags().String("delimiter", ",", "Field delimiter of the CSV file.")
+	cmd.Flags().StringVar(&delimiter, "delimiter", ",", "Field delimiter for the CSV file")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/csv_test.go
+++ b/cmd/registry/cmd/upload/csv_test.go
@@ -163,7 +163,7 @@ func TestUploadCSV(t *testing.T) {
 
 			args := append([]string{"csv"}, test.args...)
 
-			cmd := Command()
+			cmd := Command(ctx)
 			cmd.SetArgs(args)
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("Execute() with args %v returned error: %s", args, err)

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -27,23 +27,15 @@ import (
 )
 
 func manifestCommand() *cobra.Command {
+	var projectID string
 	cmd := &cobra.Command{
 		Use:   "manifest FILE_PATH --project_id=value",
 		Short: "Upload a dependency manifest",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			flagset := cmd.LocalFlags()
 			manifestPath := args[0]
 			if manifestPath == "" {
 				log.Fatal("Please provide manifest_path")
-			}
-
-			project, err := flagset.GetString("project_id")
-			if err != nil {
-				log.Fatalf("%s", err.Error())
-			}
-			if project == "" {
-				log.Fatal("Please specify a project")
 			}
 
 			manifest, err := controller.ReadManifestProto(manifestPath)
@@ -59,7 +51,7 @@ func manifestCommand() *cobra.Command {
 			}
 
 			artifact := &rpc.Artifact{
-				Name:     "projects/" + project + "/artifacts/" + manifest.Name,
+				Name:     "projects/" + projectID + "/artifacts/" + manifest.Name,
 				MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.Manifest"),
 				Contents: manifestData,
 			}
@@ -72,6 +64,7 @@ func manifestCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("project_id", "", "ProjectID this manifest should be associated with.")
+	cmd.Flags().StringVar(&projectID, "project_id", "", "Project ID to use when saving the result manifest artifact")
+	cmd.MarkFlagRequired("project_id")
 	return cmd
 }

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -42,7 +42,7 @@ func manifestCommand() *cobra.Command {
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			manifestData, err := proto.Marshal(manifest)
+			manifestData, _ := proto.Marshal(manifest)
 
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
@@ -59,8 +59,6 @@ func manifestCommand() *cobra.Command {
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-
-			return
 		},
 	}
 

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func manifestCommand() *cobra.Command {
+func manifestCommand(ctx context.Context) *cobra.Command {
 	var projectID string
 	cmd := &cobra.Command{
 		Use:   "manifest FILE_PATH --project_id=value",

--- a/cmd/registry/cmd/upload/manifest_test.go
+++ b/cmd/registry/cmd/upload/manifest_test.go
@@ -83,7 +83,7 @@ func TestManifestUpload(t *testing.T) {
 				t.Fatalf("Failed to create project %s: %s", test.project, err.Error())
 			}
 
-			cmd := Command()
+			cmd := Command(ctx)
 			args := []string{"manifest", test.filePath, "--project_id", test.project}
 			cmd.SetArgs(args)
 			if err = cmd.Execute(); err != nil {

--- a/cmd/registry/cmd/upload/manifest_test.go
+++ b/cmd/registry/cmd/upload/manifest_test.go
@@ -86,7 +86,7 @@ func TestManifestUpload(t *testing.T) {
 			cmd := Command()
 			args := []string{"manifest", test.filePath, "--project_id", test.project}
 			cmd.SetArgs(args)
-			if err = uploadManifestCmd.Execute(); err != nil {
+			if err = cmd.Execute(); err != nil {
 				t.Fatalf("Execute() with args %v returned error: %s", args, err)
 			}
 

--- a/cmd/registry/cmd/upload/manifest_test.go
+++ b/cmd/registry/cmd/upload/manifest_test.go
@@ -95,9 +95,9 @@ func TestManifestUpload(t *testing.T) {
 			}
 
 			manifest := rpc.Manifest{}
-			body, err := client.GetArtifactContents(ctx, req)
+			body, _ := client.GetArtifactContents(ctx, req)
 			contents := body.GetData()
-			err = proto.Unmarshal(contents, &manifest)
+			_ = proto.Unmarshal(contents, &manifest)
 
 			// Verify the manifest definition is correct
 			opts := cmp.Options{

--- a/cmd/registry/cmd/upload/spec.go
+++ b/cmd/registry/cmd/upload/spec.go
@@ -31,27 +31,17 @@ import (
 )
 
 func specCommand() *cobra.Command {
+	var (
+		version string
+		style   string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "spec",
 		Short: "Upload an API spec",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()
-			flagset := cmd.LocalFlags()
-			version, err := flagset.GetString("version")
-			if err != nil {
-				log.Fatalf("%s", err.Error())
-			}
-			if version == "" {
-				log.Fatalf("Please specify a version")
-			}
-			style, err := flagset.GetString("style")
-			if err != nil {
-				log.Fatalf("%s", err.Error())
-			}
-			if style == "" {
-				log.Fatal("Please specify a style")
-			}
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
@@ -85,8 +75,10 @@ func specCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("version", "", "Version for uploaded spec")
-	cmd.Flags().String("style", "", "style of spec to upload (openapi, discovery, proto)")
+	cmd.Flags().StringVar(&version, "version", "", "Version to use as parent for the spec upload")
+	cmd.MarkFlagRequired("version")
+	cmd.Flags().StringVar(&style, "style", "", "Style of spec to upload (openapi|discovery|proto)")
+	cmd.MarkFlagRequired("style")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/spec.go
+++ b/cmd/registry/cmd/upload/spec.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/gapic"
-	rpcpb "github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/rpc"
 	"github.com/spf13/cobra"
 )
 
@@ -100,10 +100,10 @@ func uploadSpecDirectory(ctx context.Context, dirname string, client *gapic.Regi
 	if err != nil {
 		return err
 	}
-	request := &rpcpb.CreateApiSpecRequest{
+	request := &rpc.CreateApiSpecRequest{
 		Parent:    version,
 		ApiSpecId: "protos.zip",
-		ApiSpec: &rpcpb.ApiSpec{
+		ApiSpec: &rpc.ApiSpec{
 			MimeType: style,
 			Filename: core.ProtobufMimeType("+zip"),
 			Contents: buf.Bytes(),
@@ -131,16 +131,14 @@ func uploadSpecFile(ctx context.Context, filename string, client *gapic.Registry
 		} else {
 			mimeType = core.OpenAPIMimeType("+gzip", "3")
 		}
-		break
 	case "discovery":
 		mimeType = core.DiscoveryMimeType("+gzip")
-		break
 	default:
 		return fmt.Errorf("unsupported file style %s", style)
 	}
 	specID := filepath.Base(filename)
 	// does the spec file exist? if not, create it
-	request := &rpcpb.GetApiSpecRequest{}
+	request := &rpc.GetApiSpecRequest{}
 	request.Name = version + "/specs/" + specID
 	_, err := client.GetApiSpec(ctx, request)
 	if err != nil { // TODO only do this for NotFound errors
@@ -148,12 +146,12 @@ func uploadSpecFile(ctx context.Context, filename string, client *gapic.Registry
 		if err != nil {
 			log.Printf("err %+v", err)
 		} else {
-			request := &rpcpb.CreateApiSpecRequest{}
+			request := &rpc.CreateApiSpecRequest{}
 			request.Parent = version
 			request.ApiSpecId = specID
-			request.ApiSpec = &rpcpb.ApiSpec{}
+			request.ApiSpec = &rpc.ApiSpec{}
 			request.ApiSpec.Filename = specID
-			request.ApiSpec.Contents, err = core.GZippedBytes(bytes)
+			request.ApiSpec.Contents, _ = core.GZippedBytes(bytes)
 			request.ApiSpec.MimeType = mimeType
 			response, err := client.CreateApiSpec(ctx, request)
 			log.Printf("response %+v\nerr %+v", response, err)

--- a/cmd/registry/cmd/upload/spec.go
+++ b/cmd/registry/cmd/upload/spec.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func specCommand() *cobra.Command {
+func specCommand(ctx context.Context) *cobra.Command {
 	var (
 		version string
 		style   string

--- a/cmd/registry/cmd/upload/upload.go
+++ b/cmd/registry/cmd/upload/upload.go
@@ -15,20 +15,22 @@
 package upload
 
 import (
+	"context"
+
 	"github.com/apigee/registry/cmd/registry/cmd/upload/bulk"
 	"github.com/spf13/cobra"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upload",
 		Short: "Upload information to the API Registry",
 	}
 
-	cmd.AddCommand(bulk.Command())
-	cmd.AddCommand(csvCommand())
-	cmd.AddCommand(manifestCommand())
-	cmd.AddCommand(specCommand())
+	cmd.AddCommand(bulk.Command(ctx))
+	cmd.AddCommand(csvCommand(ctx))
+	cmd.AddCommand(manifestCommand(ctx))
+	cmd.AddCommand(specCommand(ctx))
 
 	return cmd
 }

--- a/cmd/registry/cmd/upload/upload.go
+++ b/cmd/registry/cmd/upload/upload.go
@@ -26,9 +26,9 @@ func Command() *cobra.Command {
 	}
 
 	cmd.AddCommand(bulk.Command())
-	cmd.AddCommand(uploadCsvCmd)
-	cmd.AddCommand(uploadManifestCmd)
-	cmd.AddCommand(specCmd)
+	cmd.AddCommand(csvCommand())
+	cmd.AddCommand(manifestCommand())
+	cmd.AddCommand(specCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/difference.go
+++ b/cmd/registry/cmd/vocabulary/difference.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func differenceCommand() *cobra.Command {
+func differenceCommand(ctx context.Context) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "difference",

--- a/cmd/registry/cmd/vocabulary/difference.go
+++ b/cmd/registry/cmd/vocabulary/difference.go
@@ -52,6 +52,5 @@ func differenceCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
-	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/difference.go
+++ b/cmd/registry/cmd/vocabulary/difference.go
@@ -25,32 +25,33 @@ import (
 )
 
 func differenceCommand() *cobra.Command {
+	var output string
 	cmd := &cobra.Command{
 		Use:   "difference",
 		Short: "Compute the difference of specified API vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			outputArtifactName, err := flagset.GetString("output")
+			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.Fatalf("%s", err.Error())
+				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-			output := vocabulary.Difference(inputs)
-			if outputArtifactName != "" {
-				setVocabularyToArtifact(ctx, client, output, outputArtifactName)
+			_, inputs := collectInputVocabularies(ctx, client, args, filter)
+			vocab := vocabulary.Difference(inputs)
+			if output != "" {
+				setVocabularyToArtifact(ctx, client, vocab, output)
 			} else {
-				core.PrintMessage(output)
+				core.PrintMessage(vocab)
 			}
 		},
 	}
 
-	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
+	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/intersection.go
+++ b/cmd/registry/cmd/vocabulary/intersection.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func intersectionCommand() *cobra.Command {
+func intersectionCommand(ctx context.Context) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "intersection",

--- a/cmd/registry/cmd/vocabulary/intersection.go
+++ b/cmd/registry/cmd/vocabulary/intersection.go
@@ -24,32 +24,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	vocabularyIntersectionCmd.Flags().String("output", "", "name of artifact where output should be stored")
-}
+func intersectionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "intersection",
+		Short: "Compute the intersection of specified API vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			flagset := cmd.LocalFlags()
+			outputArtifactName, err := flagset.GetString("output")
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
+			output := vocabulary.Intersection(inputs)
+			if outputArtifactName != "" {
+				setVocabularyToArtifact(ctx, client, output, outputArtifactName)
+			} else {
+				core.PrintMessage(output)
+			}
+		},
+	}
 
-var vocabularyIntersectionCmd = &cobra.Command{
-	Use:   "intersection",
-	Short: "Compute the intersection of specified API vocabularies",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		flagset := cmd.LocalFlags()
-		outputArtifactName, err := flagset.GetString("output")
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-		output := vocabulary.Intersection(inputs)
-		if outputArtifactName != "" {
-			setVocabularyToArtifact(ctx, client, output, outputArtifactName)
-		} else {
-			core.PrintMessage(output)
-		}
-	},
+	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/intersection.go
+++ b/cmd/registry/cmd/vocabulary/intersection.go
@@ -52,6 +52,5 @@ func intersectionCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
-	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/intersection.go
+++ b/cmd/registry/cmd/vocabulary/intersection.go
@@ -25,32 +25,33 @@ import (
 )
 
 func intersectionCommand() *cobra.Command {
+	var output string
 	cmd := &cobra.Command{
 		Use:   "intersection",
 		Short: "Compute the intersection of specified API vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			outputArtifactName, err := flagset.GetString("output")
+			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.Fatalf("%s", err.Error())
+				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-			output := vocabulary.Intersection(inputs)
-			if outputArtifactName != "" {
-				setVocabularyToArtifact(ctx, client, output, outputArtifactName)
+			_, inputs := collectInputVocabularies(ctx, client, args, filter)
+			vocab := vocabulary.Intersection(inputs)
+			if output != "" {
+				setVocabularyToArtifact(ctx, client, vocab, output)
 			} else {
-				core.PrintMessage(output)
+				core.PrintMessage(vocab)
 			}
 		},
 	}
 
-	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
+	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/union.go
+++ b/cmd/registry/cmd/vocabulary/union.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func unionCommand() *cobra.Command {
+func unionCommand(ctx context.Context) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "union",

--- a/cmd/registry/cmd/vocabulary/union.go
+++ b/cmd/registry/cmd/vocabulary/union.go
@@ -24,32 +24,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	vocabularyUnionCmd.Flags().String("output", "", "name of artifact where output should be stored")
-}
+func unionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "union",
+		Short: "Compute the union of specified API vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			flagset := cmd.LocalFlags()
+			outputArtifactName, err := flagset.GetString("output")
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
+			output := vocabulary.Union(inputs)
+			if outputArtifactName != "" {
+				setVocabularyToArtifact(ctx, client, output, outputArtifactName)
+			} else {
+				core.PrintMessage(output)
+			}
+		},
+	}
 
-var vocabularyUnionCmd = &cobra.Command{
-	Use:   "union",
-	Short: "Compute the union of specified API vocabularies",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		flagset := cmd.LocalFlags()
-		outputArtifactName, err := flagset.GetString("output")
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-		output := vocabulary.Union(inputs)
-		if outputArtifactName != "" {
-			setVocabularyToArtifact(ctx, client, output, outputArtifactName)
-		} else {
-			core.PrintMessage(output)
-		}
-	},
+	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/union.go
+++ b/cmd/registry/cmd/vocabulary/union.go
@@ -25,32 +25,33 @@ import (
 )
 
 func unionCommand() *cobra.Command {
+	var output string
 	cmd := &cobra.Command{
 		Use:   "union",
 		Short: "Compute the union of specified API vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			outputArtifactName, err := flagset.GetString("output")
+			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.Fatalf("%s", err.Error())
+				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			_, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-			output := vocabulary.Union(inputs)
-			if outputArtifactName != "" {
-				setVocabularyToArtifact(ctx, client, output, outputArtifactName)
+			_, inputs := collectInputVocabularies(ctx, client, args, filter)
+			vocab := vocabulary.Union(inputs)
+			if output != "" {
+				setVocabularyToArtifact(ctx, client, vocab, output)
 			} else {
-				core.PrintMessage(output)
+				core.PrintMessage(vocab)
 			}
 		},
 	}
 
-	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
+	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/union.go
+++ b/cmd/registry/cmd/vocabulary/union.go
@@ -52,6 +52,5 @@ func unionCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
-	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/unique.go
+++ b/cmd/registry/cmd/vocabulary/unique.go
@@ -26,38 +26,39 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	vocabularyUniqueCmd.Flags().String("output_id", "vocabulary-unique", "id of artifact to store output.")
-}
-
-var vocabularyUniqueCmd = &cobra.Command{
-	Use:   "unique",
-	Short: "Compute the unique subsets of each member of specified vocabularies",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		flagset := cmd.LocalFlags()
-		outputArtifactID, err := flagset.GetString("output_id")
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		if strings.Contains(outputArtifactID, "/") {
-			log.Fatal("output_id must specify an artifact id (final segment only) and not a full name.")
-		}
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		names, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-		output := vocabulary.FilterCommon(inputs)
-		if outputArtifactID != "" {
-			for i, unique := range output.Vocabularies {
-				outputArtifactName := filepath.Dir(names[i]) + "/" + outputArtifactID
-				setVocabularyToArtifact(ctx, client, unique, outputArtifactName)
+func uniqueCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unique",
+		Short: "Compute the unique subsets of each member of specified vocabularies",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			flagset := cmd.LocalFlags()
+			outputArtifactID, err := flagset.GetString("output_id")
+			if err != nil {
+				log.Fatalf("%s", err.Error())
 			}
-		} else {
-			core.PrintMessage(output)
-		}
-	},
+			if strings.Contains(outputArtifactID, "/") {
+				log.Fatal("output_id must specify an artifact id (final segment only) and not a full name.")
+			}
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			names, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
+			output := vocabulary.FilterCommon(inputs)
+			if outputArtifactID != "" {
+				for i, unique := range output.Vocabularies {
+					outputArtifactName := filepath.Dir(names[i]) + "/" + outputArtifactID
+					setVocabularyToArtifact(ctx, client, unique, outputArtifactName)
+				}
+			} else {
+				core.PrintMessage(output)
+			}
+		},
+	}
+
+	cmd.Flags().String("output_id", "vocabulary-unique", "id of artifact to store output.")
+	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/unique.go
+++ b/cmd/registry/cmd/vocabulary/unique.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func uniqueCommand() *cobra.Command {
+func uniqueCommand(ctx context.Context) *cobra.Command {
 	var outputID string
 	cmd := &cobra.Command{
 		Use:   "unique",

--- a/cmd/registry/cmd/vocabulary/unique.go
+++ b/cmd/registry/cmd/vocabulary/unique.go
@@ -27,38 +27,39 @@ import (
 )
 
 func uniqueCommand() *cobra.Command {
+	var outputID string
 	cmd := &cobra.Command{
 		Use:   "unique",
 		Short: "Compute the unique subsets of each member of specified vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			outputArtifactID, err := flagset.GetString("output_id")
+			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.Fatalf("%s", err.Error())
+				log.Fatalf("Failed to get filter from flags: %s", err)
 			}
-			if strings.Contains(outputArtifactID, "/") {
+
+			if strings.Contains(outputID, "/") {
 				log.Fatal("output_id must specify an artifact id (final segment only) and not a full name.")
 			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			names, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
-			output := vocabulary.FilterCommon(inputs)
-			if outputArtifactID != "" {
-				for i, unique := range output.Vocabularies {
-					outputArtifactName := filepath.Dir(names[i]) + "/" + outputArtifactID
+			names, inputs := collectInputVocabularies(ctx, client, args, filter)
+			list := vocabulary.FilterCommon(inputs)
+			if outputID != "" {
+				for i, unique := range list.Vocabularies {
+					outputArtifactName := filepath.Dir(names[i]) + "/" + outputID
 					setVocabularyToArtifact(ctx, client, unique, outputArtifactName)
 				}
 			} else {
-				core.PrintMessage(output)
+				core.PrintMessage(list)
 			}
 		},
 	}
 
-	cmd.Flags().String("output_id", "vocabulary-unique", "id of artifact to store output.")
+	cmd.Flags().StringVar(&outputID, "output_id", "vocabulary-unique", "Artifact ID to use when saving each result vocabulary")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -36,7 +36,7 @@ var vocabularyVersionsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		flagset := cmd.LocalFlags()
-		outputArtifactName, err := flagset.GetString("output")
+		outputArtifactName, _ := flagset.GetString("output")
 		ctx := context.Background()
 		client, err := connection.NewClient(ctx)
 		if err != nil {

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func versionsCommand() *cobra.Command {
+func versionsCommand(ctx context.Context) *cobra.Command {
 	var output string
 	cmd := &cobra.Command{
 		Use:   "versions",

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -26,34 +26,38 @@ import (
 )
 
 func versionsCommand() *cobra.Command {
+	var output string
 	cmd := &cobra.Command{
 		Use:   "versions",
 		Short: "Compute the differences in API vocabularies associated with successive API versions",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			flagset := cmd.LocalFlags()
-			outputArtifactName, _ := flagset.GetString("output")
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.Fatalf("Failed to get filter from flags: %s", err)
+			}
+
 			ctx := context.Background()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.Fatalf("%s", err.Error())
 			}
-			names, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
+			names, inputs := collectInputVocabularies(ctx, client, args, filter)
 
 			parts := strings.Split(names[0], "/")
 			parts = parts[0:4]
 			parent := strings.Join(parts, "/")
 
-			output := vocabulary.Version(inputs, names, parent)
-			if outputArtifactName != "" {
-				setVersionHistoryToArtifact(ctx, client, output, outputArtifactName)
+			history := vocabulary.Version(inputs, names, parent)
+			if output != "" {
+				setVersionHistoryToArtifact(ctx, client, history, output)
 			} else {
-				core.PrintMessage(output)
+				core.PrintMessage(history)
 			}
 		},
 	}
 
-	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
+	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -25,34 +25,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	vocabularyVersionsCmd.Flags().String("output", "", "name of artifact where output should be stored")
-}
+func versionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "Compute the differences in API vocabularies associated with successive API versions",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			flagset := cmd.LocalFlags()
+			outputArtifactName, _ := flagset.GetString("output")
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			names, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
 
-var vocabularyVersionsCmd = &cobra.Command{
-	Use:   "versions",
-	Short: "Compute the differences in API vocabularies associated with successive API versions",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		flagset := cmd.LocalFlags()
-		outputArtifactName, _ := flagset.GetString("output")
-		ctx := context.Background()
-		client, err := connection.NewClient(ctx)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		names, inputs := collectInputVocabularies(ctx, client, args, vocabularyFilter)
+			parts := strings.Split(names[0], "/")
+			parts = parts[0:4]
+			parent := strings.Join(parts, "/")
 
-		parts := strings.Split(names[0], "/")
-		parts = parts[0:4]
-		parent := strings.Join(parts, "/")
+			output := vocabulary.Version(inputs, names, parent)
+			if outputArtifactName != "" {
+				setVersionHistoryToArtifact(ctx, client, output, outputArtifactName)
+			} else {
+				core.PrintMessage(output)
+			}
+		},
+	}
 
-		output := vocabulary.Version(inputs, names, parent)
-		if outputArtifactName != "" {
-			setVersionHistoryToArtifact(ctx, client, output, outputArtifactName)
-		} else {
-			core.PrintMessage(output)
-		}
-	},
+	cmd.Flags().String("output", "", "name of artifact where output should be stored")
+	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -58,6 +58,5 @@ func versionsCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().String("output", "", "Artifact name to use when saving the vocabulary artifact")
-	cmd.MarkFlagRequired("output")
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -37,11 +37,11 @@ func Command() *cobra.Command {
 		Short: "Operate on API vocabularies in the API Registry",
 	}
 
-	cmd.AddCommand(vocabularyDifferenceCmd)
-	cmd.AddCommand(vocabularyIntersectionCmd)
-	cmd.AddCommand(vocabularyUnionCmd)
-	cmd.AddCommand(vocabularyUniqueCmd)
-	cmd.AddCommand(vocabularyVersionsCmd)
+	cmd.AddCommand(differenceCommand())
+	cmd.AddCommand(intersectionCommand())
+	cmd.AddCommand(unionCommand())
+	cmd.AddCommand(uniqueCommand())
+	cmd.AddCommand(versionsCommand())
 
 	// TODO: Remove the global state.
 	cmd.PersistentFlags().StringVar(&vocabularyFilter, "filter", "", "filter vocabulary arguments")

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -23,9 +23,10 @@ import (
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/names"
-	metrics "github.com/googleapis/gnostic/metrics"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
+
+	metrics "github.com/googleapis/gnostic/metrics"
 )
 
 var vocabularyFilter string
@@ -79,13 +80,13 @@ func setVocabularyToArtifact(ctx context.Context, client connection.Client, outp
 	parts := strings.Split(outputArtifactName, "/artifacts/")
 	subject := parts[0]
 	relation := parts[1]
-	messageData, err := proto.Marshal(output)
+	messageData, _ := proto.Marshal(output)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("gnostic.metrics.Vocabulary"),
 		Contents: messageData,
 	}
-	err = core.SetArtifact(ctx, client, artifact)
+	err := core.SetArtifact(ctx, client, artifact)
 	if err != nil {
 		log.Fatalf("%s", err.Error())
 	}
@@ -95,13 +96,13 @@ func setVersionHistoryToArtifact(ctx context.Context, client connection.Client, 
 	parts := strings.Split(outputArtifactName, "/artifacts/")
 	subject := parts[0]
 	relation := parts[1]
-	messageData, err := proto.Marshal(output)
+	messageData, _ := proto.Marshal(output)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("gnostic.metrics.VersionHistory"),
 		Contents: messageData,
 	}
-	err = core.SetArtifact(ctx, client, artifact)
+	err := core.SetArtifact(ctx, client, artifact)
 	if err != nil {
 		log.Fatalf("%s", err.Error())
 	}

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -29,8 +29,6 @@ import (
 	metrics "github.com/googleapis/gnostic/metrics"
 )
 
-var vocabularyFilter string
-
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vocabulary",
@@ -43,8 +41,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(uniqueCommand())
 	cmd.AddCommand(versionsCommand())
 
-	// TODO: Remove the global state.
-	cmd.PersistentFlags().StringVar(&vocabularyFilter, "filter", "", "filter vocabulary arguments")
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	return cmd
 }
 

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -29,17 +29,17 @@ import (
 	metrics "github.com/googleapis/gnostic/metrics"
 )
 
-func Command() *cobra.Command {
+func Command(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vocabulary",
 		Short: "Operate on API vocabularies in the API Registry",
 	}
 
-	cmd.AddCommand(differenceCommand())
-	cmd.AddCommand(intersectionCommand())
-	cmd.AddCommand(unionCommand())
-	cmd.AddCommand(uniqueCommand())
-	cmd.AddCommand(versionsCommand())
+	cmd.AddCommand(differenceCommand(ctx))
+	cmd.AddCommand(intersectionCommand(ctx))
+	cmd.AddCommand(unionCommand(ctx))
+	cmd.AddCommand(uniqueCommand(ctx))
+	cmd.AddCommand(versionsCommand(ctx))
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	return cmd

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -22,7 +23,8 @@ import (
 )
 
 func main() {
-	cmd := cmd.Command()
+	ctx := context.Background()
+	cmd := cmd.Command(ctx)
 	if err := cmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Blocked by #218 to maintain git file history as much as possible. The diff will be hard to understand until that PR is merged. This change removes package-global variables, updates flag descriptions, addresses lint + staticcheck issues, and moves commands into functional constructors instead of package-level singletons with init function configuration.