### PR TITLE
Generate microsecond resolution timestamps

### DIFF
--- a/server/models/api.go
+++ b/server/models/api.go
@@ -40,7 +40,7 @@ type Api struct {
 
 // NewApi initializes a new resource.
 func NewApi(name names.Api, body *rpc.Api) (api *Api, err error) {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	api = &Api{
 		ProjectID:          name.ProjectID,
 		ApiID:              name.ApiID,

--- a/server/models/api.go
+++ b/server/models/api.go
@@ -100,7 +100,7 @@ func (api *Api) Message() (message *rpc.Api, err error) {
 
 // Update modifies a api using the contents of a message.
 func (api *Api) Update(message *rpc.Api, mask *fieldmaskpb.FieldMask) error {
-	api.UpdateTime = time.Now()
+	api.UpdateTime = time.Now().Round(time.Microsecond)
 	for _, field := range mask.Paths {
 		switch field {
 		case "display_name":

--- a/server/models/artifact.go
+++ b/server/models/artifact.go
@@ -40,7 +40,7 @@ type Artifact struct {
 
 // NewArtifact initializes a new resource.
 func NewArtifact(name names.Artifact, body *rpc.Artifact) *Artifact {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	artifact := &Artifact{
 		ProjectID:  name.ProjectID(),
 		ApiID:      name.ApiID(),

--- a/server/models/blob.go
+++ b/server/models/blob.go
@@ -37,7 +37,7 @@ type Blob struct {
 
 // NewBlobForSpec creates a new Blob object to store spec contents.
 func NewBlobForSpec(spec *Spec, contents []byte) *Blob {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	return &Blob{
 		ProjectID:   spec.ProjectID,
 		ApiID:       spec.ApiID,

--- a/server/models/blob.go
+++ b/server/models/blob.go
@@ -54,7 +54,7 @@ func NewBlobForSpec(spec *Spec, contents []byte) *Blob {
 
 // NewBlobForArtifact creates a new Blob object to store artifact contents.
 func NewBlobForArtifact(artifact *Artifact, contents []byte) *Blob {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	return &Blob{
 		ProjectID:   artifact.ProjectID,
 		ApiID:       artifact.ApiID,

--- a/server/models/project.go
+++ b/server/models/project.go
@@ -65,7 +65,7 @@ func (p *Project) Message() *rpc.Project {
 
 // Update modifies a project using the contents of a message.
 func (p *Project) Update(message *rpc.Project, mask *fieldmaskpb.FieldMask) {
-	p.UpdateTime = time.Now()
+	p.UpdateTime = time.Now().Round(time.Microsecond)
 	for _, field := range mask.GetPaths() {
 		switch field {
 		case "display_name":

--- a/server/models/project.go
+++ b/server/models/project.go
@@ -35,7 +35,7 @@ type Project struct {
 
 // NewProject initializes a new resource.
 func NewProject(name names.Project, body *rpc.Project) *Project {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	return &Project{
 		ProjectID:   name.ProjectID,
 		Description: body.GetDescription(),

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -49,7 +49,7 @@ type Spec struct {
 
 // NewSpec initializes a new resource.
 func NewSpec(name names.Spec, body *rpc.ApiSpec) (spec *Spec, err error) {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	spec = &Spec{
 		ProjectID:          name.ProjectID,
 		ApiID:              name.ApiID,
@@ -150,7 +150,7 @@ func (s *Spec) BasicMessage(name string) (message *rpc.ApiSpec, err error) {
 
 // Update modifies a spec using the contents of a message.
 func (s *Spec) Update(message *rpc.ApiSpec, mask *fieldmaskpb.FieldMask) error {
-	s.RevisionUpdateTime = time.Now()
+	s.RevisionUpdateTime = time.Now().Round(time.Microsecond)
 	for _, field := range mask.Paths {
 		switch field {
 		case "filename":
@@ -185,7 +185,7 @@ func (s *Spec) updateContents(contents []byte) {
 		s.RevisionID = newRevisionID()
 		s.SizeInBytes = int32(len(contents))
 
-		now := time.Now()
+		now := time.Now().Round(time.Microsecond)
 		s.RevisionCreateTime = now
 		s.RevisionUpdateTime = now
 	}
@@ -227,7 +227,7 @@ type SpecRevisionTag struct {
 
 // NewSpecRevisionTag initializes a new revision tag from a given revision name and tag string.
 func NewSpecRevisionTag(name names.SpecRevision, tag string) *SpecRevisionTag {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	return &SpecRevisionTag{
 		ProjectID:  name.ProjectID,
 		ApiID:      name.ApiID,

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -85,7 +85,7 @@ func NewSpec(name names.Spec, body *rpc.ApiSpec) (spec *Spec, err error) {
 
 // NewRevision returns a new revision based on the spec.
 func (s *Spec) NewRevision() *Spec {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	return &Spec{
 		ProjectID:          s.ProjectID,
 		ApiID:              s.ApiID,

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -40,7 +40,7 @@ type Version struct {
 
 // NewVersion initializes a new resource.
 func NewVersion(name names.Version, body *rpc.ApiVersion) (version *Version, err error) {
-	now := time.Now()
+	now := time.Now().Round(time.Microsecond)
 	version = &Version{
 		ProjectID:   name.ProjectID,
 		ApiID:       name.ApiID,

--- a/server/models/version.go
+++ b/server/models/version.go
@@ -100,7 +100,7 @@ func (v *Version) Message() (message *rpc.ApiVersion, err error) {
 
 // Update modifies a version using the contents of a message.
 func (v *Version) Update(message *rpc.ApiVersion, mask *fieldmaskpb.FieldMask) error {
-	v.UpdateTime = time.Now()
+	v.UpdateTime = time.Now().Round(time.Microsecond)
 	for _, field := range mask.Paths {
 		switch field {
 		case "display_name":


### PR DESCRIPTION
PostgreSQL doesn't support storage of nanosecond resolution timestamps
that can be generated in some environments. This change guarantees the
timestamps are created with a resolution that can be stored by our
supported databases.

Fixes #232 