### PR TITLE
Include completion information in controller's tasks

### DIFF
--- a/cmd/registry/cmd/resolve/resolve.go
+++ b/cmd/registry/cmd/resolve/resolve.go
@@ -84,7 +84,7 @@ func Command(ctx context.Context) *cobra.Command {
 			}
 
 			if len(actions) == 0 {
-				log.Printf("No actions needed. The registry is already in a resolved state.")
+				log.Printf("Generated 0 actions. The registry is already in a resolved state.")
 				return
 			}
 

--- a/cmd/registry/controller/local-tasks.go
+++ b/cmd/registry/controller/local-tasks.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -36,12 +37,14 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 		return fmt.Errorf("'resolve' not allowed in action, cannot invoke %q", task.Action)
 	}
 	cmd := exec.Command("registry", strings.Fields(task.Action)...)
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	err := cmd.Run()
+	details := fmt.Sprintf("action={%s} taskID={%s}", task.Action, task.TaskID)
 
 	if err != nil {
+		log.Printf("Failed Execution: %s Error: %s", details, err)
 		return err
 	}
-	log.Printf("Finished executing taskId %s with action: %s\n Output: %s", task.TaskID, task.Action, output)
-
+	log.Printf("Successful Execution: %s", details)
 	return nil
 }


### PR DESCRIPTION
This PR includes the following changes:
1) Setting the output of child commands to StdOut and StdErr so that the logs generated by the child commands are all visible.
2) `local-tasks.go`: Each individual go routine will log the completion of a command execution by logging the status, action and taskID (will be tied to child command's uid in the future). This information should be enough for now to generate basic summary dashboards like: total num actions, num failures, % success, etc
