### PR TITLE
Add unique per-process ID to registry command logs

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -17,10 +17,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/apigee/registry/cmd/registry/cmd"
+	"github.com/google/uuid"
 )
+
+// Initialize global default logger with unique process identifier.
+func init() {
+	uid := fmt.Sprintf("[ %.8s ] ", uuid.New())
+	log.SetPrefix(uid)
+}
 
 func main() {
 	ctx := context.Background()


### PR DESCRIPTION
Addresses some concerns from #243. Each child command will have a unique ID associated with its logs, allowing them to be inspected together as a group while ignoring interleaved logs from concurrently executing commands. This allows easy inspection of logs when commands are executed concurrently.

As our logging continues to improve we can relocate this unique ID into the command's context where it can be reused by the server logs for easier system-wide analysis. We will need to migrate away from using a global default logger before this can be implemented.

This change does not provide any information about the relationship between parent/child commands. For example, `registry resolve` may execute several children `registry` commands, and each will have a unique ID, but logs in the `registry resolve` command will not be able to reliably identify the logging IDs of their child commands (yet).