### PR TITLE
Use empty non-nil field masks as implicit updates

### DIFF
--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -742,7 +742,7 @@ func TestUpdateApi(t *testing.T) {
 		want *rpc.Api
 	}{
 		{
-			desc: "implicit mask",
+			desc: "implicit nil mask",
 			seed: &rpc.Api{
 				Name:        "projects/my-project/apis/my-api",
 				DisplayName: "My Api",
@@ -753,6 +753,26 @@ func TestUpdateApi(t *testing.T) {
 					Name:        "projects/my-project/apis/my-api",
 					DisplayName: "My Updated Api",
 				},
+			},
+			want: &rpc.Api{
+				Name:        "projects/my-project/apis/my-api",
+				DisplayName: "My Updated Api",
+				Description: "Api for my APIs",
+			},
+		},
+		{
+			desc: "implicit empty mask",
+			seed: &rpc.Api{
+				Name:        "projects/my-project/apis/my-api",
+				DisplayName: "My Api",
+				Description: "Api for my APIs",
+			},
+			req: &rpc.UpdateApiRequest{
+				Api: &rpc.Api{
+					Name:        "projects/my-project/apis/my-api",
+					DisplayName: "My Updated Api",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{},
 			},
 			want: &rpc.Api{
 				Name:        "projects/my-project/apis/my-api",

--- a/server/actions_projects_test.go
+++ b/server/actions_projects_test.go
@@ -628,7 +628,7 @@ func TestUpdateProject(t *testing.T) {
 		want *rpc.Project
 	}{
 		{
-			desc: "implicit mask",
+			desc: "implicit nil mask",
 			seed: &rpc.Project{
 				Name:        "projects/my-project",
 				DisplayName: "My Project",
@@ -639,6 +639,26 @@ func TestUpdateProject(t *testing.T) {
 					Name:        "projects/my-project",
 					DisplayName: "My Updated Project",
 				},
+			},
+			want: &rpc.Project{
+				Name:        "projects/my-project",
+				DisplayName: "My Updated Project",
+				Description: "Project for my APIs",
+			},
+		},
+		{
+			desc: "implicit empty mask",
+			seed: &rpc.Project{
+				Name:        "projects/my-project",
+				DisplayName: "My Project",
+				Description: "Project for my APIs",
+			},
+			req: &rpc.UpdateProjectRequest{
+				Project: &rpc.Project{
+					Name:        "projects/my-project",
+					DisplayName: "My Updated Project",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{},
 			},
 			want: &rpc.Project{
 				Name:        "projects/my-project",

--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -965,7 +965,7 @@ func TestUpdateApiSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "implicit mask",
+			desc: "implicit nil mask",
 			seed: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 				Description: "My ApiSpec",
@@ -976,6 +976,26 @@ func TestUpdateApiSpec(t *testing.T) {
 					Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
 					Description: "My Updated ApiSpec",
 				},
+			},
+			want: &rpc.ApiSpec{
+				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Description: "My Updated ApiSpec",
+				Filename:    "openapi.json",
+			},
+		},
+		{
+			desc: "implicit empty mask",
+			seed: &rpc.ApiSpec{
+				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Description: "My ApiSpec",
+				Filename:    "openapi.json",
+			},
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+					Description: "My Updated ApiSpec",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{},
 			},
 			want: &rpc.ApiSpec{
 				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -775,7 +775,7 @@ func TestUpdateApiVersion(t *testing.T) {
 		want *rpc.ApiVersion
 	}{
 		{
-			desc: "implicit mask",
+			desc: "implicit nil mask",
 			seed: &rpc.ApiVersion{
 				Name:        "projects/my-project/apis/my-api/versions/v1",
 				DisplayName: "Version One",
@@ -786,6 +786,26 @@ func TestUpdateApiVersion(t *testing.T) {
 					Name:        "projects/my-project/apis/my-api/versions/v1",
 					Description: "My Updated ApiVersion",
 				},
+			},
+			want: &rpc.ApiVersion{
+				Name:        "projects/my-project/apis/my-api/versions/v1",
+				DisplayName: "Version One",
+				Description: "My Updated ApiVersion",
+			},
+		},
+		{
+			desc: "implicit empty mask",
+			seed: &rpc.ApiVersion{
+				Name:        "projects/my-project/apis/my-api/versions/v1",
+				DisplayName: "Version One",
+				Description: "My ApiVersion",
+			},
+			req: &rpc.UpdateApiVersionRequest{
+				ApiVersion: &rpc.ApiVersion{
+					Name:        "projects/my-project/apis/my-api/versions/v1",
+					Description: "My Updated ApiVersion",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{},
 			},
 			want: &rpc.ApiVersion{
 				Name:        "projects/my-project/apis/my-api/versions/v1",

--- a/server/models/update_masks.go
+++ b/server/models/update_masks.go
@@ -53,7 +53,7 @@ func ValidateMask(message protoreflect.ProtoMessage, mask *fieldmaskpb.FieldMask
 // When the mask argument is nil, only populated (non-default) fields are included.
 // When the mask argument only contains the wildcard character '*', every proto fields is included.
 func ExpandMask(m protoreflect.ProtoMessage, mask *fieldmaskpb.FieldMask) *fieldmaskpb.FieldMask {
-	if mask == nil {
+	if mask == nil || len(mask.GetPaths()) == 0 {
 		return populatedFields(m)
 	} else if len(mask.GetPaths()) == 1 && mask.Paths[0] == "*" {
 		return allFields(m)


### PR DESCRIPTION
The generated apg tool allows callers to set update_mask.paths with
fields, and defaults to an empty slice if none are provided. Every
request to update a resource from apg has a non-nil mask as a result.

This change adds a check for non-nil but empty field masks and behaves
the same as a nil mask in those cases, i.e. performs an implicit update.

Fixes #220 