### PR TITLE
Add "/locations/global" to the names of all resources below projects.

### DIFF
--- a/cmd/registry-graphql/graphql/apis.go
+++ b/cmd/registry-graphql/graphql/apis.go
@@ -74,7 +74,7 @@ func resolveAPIs(p graphql.ResolveParams) (interface{}, error) {
 		return nil, err
 	}
 	req := &rpc.ListApisRequest{
-		Parent: getParentFromParams(p),
+		Parent: getParentFromParams(p) + "/locations/global",
 	}
 	filter, isFound := p.Args["filter"].(string)
 	if isFound {

--- a/cmd/registry-graphql/graphql/graphql_test.go
+++ b/cmd/registry-graphql/graphql/graphql_test.go
@@ -158,7 +158,7 @@ func buildTestProject(ctx context.Context, registryClient connection.Client, t *
 	// Create test APIs.
 	for i := 0; i < apiCount; i++ {
 		req := &rpc.CreateApiRequest{
-			Parent: project.GetName(),
+			Parent: project.GetName() + "/locations/global",
 			ApiId:  fmt.Sprintf("api%03d", i),
 			Api: &rpc.Api{
 				DisplayName:  fmt.Sprintf("API-%03d", i),

--- a/cmd/registry/cmd/annotate/annotate_test.go
+++ b/cmd/registry/cmd/annotate/annotate_test.go
@@ -30,7 +30,7 @@ func TestAnnotate(t *testing.T) {
 		projectID   = "annotate-test"
 		projectName = "projects/" + projectID
 		apiID       = "sample"
-		apiName     = projectName + "/apis/" + apiID
+		apiName     = projectName + "/locations/global/apis/" + apiID
 		versionID   = "1.0.0"
 		versionName = apiName + "/versions/" + versionID
 		specID      = "openapi.json"
@@ -64,7 +64,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// Create a sample api.
 	_, err = registryClient.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: projectName,
+		Parent: projectName + "/locations/global",
 		ApiId:  apiID,
 		Api:    &rpc.Api{},
 	})

--- a/cmd/registry/cmd/export/csv_test.go
+++ b/cmd/registry/cmd/export/csv_test.go
@@ -60,7 +60,7 @@ func TestExportCSV(t *testing.T) {
 	}
 
 	api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: project.GetName(),
+		Parent: project.GetName() + "/locations/global",
 		ApiId:  apiID,
 		Api:    &rpc.Api{},
 	})

--- a/cmd/registry/cmd/label/label_test.go
+++ b/cmd/registry/cmd/label/label_test.go
@@ -30,7 +30,7 @@ func TestLabel(t *testing.T) {
 		projectID   = "label-test"
 		projectName = "projects/" + projectID
 		apiID       = "sample"
-		apiName     = projectName + "/apis/" + apiID
+		apiName     = projectName + "/locations/global/apis/" + apiID
 		versionID   = "1.0.0"
 		versionName = apiName + "/versions/" + versionID
 		specID      = "openapi.json"
@@ -64,7 +64,7 @@ func TestLabel(t *testing.T) {
 	}
 	// Create a sample api.
 	_, err = registryClient.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: projectName,
+		Parent: projectName + "/locations/global",
 		ApiId:  apiID,
 		Api:    &rpc.Api{},
 	})

--- a/cmd/registry/cmd/resolve/resolve_test.go
+++ b/cmd/registry/cmd/resolve/resolve_test.go
@@ -79,7 +79,7 @@ func TestResolve(t *testing.T) {
 
 	// Create API
 	api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: project.Name,
+		Parent: project.Name + "/locations/global",
 		ApiId:  "petstore",
 		Api: &rpc.Api{
 			DisplayName:  "petstore",
@@ -194,7 +194,7 @@ func TestResolve(t *testing.T) {
 	}
 
 	resolveCmd := Command(ctx)
-	args = []string{"projects/" + testProject + "/artifacts/test-manifest"}
+	args = []string{"projects/" + testProject + "/locations/global/artifacts/test-manifest"}
 	resolveCmd.SetArgs(args)
 	if err = resolveCmd.Execute(); err != nil {
 		t.Fatalf("Execute() with args %v returned error: %s", args, err)
@@ -202,7 +202,7 @@ func TestResolve(t *testing.T) {
 
 	// List all the artifacts
 	got := make([]string, 0)
-	listPattern := "projects/controller-demo/apis/petstore/versions/-/specs/-/artifacts/-"
+	listPattern := "projects/controller-demo/locations/global/apis/petstore/versions/-/specs/-/artifacts/-"
 	segments := names.ArtifactRegexp().FindStringSubmatch(listPattern)
 	_ = core.ListArtifacts(ctx, client, segments, "", false,
 		func(artifact *rpc.Artifact) {

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -174,7 +174,7 @@ type uploadSpecTask struct {
 
 func (t uploadSpecTask) Run(ctx context.Context) error {
 	api, err := t.client.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: fmt.Sprintf("projects/%s", t.projectID),
+		Parent: fmt.Sprintf("projects/%s/locations/global", t.projectID),
 		ApiId:  t.apiID,
 		Api:    &rpc.Api{},
 	})
@@ -184,7 +184,7 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		log.Printf("Created API: %s", api.GetName())
 	case codes.AlreadyExists:
 		api = &rpc.Api{
-			Name: fmt.Sprintf("projects/%s/apis/%s", t.projectID, t.apiID),
+			Name: fmt.Sprintf("projects/%s/locations/global/apis/%s", t.projectID, t.apiID),
 		}
 	default:
 		return fmt.Errorf("failed to ensure API exists: %s", err)

--- a/cmd/registry/cmd/upload/csv_test.go
+++ b/cmd/registry/cmd/upload/csv_test.go
@@ -70,22 +70,22 @@ func TestUploadCSV(t *testing.T) {
 			},
 			want: []*rpc.ApiSpec{
 				{
-					Name:     fmt.Sprintf("projects/%s/apis/cloudtasks/versions/v2beta2/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2beta2/specs/openapi.yaml", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: cloudtasksBeta,
 				},
 				{
-					Name:     fmt.Sprintf("projects/%s/apis/cloudtasks/versions/v2/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2/specs/openapi.yaml", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: cloudtasksGA,
 				},
 				{
-					Name:     fmt.Sprintf("projects/%s/apis/datastore/versions/v1beta1/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/datastore/versions/v1beta1/specs/openapi.yaml", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: datastoreBeta,
 				},
 				{
-					Name:     fmt.Sprintf("projects/%s/apis/datastore/versions/v1/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/datastore/versions/v1/specs/openapi.yaml", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: datastoreGA,
 				},
@@ -99,7 +99,7 @@ func TestUploadCSV(t *testing.T) {
 			},
 			want: []*rpc.ApiSpec{
 				{
-					Name:     fmt.Sprintf("projects/%s/apis/cloudtasks/versions/v2/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2/specs/openapi.yaml", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: cloudtasksGA,
 				},
@@ -139,7 +139,7 @@ func TestUploadCSV(t *testing.T) {
 			}
 
 			it := client.ListApiSpecs(ctx, &rpc.ListApiSpecsRequest{
-				Parent:   fmt.Sprintf("projects/%s/apis/-/versions/-", testProject),
+				Parent:   fmt.Sprintf("projects/%s/locations/global/apis/-/versions/-", testProject),
 				PageSize: int32(len(test.want)),
 			})
 

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -72,7 +72,7 @@ func manifestCommand(ctx context.Context) *cobra.Command {
 			}
 
 			artifact := &rpc.Artifact{
-				Name:     "projects/" + projectID + "/artifacts/" + manifest.Name,
+				Name:     "projects/" + projectID + "/locations/global/artifacts/" + manifest.Name,
 				MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.Manifest"),
 				Contents: manifestData,
 			}

--- a/cmd/registry/cmd/upload/manifest_test.go
+++ b/cmd/registry/cmd/upload/manifest_test.go
@@ -92,7 +92,7 @@ func TestManifestUpload(t *testing.T) {
 			}
 
 			req := &rpc.GetArtifactContentsRequest{
-				Name: "projects/" + test.project + "/artifacts/test-manifest",
+				Name: "projects/" + test.project + "/locations/global/artifacts/test-manifest",
 			}
 
 			manifest := rpc.Manifest{}

--- a/cmd/registry/controller/controller.go
+++ b/cmd/registry/controller/controller.go
@@ -53,7 +53,7 @@ func processManifestResource(
 	projectID string,
 	resource *rpc.GeneratedResource) ([]string, error) {
 	// Generate dependency map
-	resourcePattern := fmt.Sprintf("projects/%s/%s", projectID, resource.Pattern)
+	resourcePattern := fmt.Sprintf("projects/%s/locations/global/%s", projectID, resource.Pattern)
 	dependencyMaps := make([]map[string]ResourceCollection, 0, len(resource.Dependencies))
 	for _, d := range resource.Dependencies {
 		dMap, err := generateDependencyMap(ctx, client, resourcePattern, d.Pattern, d.Filter)

--- a/cmd/registry/controller/controller_test.go
+++ b/cmd/registry/controller/controller_test.go
@@ -231,9 +231,9 @@ func TestSingleSpec(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 
 	// Test the manifest
 	manifest := manifests[0]
@@ -241,7 +241,7 @@ func TestSingleSpec(t *testing.T) {
 	if err != nil {
 		log.Printf(err.Error())
 	}
-	expectedActions := []string{"compute lint projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic"}
+	expectedActions := []string{"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic"}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
 	}
@@ -263,16 +263,16 @@ func TestMultipleSpecs(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
 
 	// Test the manifest
 	manifest := manifests[0]
@@ -281,9 +281,9 @@ func TestMultipleSpecs(t *testing.T) {
 		log.Printf(err.Error())
 	}
 	expectedActions := []string{
-		"compute lint projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
-		"compute lint projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
-		"compute lint projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic"}
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic"}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
 	}
@@ -307,17 +307,17 @@ func TestPartiallyExistingArtifacts(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
 
 	// Test the manifest
 	manifest := manifests[0]
@@ -326,8 +326,8 @@ func TestPartiallyExistingArtifacts(t *testing.T) {
 		log.Printf(err.Error())
 	}
 	expectedActions := []string{
-		"compute lint projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
-		"compute lint projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic"}
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic"}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
 	}
@@ -350,20 +350,20 @@ func TestOutdatedArtifacts(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
 	// Update spec 1.0.1 to make the artifact outdated
-	updateSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml")
+	updateSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml")
 
 	// Test the manifest
 	manifest := manifests[0]
@@ -372,8 +372,8 @@ func TestOutdatedArtifacts(t *testing.T) {
 		log.Printf(err.Error())
 	}
 	expectedActions := []string{
-		"compute lint projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
-		"compute lint projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic"}
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
+		"compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic"}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
 	}
@@ -394,28 +394,28 @@ func TestApiLevelArtifactsCreate(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "test-api-1")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "test-api-1")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-1", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-1", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-1", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
 
 	// Test API 2
-	createApi(ctx, registryClient, t, "projects/controller-test", "test-api-2")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "test-api-2")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-2", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-2", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-2", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
 
 	// Test the manifest
 	manifest := manifests[1]
@@ -424,8 +424,8 @@ func TestApiLevelArtifactsCreate(t *testing.T) {
 		log.Printf(err.Error())
 	}
 	expectedActions := []string{
-		"compute vocabulary projects/controller-test/apis/test-api-1",
-		"compute vocabulary projects/controller-test/apis/test-api-2"}
+		"compute vocabulary projects/controller-test/locations/global/apis/test-api-1",
+		"compute vocabulary projects/controller-test/locations/global/apis/test-api-2"}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
 	}
@@ -445,32 +445,32 @@ func TestApiLevelArtifactsOutdated(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "test-api-1")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "test-api-1")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-1", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-1", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-1", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/test-api-1/artifacts/vocabulary")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-1/artifacts/vocabulary")
 
 	// Test API 2
-	createApi(ctx, registryClient, t, "projects/controller-test", "test-api-2")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "test-api-2")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-2", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-2", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/test-api-2", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/artifacts/vocabulary")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/artifacts/vocabulary")
 	// Update underlying spec to make artifact outdated
-	updateSpec(ctx, registryClient, t, "projects/controller-test/apis/test-api-2/versions/1.0.1/specs/openapi.yaml")
+	updateSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi.yaml")
 
 	// Test the manifest
 	manifest := manifests[1]
@@ -479,7 +479,7 @@ func TestApiLevelArtifactsOutdated(t *testing.T) {
 		log.Printf(err.Error())
 	}
 	expectedActions := []string{
-		"compute vocabulary projects/controller-test/apis/test-api-2"}
+		"compute vocabulary projects/controller-test/locations/global/apis/test-api-2"}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
 	}
@@ -500,22 +500,22 @@ func TestDerivedArtifactsCreate(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity")
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity")
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
 
 	// Test the manifest
 	manifest := manifests[2]
@@ -526,16 +526,16 @@ func TestDerivedArtifactsCreate(t *testing.T) {
 	expectedActions := []string{
 		fmt.Sprintf(
 			"compute score %s %s",
-			"projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
-			"projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
 		fmt.Sprintf(
 			"compute score %s %s",
-			"projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
-			"projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
 		fmt.Sprintf(
 			"compute score %s %s",
-			"projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
-			"projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
+			"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+			"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
 	}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
@@ -556,20 +556,20 @@ func TestDerivedArtifactsMissing(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity")
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
 
 	// Test the manifest
 	manifest := manifests[2]
@@ -580,8 +580,8 @@ func TestDerivedArtifactsMissing(t *testing.T) {
 	expectedActions := []string{
 		fmt.Sprintf(
 			"compute score %s %s",
-			"projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
-			"projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
 	}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)
@@ -602,30 +602,30 @@ func TestDerivedArtifactsOutdated(t *testing.T) {
 	// Setup
 	deleteProject(ctx, registryClient, t, "controller-test")
 	createProject(ctx, registryClient, t, "controller-test")
-	createApi(ctx, registryClient, t, "projects/controller-test", "petstore")
+	createApi(ctx, registryClient, t, "projects/controller-test/locations/global", "petstore")
 
 	// Version 1.0.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score")
 	// Version 1.0.1
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.0.1")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.0.1")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score")
 	// Version 1.1.0
-	createVersion(ctx, registryClient, t, "projects/controller-test/apis/petstore", "1.1.0")
-	createSpec(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score")
+	createVersion(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore", "1.1.0")
+	createSpec(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0", "openapi.yaml", gzipOpenAPIv3)
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score")
 
 	// Make some artifacts outdated from the above setup
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
-	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")
+	createUpdateArtifact(ctx, registryClient, t, "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity")
 
 	// Test the manifest
 	manifest := manifests[2]
@@ -636,12 +636,12 @@ func TestDerivedArtifactsOutdated(t *testing.T) {
 	expectedActions := []string{
 		fmt.Sprintf(
 			"compute score %s %s",
-			"projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
-			"projects/controller-test/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+			"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
 		fmt.Sprintf(
 			"compute score %s %s",
-			"projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
-			"projects/controller-test/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
+			"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+			"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
 	}
 	if diff := cmp.Diff(expectedActions, actions, sortStrings); diff != "" {
 		t.Errorf("ProcessManifest(%+v) returned unexpected diff (-want +got):\n%s", manifest, diff)

--- a/cmd/registry/core/list.go
+++ b/cmd/registry/core/list.go
@@ -55,7 +55,7 @@ func ListAPIs(ctx context.Context,
 	filterFlag string,
 	handler ApiHandler) error {
 	request := &rpc.ListApisRequest{
-		Parent: "projects/" + segments[1],
+		Parent: "projects/" + segments[1] + "/locations/global",
 	}
 	filter := filterFlag
 	if len(segments) == 3 && segments[2] != "-" {
@@ -83,7 +83,7 @@ func ListVersions(ctx context.Context,
 	filterFlag string,
 	handler VersionHandler) error {
 	request := &rpc.ListApiVersionsRequest{
-		Parent: "projects/" + segments[1] + "/apis/" + segments[2],
+		Parent: "projects/" + segments[1] + "/locations/global/apis/" + segments[2],
 	}
 	filter := filterFlag
 	if len(segments) == 4 && segments[3] != "-" {
@@ -111,7 +111,7 @@ func ListSpecs(ctx context.Context,
 	filterFlag string,
 	handler SpecHandler) error {
 	request := &rpc.ListApiSpecsRequest{
-		Parent: "projects/" + segments[1] + "/apis/" + segments[2] + "/versions/" + segments[3],
+		Parent: "projects/" + segments[1] + "/locations/global/apis/" + segments[2] + "/versions/" + segments[3],
 	}
 	filter := filterFlag
 	if len(segments) > 4 && segments[4] != "-" {
@@ -139,7 +139,7 @@ func ListSpecRevisions(ctx context.Context,
 	filterFlag string,
 	handler SpecHandler) error {
 	request := &rpc.ListApiSpecRevisionsRequest{
-		Name: "projects/" + segments[1] +
+		Name: "projects/" + segments[1] + "/locations/global" +
 			"/apis/" + segments[2] +
 			"/versions/" + segments[3] +
 			"/specs/" + segments[4],
@@ -163,7 +163,7 @@ func ListArtifacts(ctx context.Context,
 	filterFlag string,
 	getContents bool,
 	handler ArtifactHandler) error {
-	parent := "projects/" + segments[1]
+	parent := "projects/" + segments[1] + "/locations/global"
 	if segments[3] != "" {
 		parent += "/apis/" + segments[3]
 		if segments[5] != "" {
@@ -213,7 +213,7 @@ func ListArtifactsForParent(ctx context.Context,
 	client *gapic.RegistryClient,
 	segments []string,
 	handler ArtifactHandler) error {
-	parent := "projects/" + segments[1]
+	parent := "projects/" + segments[1] + "/locations/global"
 	if len(segments) > 2 {
 		parent += "/apis/" + segments[2]
 		if len(segments) > 3 {

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -39,7 +39,7 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 		return nil, status.Errorf(codes.InvalidArgument, "invalid api %+v: body must be provided", req.GetApi())
 	}
 
-	parent, err := names.ParseProject(req.GetParent())
+	parent, err := names.ParseProjectWithLocation(req.GetParent())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -149,7 +149,7 @@ func (s *RegistryServer) ListApis(ctx context.Context, req *rpc.ListApisRequest)
 		req.PageSize = 50
 	}
 
-	parent, err := names.ParseProject(req.GetParent())
+	parent, err := names.ParseProjectWithLocation(req.GetParent())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/server/actions_apis_test.go
+++ b/server/actions_apis_test.go
@@ -44,7 +44,7 @@ func seedApis(ctx context.Context, t *testing.T, s *RegistryServer, apis ...*rpc
 		})
 
 		req := &rpc.CreateApiRequest{
-			Parent: parent.String(),
+			Parent: parent.String() + "/locations/global",
 			ApiId:  name.ApiID,
 			Api:    api,
 		}
@@ -71,7 +71,7 @@ func TestCreateApi(t *testing.T) {
 				Name: "projects/my-project",
 			},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "my-api",
 				Api: &rpc.Api{
 					DisplayName:        "My Display Name",
@@ -87,7 +87,7 @@ func TestCreateApi(t *testing.T) {
 				},
 			},
 			want: &rpc.Api{
-				Name:               "projects/my-project/apis/my-api",
+				Name:               "projects/my-project/locations/global/apis/my-api",
 				DisplayName:        "My Display Name",
 				Description:        "My Description",
 				Availability:       "My Availability",
@@ -158,7 +158,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "parent not found",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/other-project",
+				Parent: "projects/other-project/locations/global",
 				ApiId:  "valid-id",
 				Api:    &rpc.Api{},
 			},
@@ -168,7 +168,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "missing resource body",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "valid-id",
 				Api:    nil,
 			},
@@ -178,7 +178,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "missing custom identifier",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "",
 				Api:    &rpc.Api{},
 			},
@@ -188,7 +188,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "long custom identifier",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "this-identifier-is-invalid-because-it-exceeds-the-eighty-character-maximum-length",
 				Api:    &rpc.Api{},
 			},
@@ -198,7 +198,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "custom identifier underscores",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "underscore_identifier",
 				Api:    &rpc.Api{},
 			},
@@ -208,7 +208,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "custom identifier hyphen prefix",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "-identifier",
 				Api:    &rpc.Api{},
 			},
@@ -218,7 +218,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "custom identifier hyphen suffix",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "identifier-",
 				Api:    &rpc.Api{},
 			},
@@ -228,7 +228,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "customer identifier uuid format",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "072d2288-c685-42d8-9df0-5edbb2a809ea",
 				Api:    &rpc.Api{},
 			},
@@ -238,7 +238,7 @@ func TestCreateApiResponseCodes(t *testing.T) {
 			desc: "custom identifier mixed case",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "IDentifier",
 				Api:    &rpc.Api{},
 			},
@@ -268,9 +268,9 @@ func TestCreateApiDuplicates(t *testing.T) {
 	}{
 		{
 			desc: "case sensitive",
-			seed: &rpc.Api{Name: "projects/my-project/apis/my-api"},
+			seed: &rpc.Api{Name: "projects/my-project/locations/global/apis/my-api"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "my-api",
 				Api:    &rpc.Api{},
 			},
@@ -278,9 +278,9 @@ func TestCreateApiDuplicates(t *testing.T) {
 		},
 		{
 			desc: "case insensitive",
-			seed: &rpc.Api{Name: "projects/my-project/apis/my-api"},
+			seed: &rpc.Api{Name: "projects/my-project/locations/global/apis/my-api"},
 			req: &rpc.CreateApiRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				ApiId:  "My-Api",
 				Api:    &rpc.Api{},
 			},
@@ -311,7 +311,7 @@ func TestGetApi(t *testing.T) {
 		{
 			desc: "fully populated resource",
 			seed: &rpc.Api{
-				Name:               "projects/my-project/apis/my-api",
+				Name:               "projects/my-project/locations/global/apis/my-api",
 				DisplayName:        "My Display Name",
 				Description:        "My Description",
 				Availability:       "My Availability",
@@ -324,10 +324,10 @@ func TestGetApi(t *testing.T) {
 				},
 			},
 			req: &rpc.GetApiRequest{
-				Name: "projects/my-project/apis/my-api",
+				Name: "projects/my-project/locations/global/apis/my-api",
 			},
 			want: &rpc.Api{
-				Name:               "projects/my-project/apis/my-api",
+				Name:               "projects/my-project/locations/global/apis/my-api",
 				DisplayName:        "My Display Name",
 				Description:        "My Description",
 				Availability:       "My Availability",
@@ -421,7 +421,7 @@ func TestListApis(t *testing.T) {
 				{Name: "projects/other-project/locations/global/apis/api1"},
 			},
 			req: &rpc.ListApisRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 			},
 			want: &rpc.ListApisResponse{
 				Apis: []*rpc.Api{
@@ -440,7 +440,7 @@ func TestListApis(t *testing.T) {
 				{Name: "projects/other-project/locations/global/apis/api1"},
 			},
 			req: &rpc.ListApisRequest{
-				Parent: "projects/-",
+				Parent: "projects/-/locations/global",
 			},
 			want: &rpc.ListApisResponse{
 				Apis: []*rpc.Api{
@@ -459,7 +459,7 @@ func TestListApis(t *testing.T) {
 				{Name: "projects/my-project/locations/global/apis/api3"},
 			},
 			req: &rpc.ListApisRequest{
-				Parent:   "projects/my-project",
+				Parent:   "projects/my-project/locations/global",
 				PageSize: 1,
 			},
 			want: &rpc.ListApisResponse{
@@ -479,7 +479,7 @@ func TestListApis(t *testing.T) {
 				{Name: "projects/my-project/locations/global/apis/api3"},
 			},
 			req: &rpc.ListApisRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				Filter: "name == 'projects/my-project/locations/global/apis/api2'",
 			},
 			want: &rpc.ListApisResponse{
@@ -499,7 +499,7 @@ func TestListApis(t *testing.T) {
 				{Name: "projects/my-project/locations/global/apis/api3"},
 			},
 			req: &rpc.ListApisRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 				Filter: "description != ''",
 			},
 			want: &rpc.ListApisResponse{
@@ -556,7 +556,7 @@ func TestListApisResponseCodes(t *testing.T) {
 		{
 			desc: "parent not found",
 			req: &rpc.ListApisRequest{
-				Parent: "projects/my-project",
+				Parent: "projects/my-project/locations/global",
 			},
 			want: codes.NotFound,
 		},
@@ -610,7 +610,7 @@ func TestListApisSequence(t *testing.T) {
 	var nextToken string
 	t.Run("first page", func(t *testing.T) {
 		req := &rpc.ListApisRequest{
-			Parent:   "projects/my-project",
+			Parent:   "projects/my-project/locations/global",
 			PageSize: 1,
 		}
 
@@ -637,7 +637,7 @@ func TestListApisSequence(t *testing.T) {
 
 	t.Run("intermediate page", func(t *testing.T) {
 		req := &rpc.ListApisRequest{
-			Parent:    "projects/my-project",
+			Parent:    "projects/my-project/locations/global",
 			PageSize:  1,
 			PageToken: nextToken,
 		}
@@ -665,7 +665,7 @@ func TestListApisSequence(t *testing.T) {
 
 	t.Run("final page", func(t *testing.T) {
 		req := &rpc.ListApisRequest{
-			Parent:    "projects/my-project",
+			Parent:    "projects/my-project/locations/global",
 			PageSize:  1,
 			PageToken: nextToken,
 		}
@@ -715,7 +715,7 @@ func TestListApisLargeCollectionFiltering(t *testing.T) {
 	}
 
 	req := &rpc.ListApisRequest{
-		Parent:   "projects/my-project",
+		Parent:   "projects/my-project/locations/global",
 		PageSize: 1,
 		Filter:   "name == 'projects/my-project/locations/global/apis/a099'",
 	}
@@ -744,18 +744,18 @@ func TestUpdateApi(t *testing.T) {
 		{
 			desc: "implicit nil mask",
 			seed: &rpc.Api{
-				Name:        "projects/my-project/apis/my-api",
+				Name:        "projects/my-project/locations/global/apis/my-api",
 				DisplayName: "My Api",
 				Description: "Api for my APIs",
 			},
 			req: &rpc.UpdateApiRequest{
 				Api: &rpc.Api{
-					Name:        "projects/my-project/apis/my-api",
+					Name:        "projects/my-project/locations/global/apis/my-api",
 					DisplayName: "My Updated Api",
 				},
 			},
 			want: &rpc.Api{
-				Name:        "projects/my-project/apis/my-api",
+				Name:        "projects/my-project/locations/global/apis/my-api",
 				DisplayName: "My Updated Api",
 				Description: "Api for my APIs",
 			},

--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -40,7 +40,7 @@ func parseArtifactParent(name string) (artifactParent, error) {
 		return v, nil
 	} else if a, err := names.ParseApi(name); err == nil {
 		return a, nil
-	} else if p, err := names.ParseProject(name); err == nil {
+	} else if p, err := names.ParseProjectWithLocation(name); err == nil {
 		return p, nil
 	}
 

--- a/server/actions_spec_revisions_test.go
+++ b/server/actions_spec_revisions_test.go
@@ -287,7 +287,7 @@ func TestListApiSpecRevisions(t *testing.T) {
 	})
 
 	createReq := &rpc.CreateApiSpecRequest{
-		Parent:    "projects/my-project/apis/my-api/versions/v1",
+		Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 		ApiSpecId: "my-spec",
 		ApiSpec:   &rpc.ApiSpec{},
 	}
@@ -401,7 +401,7 @@ func TestUpdateApiSpecRevisions(t *testing.T) {
 	})
 
 	createReq := &rpc.CreateApiSpecRequest{
-		Parent:    "projects/my-project/apis/my-api/versions/v1",
+		Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 		ApiSpecId: "my-spec",
 		ApiSpec: &rpc.ApiSpec{
 			Description: "Empty First Revision",

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -82,7 +82,7 @@ func (s *RegistryServer) createSpec(ctx context.Context, name names.Spec, body *
 		return nil, err
 	}
 
-	message, err := spec.BasicMessage(name.String())
+	message, err := spec.BasicMessage(name.String(), []string{})
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -142,7 +142,12 @@ func (s *RegistryServer) getApiSpec(ctx context.Context, name names.Spec) (*rpc.
 		return nil, err
 	}
 
-	message, err := spec.BasicMessage(name.String())
+	tags, err := revisionTags(ctx, db, name.Revision(spec.RevisionID))
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := spec.BasicMessage(name.String(), tags)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -163,7 +168,12 @@ func (s *RegistryServer) getApiSpecRevision(ctx context.Context, name names.Spec
 		return nil, err
 	}
 
-	message, err := revision.BasicMessage(name.String())
+	tags, err := revisionTags(ctx, db, name)
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := revision.BasicMessage(name.String(), tags)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -266,8 +276,14 @@ func (s *RegistryServer) ListApiSpecs(ctx context.Context, req *rpc.ListApiSpecs
 		NextPageToken: listing.Token,
 	}
 
+	tags, err := db.GetSpecTags(ctx, parent.Spec("-"))
+	if err != nil {
+		return nil, err
+	}
+
+	tagsByRev := tagsByRevision(tags)
 	for i, spec := range listing.Specs {
-		response.ApiSpecs[i], err = spec.BasicMessage(spec.Name())
+		response.ApiSpecs[i], err = spec.BasicMessage(spec.Name(), tagsByRev[spec.RevisionName()])
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -304,7 +320,8 @@ func (s *RegistryServer) UpdateApiSpec(ctx context.Context, req *rpc.UpdateApiSp
 	}
 
 	// Apply the update to the spec - possibly changing the revision ID.
-	if err := spec.Update(req.GetApiSpec(), models.ExpandMask(req.GetApiSpec(), req.GetUpdateMask())); err != nil {
+	maskExpansion := models.ExpandMask(req.GetApiSpec(), req.GetUpdateMask())
+	if err := spec.Update(req.GetApiSpec(), maskExpansion); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -314,19 +331,55 @@ func (s *RegistryServer) UpdateApiSpec(ctx context.Context, req *rpc.UpdateApiSp
 	}
 
 	// If the spec contents were updated, save a new blob.
-	implicitUpdate := req.GetUpdateMask() == nil && len(req.ApiSpec.GetContents()) > 0
-	explicitUpdate := len(fieldmaskpb.Intersect(req.GetUpdateMask(), &fieldmaskpb.FieldMask{Paths: []string{"contents"}}).GetPaths()) > 0
-	if implicitUpdate || explicitUpdate {
+	if len(fieldmaskpb.Intersect(maskExpansion, &fieldmaskpb.FieldMask{Paths: []string{"contents"}}).GetPaths()) > 0 {
 		if err := db.SaveSpecRevisionContents(ctx, spec, req.ApiSpec.GetContents()); err != nil {
 			return nil, err
 		}
 	}
 
-	message, err := spec.BasicMessage(name.String())
+	tags, err := revisionTags(ctx, db, name.Revision(spec.RevisionID))
+	if err != nil {
+		return nil, err
+	}
+
+	message, err := spec.BasicMessage(name.String(), tags)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	s.notify(ctx, rpc.Notification_UPDATED, spec.RevisionName())
 	return message, nil
+}
+
+func revisionTags(ctx context.Context, db dao.DAO, name names.SpecRevision) ([]string, error) {
+	allTags, err := db.GetSpecTags(ctx, name.Spec())
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make([]string, 0)
+	for _, tag := range allTags {
+		if tag.RevisionID == name.RevisionID {
+			tags = append(tags, tag.Tag)
+		}
+	}
+
+	return tags, nil
+}
+
+func tagsByRevision(tags []*models.SpecRevisionTag) map[string][]string {
+	revTags := make(map[string][]string, len(tags))
+	for _, tag := range tags {
+		rev := names.SpecRevision{
+			ProjectID:  tag.ProjectID,
+			ApiID:      tag.ApiID,
+			VersionID:  tag.VersionID,
+			SpecID:     tag.SpecID,
+			RevisionID: tag.RevisionID,
+		}.String()
+
+		revTags[rev] = append(revTags[rev], tag.Tag)
+	}
+
+	return revTags
 }

--- a/server/actions_specs_test.go
+++ b/server/actions_specs_test.go
@@ -75,7 +75,7 @@ func TestCreateApiSpec(t *testing.T) {
 	}{
 		{
 			desc: "fully populated resource",
-			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
 				Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 				ApiSpecId: "my-spec",
@@ -94,7 +94,7 @@ func TestCreateApiSpec(t *testing.T) {
 				},
 			},
 			want: &rpc.ApiSpec{
-				Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Name:         "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 				Filename:     "openapi.json",
 				Description:  "My Description",
 				MimeType:     "application/x.openapi;version=3.0.0",
@@ -174,7 +174,7 @@ func TestCreateApiSpecResponseCodes(t *testing.T) {
 			desc: "parent not found",
 			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
-				Parent:    "projects/my-project/apis/my-api/versions/v2",
+				Parent:    "projects/my-project/locations/global/apis/my-api/versions/v2",
 				ApiSpecId: "valid-id",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -184,7 +184,7 @@ func TestCreateApiSpecResponseCodes(t *testing.T) {
 			desc: "missing resource body",
 			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
-				Parent:    "projects/my-project/apis/my-api/versions/v1",
+				Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 				ApiSpecId: "valid-id",
 				ApiSpec:   nil,
 			},
@@ -192,9 +192,9 @@ func TestCreateApiSpecResponseCodes(t *testing.T) {
 		},
 		{
 			desc: "missing custom identifier",
-			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiSpecRequest{
-				Parent:    "projects/my-project/apis/my-api/versions/v1",
+				Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 				ApiSpecId: "",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -294,9 +294,9 @@ func TestCreateApiSpecDuplicates(t *testing.T) {
 	}{
 		{
 			desc: "case sensitive",
-			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+			seed: &rpc.ApiSpec{Name: "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec"},
 			req: &rpc.CreateApiSpecRequest{
-				Parent:    "projects/my-project/apis/my-api/versions/v1",
+				Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 				ApiSpecId: "my-spec",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -304,9 +304,9 @@ func TestCreateApiSpecDuplicates(t *testing.T) {
 		},
 		{
 			desc: "case insensitive",
-			seed: &rpc.ApiSpec{Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec"},
+			seed: &rpc.ApiSpec{Name: "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec"},
 			req: &rpc.CreateApiSpecRequest{
-				Parent:    "projects/my-project/apis/my-api/versions/v1",
+				Parent:    "projects/my-project/locations/global/apis/my-api/versions/v1",
 				ApiSpecId: "My-Spec",
 				ApiSpec:   &rpc.ApiSpec{},
 			},
@@ -337,7 +337,7 @@ func TestGetApiSpec(t *testing.T) {
 		{
 			desc: "fully populated resource",
 			seed: &rpc.ApiSpec{
-				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 				Filename:    "openapi.json",
 				Description: "My API Spec",
 				MimeType:    "application/x.openapi;version=3.0.0",
@@ -351,10 +351,10 @@ func TestGetApiSpec(t *testing.T) {
 				},
 			},
 			req: &rpc.GetApiSpecRequest{
-				Name: "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Name: "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 			},
 			want: &rpc.ApiSpec{
-				Name:         "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Name:         "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 				Filename:     "openapi.json",
 				Description:  "My API Spec",
 				MimeType:     "application/x.openapi;version=3.0.0",
@@ -967,18 +967,18 @@ func TestUpdateApiSpec(t *testing.T) {
 		{
 			desc: "implicit nil mask",
 			seed: &rpc.ApiSpec{
-				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 				Description: "My ApiSpec",
 				Filename:    "openapi.json",
 			},
 			req: &rpc.UpdateApiSpecRequest{
 				ApiSpec: &rpc.ApiSpec{
-					Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+					Name:        "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 					Description: "My Updated ApiSpec",
 				},
 			},
 			want: &rpc.ApiSpec{
-				Name:        "projects/my-project/apis/my-api/versions/v1/specs/my-spec",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/v1/specs/my-spec",
 				Description: "My Updated ApiSpec",
 				Filename:    "openapi.json",
 			},

--- a/server/actions_versions_test.go
+++ b/server/actions_versions_test.go
@@ -71,7 +71,7 @@ func TestCreateApiVersion(t *testing.T) {
 				Name: "projects/my-project/locations/global/apis/my-api",
 			},
 			req: &rpc.CreateApiVersionRequest{
-				Parent:       "projects/my-project/apis/my-api",
+				Parent:       "projects/my-project/locations/global/apis/my-api",
 				ApiVersionId: "v1",
 				ApiVersion: &rpc.ApiVersion{
 					DisplayName: "My Display Name",
@@ -86,7 +86,7 @@ func TestCreateApiVersion(t *testing.T) {
 				},
 			},
 			want: &rpc.ApiVersion{
-				Name:        "projects/my-project/apis/my-api/versions/v1",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/v1",
 				DisplayName: "My Display Name",
 				Description: "My Description",
 				State:       "My State",
@@ -156,7 +156,7 @@ func TestCreateApiVersionResponseCodes(t *testing.T) {
 			desc: "parent not found",
 			seed: &rpc.Api{Name: "projects/my-project/locations/global/apis/my-api"},
 			req: &rpc.CreateApiVersionRequest{
-				Parent:       "projects/my-project/apis/other-api",
+				Parent:       "projects/my-project/locations/global/apis/other-api",
 				ApiVersionId: "valid-id",
 				ApiVersion:   &rpc.ApiVersion{},
 			},
@@ -166,7 +166,7 @@ func TestCreateApiVersionResponseCodes(t *testing.T) {
 			desc: "missing resource body",
 			seed: &rpc.Api{Name: "projects/my-project/locations/global/apis/my-api"},
 			req: &rpc.CreateApiVersionRequest{
-				Parent:       "projects/my-project/apis/my-api",
+				Parent:       "projects/my-project/locations/global/apis/my-api",
 				ApiVersionId: "valid-id",
 				ApiVersion:   nil,
 			},
@@ -174,9 +174,9 @@ func TestCreateApiVersionResponseCodes(t *testing.T) {
 		},
 		{
 			desc: "missing custom identifier",
-			seed: &rpc.Api{Name: "projects/my-project/apis/my-api"},
+			seed: &rpc.Api{Name: "projects/my-project/locations/global/apis/my-api"},
 			req: &rpc.CreateApiVersionRequest{
-				Parent:       "projects/my-project/apis/my-api",
+				Parent:       "projects/my-project/locations/global/apis/my-api",
 				ApiVersionId: "",
 				ApiVersion:   &rpc.ApiVersion{},
 			},
@@ -266,9 +266,9 @@ func TestCreateApiVersionDuplicates(t *testing.T) {
 	}{
 		{
 			desc: "case sensitive",
-			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiVersionRequest{
-				Parent:       "projects/my-project/apis/my-api",
+				Parent:       "projects/my-project/locations/global/apis/my-api",
 				ApiVersionId: "v1",
 				ApiVersion:   &rpc.ApiVersion{},
 			},
@@ -276,9 +276,9 @@ func TestCreateApiVersionDuplicates(t *testing.T) {
 		},
 		{
 			desc: "case insensitive",
-			seed: &rpc.ApiVersion{Name: "projects/my-project/apis/my-api/versions/v1"},
+			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/v1"},
 			req: &rpc.CreateApiVersionRequest{
-				Parent:       "projects/my-project/apis/my-api",
+				Parent:       "projects/my-project/locations/global/apis/my-api",
 				ApiVersionId: "V1",
 				ApiVersion:   &rpc.ApiVersion{},
 			},
@@ -309,7 +309,7 @@ func TestGetApiVersion(t *testing.T) {
 		{
 			desc: "fully populated resource",
 			seed: &rpc.ApiVersion{
-				Name:        "projects/my-project/apis/my-api/versions/my-version",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/my-version",
 				DisplayName: "My Display Name",
 				Description: "My Description",
 				State:       "My State",
@@ -321,10 +321,10 @@ func TestGetApiVersion(t *testing.T) {
 				},
 			},
 			req: &rpc.GetApiVersionRequest{
-				Name: "projects/my-project/apis/my-api/versions/my-version",
+				Name: "projects/my-project/locations/global/apis/my-api/versions/my-version",
 			},
 			want: &rpc.ApiVersion{
-				Name:        "projects/my-project/apis/my-api/versions/my-version",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/my-version",
 				DisplayName: "My Display Name",
 				Description: "My Description",
 				State:       "My State",
@@ -777,18 +777,18 @@ func TestUpdateApiVersion(t *testing.T) {
 		{
 			desc: "implicit nil mask",
 			seed: &rpc.ApiVersion{
-				Name:        "projects/my-project/apis/my-api/versions/v1",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/v1",
 				DisplayName: "Version One",
 				Description: "My ApiVersion",
 			},
 			req: &rpc.UpdateApiVersionRequest{
 				ApiVersion: &rpc.ApiVersion{
-					Name:        "projects/my-project/apis/my-api/versions/v1",
+					Name:        "projects/my-project/locations/global/apis/my-api/versions/v1",
 					Description: "My Updated ApiVersion",
 				},
 			},
 			want: &rpc.ApiVersion{
-				Name:        "projects/my-project/apis/my-api/versions/v1",
+				Name:        "projects/my-project/locations/global/apis/my-api/versions/v1",
 				DisplayName: "Version One",
 				Description: "My Updated ApiVersion",
 			},

--- a/server/dao/specs.go
+++ b/server/dao/specs.go
@@ -184,3 +184,29 @@ func (d *DAO) DeleteSpec(ctx context.Context, name names.Spec) error {
 
 	return nil
 }
+
+func (d *DAO) GetSpecTags(ctx context.Context, name names.Spec) ([]*models.SpecRevisionTag, error) {
+	q := d.NewQuery(storage.SpecRevisionTagEntityName)
+	q = q.Require("ProjectID", name.ProjectID)
+	q = q.Require("ApiID", name.ApiID)
+	q = q.Require("VersionID", name.VersionID)
+	if name.SpecID != "-" {
+		q = q.Require("SpecID", name.SpecID)
+	}
+
+	var (
+		tags = make([]*models.SpecRevisionTag, 0)
+		tag  = new(models.SpecRevisionTag)
+		it   = d.Run(ctx, q)
+		err  error
+	)
+
+	for _, err = it.Next(tag); err == nil; _, err = it.Next(tag) {
+		tags = append(tags, tag)
+	}
+	if err != nil && err != iterator.Done {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return tags, nil
+}

--- a/server/models/artifact.go
+++ b/server/models/artifact.go
@@ -64,17 +64,17 @@ func NewArtifact(name names.Artifact, body *rpc.Artifact) *Artifact {
 func (artifact *Artifact) Name() string {
 	switch {
 	case artifact.SpecID != "":
-		return fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/specs/%s/artifacts/%s",
-			artifact.ProjectID, names.LocationSegment, artifact.ApiID, artifact.VersionID, artifact.SpecID, artifact.ArtifactID)
+		return fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/specs/%s/artifacts/%s",
+			artifact.ProjectID, names.Location, artifact.ApiID, artifact.VersionID, artifact.SpecID, artifact.ArtifactID)
 	case artifact.VersionID != "":
-		return fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/artifacts/%s",
-			artifact.ProjectID, names.LocationSegment, artifact.ApiID, artifact.VersionID, artifact.ArtifactID)
+		return fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/artifacts/%s",
+			artifact.ProjectID, names.Location, artifact.ApiID, artifact.VersionID, artifact.ArtifactID)
 	case artifact.ApiID != "":
-		return fmt.Sprintf("projects/%s%s/apis/%s/artifacts/%s",
-			artifact.ProjectID, names.LocationSegment, artifact.ApiID, artifact.ArtifactID)
+		return fmt.Sprintf("projects/%s/locations/%s/apis/%s/artifacts/%s",
+			artifact.ProjectID, names.Location, artifact.ApiID, artifact.ArtifactID)
 	case artifact.ProjectID != "":
-		return fmt.Sprintf("projects/%s%s/artifacts/%s",
-			artifact.ProjectID, names.LocationSegment, artifact.ArtifactID)
+		return fmt.Sprintf("projects/%s/locations/%s/artifacts/%s",
+			artifact.ProjectID, names.Location, artifact.ArtifactID)
 	default:
 		return "UNKNOWN"
 	}

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -120,7 +120,7 @@ func (s *Spec) RevisionName() string {
 }
 
 // BasicMessage returns the basic view of the spec resource as an RPC message.
-func (s *Spec) BasicMessage(name string) (message *rpc.ApiSpec, err error) {
+func (s *Spec) BasicMessage(name string, tags []string) (message *rpc.ApiSpec, err error) {
 	message = &rpc.ApiSpec{
 		Name:               name,
 		Filename:           s.FileName,
@@ -130,6 +130,7 @@ func (s *Spec) BasicMessage(name string) (message *rpc.ApiSpec, err error) {
 		MimeType:           s.MimeType,
 		SourceUri:          s.SourceURI,
 		RevisionId:         s.RevisionID,
+		RevisionTags:       tags,
 		CreateTime:         timestamppb.New(s.CreateTime),
 		RevisionCreateTime: timestamppb.New(s.RevisionCreateTime),
 		RevisionUpdateTime: timestamppb.New(s.RevisionUpdateTime),

--- a/server/models/spec.go
+++ b/server/models/spec.go
@@ -116,8 +116,8 @@ func (s *Spec) Name() string {
 
 // RevisionName generates the resource name of the spec revision.
 func (s *Spec) RevisionName() string {
-	return fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/specs/%s@%s",
-		s.ProjectID, names.LocationSegment, s.ApiID, s.VersionID, s.SpecID, s.RevisionID)
+	return fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/specs/%s@%s",
+		s.ProjectID, names.Location, s.ApiID, s.VersionID, s.SpecID, s.RevisionID)
 }
 
 // BasicMessage returns the basic view of the spec resource as an RPC message.
@@ -243,6 +243,6 @@ func NewSpecRevisionTag(name names.SpecRevision, tag string) *SpecRevisionTag {
 }
 
 func (t *SpecRevisionTag) String() string {
-	return fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/specs/%s@%s",
-		t.ProjectID, names.LocationSegment, t.ApiID, t.VersionID, t.SpecID, t.Tag)
+	return fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/specs/%s@%s",
+		t.ProjectID, names.Location, t.ApiID, t.VersionID, t.SpecID, t.Tag)
 }

--- a/server/names/api.go
+++ b/server/names/api.go
@@ -64,20 +64,20 @@ func (a Api) Artifact(id string) Artifact {
 }
 
 func (a Api) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s",
-		a.ProjectID, LocationSegment, a.ApiID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s",
+		a.ProjectID, Location, a.ApiID))
 }
 
 // ApisRegexp returns a regular expression that matches collection of apis.
 func ApisRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis$",
-		identifier, LocationSegment))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis$",
+		identifier, Location))
 }
 
 // ApiRegexp returns a regular expression that matches a api resource name.
 func ApiRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s$",
-		identifier, LocationSegment, identifier))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s$",
+		identifier, Location, identifier))
 }
 
 // ParseApi parses the name of an Api.

--- a/server/names/artifact.go
+++ b/server/names/artifact.go
@@ -20,10 +20,10 @@ import (
 )
 
 var (
-	projectArtifactRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s%s/artifacts/%s", identifier, LocationSegment, identifier))
-	apiArtifactRegexp     = regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/artifacts/%s", identifier, LocationSegment, identifier, identifier))
-	versionArtifactRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s/artifacts/%s", identifier, LocationSegment, identifier, identifier, identifier))
-	specArtifactRegexp    = regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s/specs/%s/artifacts/%s", identifier, LocationSegment, identifier, identifier, identifier, identifier))
+	projectArtifactRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/artifacts/%s", identifier, Location, identifier))
+	apiArtifactRegexp     = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/artifacts/%s", identifier, Location, identifier, identifier))
+	versionArtifactRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/artifacts/%s", identifier, Location, identifier, identifier, identifier))
+	specArtifactRegexp    = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs/%s/artifacts/%s", identifier, Location, identifier, identifier, identifier, identifier))
 )
 
 // Artifact represents a resource name for an artifact.
@@ -146,8 +146,8 @@ func (a projectArtifact) Validate() error {
 }
 
 func (a projectArtifact) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/artifacts/%s",
-		a.ProjectID, LocationSegment, a.ArtifactID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/artifacts/%s",
+		a.ProjectID, Location, a.ArtifactID))
 }
 
 func parseProjectArtifact(name string) (projectArtifact, error) {
@@ -179,8 +179,8 @@ func (a apiArtifact) Validate() error {
 }
 
 func (a apiArtifact) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s/artifacts/%s",
-		a.ProjectID, LocationSegment, a.ApiID, a.ArtifactID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s/artifacts/%s",
+		a.ProjectID, Location, a.ApiID, a.ArtifactID))
 }
 
 func parseApiArtifact(name string) (apiArtifact, error) {
@@ -214,8 +214,8 @@ func (a versionArtifact) Validate() error {
 }
 
 func (a versionArtifact) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/artifacts/%s",
-		a.ProjectID, LocationSegment, a.ApiID, a.VersionID, a.ArtifactID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/artifacts/%s",
+		a.ProjectID, Location, a.ApiID, a.VersionID, a.ArtifactID))
 }
 
 func parseVersionArtifact(name string) (versionArtifact, error) {
@@ -251,8 +251,8 @@ func (a specArtifact) Validate() error {
 }
 
 func (a specArtifact) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/specs/%s/artifacts/%s",
-		a.ProjectID, LocationSegment, a.ApiID, a.VersionID, a.SpecID, a.ArtifactID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/specs/%s/artifacts/%s",
+		a.ProjectID, Location, a.ApiID, a.VersionID, a.SpecID, a.ArtifactID))
 }
 
 func parseSpecArtifact(name string) (specArtifact, error) {
@@ -275,13 +275,13 @@ func parseSpecArtifact(name string) (specArtifact, error) {
 // ArtifactsRegexp returns a regular expression that matches collection of artifacts.
 func ArtifactsRegexp() *regexp.Regexp {
 	return regexp.MustCompile(
-		fmt.Sprintf("^projects/%s%s(/apis/%s(/versions/%s(/specs/%s)?)?)?/artifacts$",
-			identifier, LocationSegment, identifier, identifier, identifier))
+		fmt.Sprintf("^projects/%s/locations/%s(/apis/%s(/versions/%s(/specs/%s)?)?)?/artifacts$",
+			identifier, Location, identifier, identifier, identifier))
 }
 
 // ArtifactRegexp returns a regular expression that matches an artifact resource name.
 func ArtifactRegexp() *regexp.Regexp {
 	return regexp.MustCompile(
-		fmt.Sprintf("^projects/%s%s(/apis/%s(/versions/%s(/specs/%s)?)?)?/artifacts/%s$",
-			identifier, LocationSegment, identifier, identifier, identifier, identifier))
+		fmt.Sprintf("^projects/%s/locations/%s(/apis/%s(/versions/%s(/specs/%s)?)?)?/artifacts/%s$",
+			identifier, Location, identifier, identifier, identifier, identifier))
 }

--- a/server/names/common.go
+++ b/server/names/common.go
@@ -65,5 +65,5 @@ func normalize(identifier string) string {
 }
 
 // LocationSegment is included in resource names immediately following the
-// project_id. It can be set to an empty string to omit location.
+// project_id.
 var LocationSegment = "/locations/global"

--- a/server/names/common.go
+++ b/server/names/common.go
@@ -64,6 +64,6 @@ func normalize(identifier string) string {
 	return strings.ToLower(identifier)
 }
 
-// LocationSegment is included in resource names immediately following the
+// Location is included in resource names immediately following the
 // project_id.
-var LocationSegment = "/locations/global"
+var Location = "global"

--- a/server/names/names_test.go
+++ b/server/names/names_test.go
@@ -55,8 +55,8 @@ func TestResourceNames(t *testing.T) {
 			name:   "apis",
 			regexp: ApisRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis",
-				"projects/-LOCATION/apis",
+				"projects/google/locations/LOCATION/apis",
+				"projects/-/locations/LOCATION/apis",
 			},
 			fail: []string{
 				"-",
@@ -66,26 +66,26 @@ func TestResourceNames(t *testing.T) {
 			name:   "api",
 			regexp: ApiRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample",
-				"projects/-LOCATION/apis/-",
-				"projects/123LOCATION/apis/abc",
-				"projects/1-2-3LOCATION/apis/abc",
+				"projects/google/locations/LOCATION/apis/sample",
+				"projects/-/locations/LOCATION/apis/-",
+				"projects/123/locations/LOCATION/apis/abc",
+				"projects/1-2-3/locations/LOCATION/apis/abc",
 			},
 			fail: []string{
 				"-",
 				"invalid",
-				"projects/LOCATION/apis/123",
-				"projects/123LOCATION/apis/",
-				"projects/123LOCATION/invalid/123",
-				"projects/123LOCATION/apis/ 123",
+				"projects//locations/LOCATION/apis/123",
+				"projects/123/locations/LOCATION/apis/",
+				"projects/123/locations/LOCATION/invalid/123",
+				"projects/123/locations/LOCATION/apis/ 123",
 			},
 		},
 		{
 			name:   "versions",
 			regexp: VersionsRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample/versions",
-				"projects/-LOCATION/apis/-/versions",
+				"projects/google/locations/LOCATION/apis/sample/versions",
+				"projects/-/locations/LOCATION/apis/-/versions",
 			},
 			fail: []string{
 				"-",
@@ -95,26 +95,26 @@ func TestResourceNames(t *testing.T) {
 			name:   "version",
 			regexp: VersionRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample/versions/v1",
-				"projects/-LOCATION/apis/-/versions/-",
-				"projects/123LOCATION/apis/abc/versions/123",
-				"projects/1-2-3LOCATION/apis/abc/versions/123",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1",
+				"projects/-/locations/LOCATION/apis/-/versions/-",
+				"projects/123/locations/LOCATION/apis/abc/versions/123",
+				"projects/1-2-3/locations/LOCATION/apis/abc/versions/123",
 			},
 			fail: []string{
 				"-",
 				"invalid",
-				"projects/LOCATION/apis/123",
-				"projects/123LOCATION/apis/",
-				"projects/123LOCATION/invalid/123",
-				"projects/123LOCATION/apis/ 123",
+				"projects//locations/LOCATION/apis/123",
+				"projects/123/locations/LOCATION/apis/",
+				"projects/123/locations/LOCATION/invalid/123",
+				"projects/123/locations/LOCATION/apis/ 123",
 			},
 		},
 		{
 			name:   "specs",
 			regexp: SpecsRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample/versions/v1/specs",
-				"projects/-LOCATION/apis/-/versions/-/specs",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/specs",
+				"projects/-/locations/LOCATION/apis/-/versions/-/specs",
 			},
 			fail: []string{
 				"-",
@@ -124,29 +124,29 @@ func TestResourceNames(t *testing.T) {
 			name:   "spec",
 			regexp: SpecRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample/versions/v1/specs/openapi.yaml@1234567890abcdef",
-				"projects/googleLOCATION/apis/sample/versions/v1/specs/openapi.yaml",
-				"projects/-LOCATION/apis/-/versions/-/specs/-",
-				"projects/123LOCATION/apis/abc/versions/123/specs/abc",
-				"projects/1-2-3LOCATION/apis/abc/versions/123/specs/abc",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/specs/openapi.yaml@1234567890abcdef",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/specs/openapi.yaml",
+				"projects/-/locations/LOCATION/apis/-/versions/-/specs/-",
+				"projects/123/locations/LOCATION/apis/abc/versions/123/specs/abc",
+				"projects/1-2-3/locations/LOCATION/apis/abc/versions/123/specs/abc",
 			},
 			fail: []string{
 				"-",
 				"invalid",
-				"projects/LOCATION/apis/123",
-				"projects/123LOCATION/apis/",
-				"projects/123LOCATION/invalid/123",
-				"projects/123LOCATION/apis/ 123",
+				"projects//locations/LOCATION/apis/123",
+				"projects/123/locations/LOCATION/apis/",
+				"projects/123/locations/LOCATION/invalid/123",
+				"projects/123/locations/LOCATION/apis/ 123",
 			},
 		},
 		{
 			name:   "artifacts",
 			regexp: ArtifactsRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample/versions/v1/specs/openapi.yaml/artifacts",
-				"projects/googleLOCATION/apis/sample/versions/v1/artifacts",
-				"projects/googleLOCATION/apis/sample/artifacts",
-				"projects/googleLOCATION/artifacts",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/specs/openapi.yaml/artifacts",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/artifacts",
+				"projects/google/locations/LOCATION/apis/sample/artifacts",
+				"projects/google/locations/LOCATION/artifacts",
 			},
 			fail: []string{
 				"-",
@@ -156,10 +156,10 @@ func TestResourceNames(t *testing.T) {
 			name:   "artifact",
 			regexp: ArtifactRegexp(),
 			pass: []string{
-				"projects/googleLOCATION/apis/sample/versions/v1/specs/openapi.yaml/artifacts/test-artifact",
-				"projects/googleLOCATION/apis/sample/versions/v1/artifacts/test-artifact",
-				"projects/googleLOCATION/apis/sample/artifacts/test-artifact",
-				"projects/googleLOCATION/artifacts/test-artifact",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/specs/openapi.yaml/artifacts/test-artifact",
+				"projects/google/locations/LOCATION/apis/sample/versions/v1/artifacts/test-artifact",
+				"projects/google/locations/LOCATION/apis/sample/artifacts/test-artifact",
+				"projects/google/locations/LOCATION/artifacts/test-artifact",
 			},
 			fail: []string{
 				"-",
@@ -168,14 +168,14 @@ func TestResourceNames(t *testing.T) {
 	}
 	for _, g := range groups {
 		for _, path := range g.pass {
-			path = strings.ReplaceAll(path, "LOCATION", LocationSegment)
+			path = strings.ReplaceAll(path, "LOCATION", Location)
 			m := g.regexp.FindStringSubmatch(path)
 			if m == nil {
 				t.Errorf("failed to match %s: %s", g.name, path)
 			}
 		}
 		for _, path := range g.fail {
-			path = strings.ReplaceAll(path, "LOCATION", LocationSegment)
+			path = strings.ReplaceAll(path, "LOCATION", Location)
 			m := g.regexp.FindStringSubmatch(path)
 			if m != nil {
 				t.Errorf("false match %s: %s", g.name, path)

--- a/server/names/project.go
+++ b/server/names/project.go
@@ -67,9 +67,27 @@ func ProjectRegexp() *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf("^projects/%s$", identifier))
 }
 
+// ProjectWithLocationRegexp returns a regular expression that matches a project resource name followed by a location.
+func ProjectWithLocationRegexp() *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s$", identifier, identifier))
+}
+
 // ParseProject parses the name of a project.
 func ParseProject(name string) (Project, error) {
 	r := ProjectRegexp()
+	if !r.MatchString(name) {
+		return Project{}, fmt.Errorf("invalid project name %q: must match %q", name, r)
+	}
+
+	m := r.FindStringSubmatch(name)
+	return Project{
+		ProjectID: m[1],
+	}, nil
+}
+
+// ParseProjectWithLocation parses the name of a project.
+func ParseProjectWithLocation(name string) (Project, error) {
+	r := ProjectWithLocationRegexp()
 	if !r.MatchString(name) {
 		return Project{}, fmt.Errorf("invalid project name %q: must match %q", name, r)
 	}

--- a/server/names/spec.go
+++ b/server/names/spec.go
@@ -21,8 +21,8 @@ import (
 
 // specRegexp is the regex pattern for spec resource names.
 // Notably, this differs from SpecRegexp() by not accepting spec revision IDs in the resource name.
-var specRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s/specs/%s$",
-	identifier, LocationSegment, identifier, identifier, identifier))
+var specRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs/%s$",
+	identifier, Location, identifier, identifier, identifier))
 
 // Spec represents a resource name for an API spec.
 type Spec struct {
@@ -102,20 +102,20 @@ func (s Spec) Normal() Spec {
 }
 
 func (s Spec) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/specs/%s",
-		s.ProjectID, LocationSegment, s.ApiID, s.VersionID, s.SpecID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/specs/%s",
+		s.ProjectID, Location, s.ApiID, s.VersionID, s.SpecID))
 }
 
 // SpecsRegexp returns a regular expression that matches a collection of specs.
 func SpecsRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s/specs$",
-		identifier, LocationSegment, identifier, identifier))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs$",
+		identifier, Location, identifier, identifier))
 }
 
 // SpecRegexp returns a regular expression that matches a spec resource name with an optional revision identifier.
 func SpecRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s/specs/%s(@%s)?$",
-		identifier, LocationSegment, identifier, identifier, identifier, revisionTag))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs/%s(@%s)?$",
+		identifier, Location, identifier, identifier, identifier, revisionTag))
 }
 
 // ParseSpec parses the name of a spec.

--- a/server/names/spec_revision.go
+++ b/server/names/spec_revision.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 )
 
-var specRevisionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s/specs/%s@%s$", identifier, LocationSegment, identifier, identifier, identifier, revisionTag))
+var specRevisionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs/%s@%s$", identifier, Location, identifier, identifier, identifier, revisionTag))
 
 // SpecRevision represents a resource name for an API spec revision.
 type SpecRevision struct {
@@ -41,8 +41,8 @@ func (s SpecRevision) Spec() Spec {
 }
 
 func (s SpecRevision) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s/versions/%s/specs/%s@%s",
-		s.ProjectID, LocationSegment, s.ApiID, s.VersionID, s.SpecID, s.RevisionID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s/specs/%s@%s",
+		s.ProjectID, Location, s.ApiID, s.VersionID, s.SpecID, s.RevisionID))
 }
 
 // ParseSpecRevision parses the name of a spec.

--- a/server/names/version.go
+++ b/server/names/version.go
@@ -73,20 +73,20 @@ func (v Version) Spec(id string) Spec {
 }
 
 func (v Version) String() string {
-	return normalize(fmt.Sprintf("projects/%s%s/apis/%s/versions/%s",
-		v.ProjectID, LocationSegment, v.ApiID, v.VersionID))
+	return normalize(fmt.Sprintf("projects/%s/locations/%s/apis/%s/versions/%s",
+		v.ProjectID, Location, v.ApiID, v.VersionID))
 }
 
 // VersionsRegexp returns a regular expression that matches a collection of versions.
 func VersionsRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions$",
-		identifier, LocationSegment, identifier))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions$",
+		identifier, Location, identifier))
 }
 
 // VersionRegexp returns a regular expression that matches a version resource name.
 func VersionRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s%s/apis/%s/versions/%s$",
-		identifier, LocationSegment, identifier, identifier))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s$",
+		identifier, Location, identifier, identifier))
 }
 
 // ParseVersion parses the name of a version.

--- a/tests/crud/crud_test.go
+++ b/tests/crud/crud_test.go
@@ -105,7 +105,7 @@ func TestCRUD(t *testing.T) {
 	// Create the sample api.
 	{
 		req := &rpc.CreateApiRequest{
-			Parent: "projects/test",
+			Parent: "projects/test/locations/global",
 			ApiId:  "sample",
 			Api: &rpc.Api{
 				DisplayName:  "Sample",
@@ -121,7 +121,7 @@ func TestCRUD(t *testing.T) {
 	// Create the sample 1.0.0 version.
 	{
 		req := &rpc.CreateApiVersionRequest{
-			Parent:       "projects/test/apis/sample",
+			Parent:       "projects/test/locations/global/apis/sample",
 			ApiVersionId: "1.0.0",
 			ApiVersion: &rpc.ApiVersion{
 				Labels:      sampleMap,
@@ -136,7 +136,7 @@ func TestCRUD(t *testing.T) {
 		buf, err := readAndGZipFile(filepath.Join("testdata", "openapi.yaml"))
 		check(t, "error reading spec", err)
 		req := &rpc.CreateApiSpecRequest{
-			Parent:    "projects/test/apis/sample/versions/1.0.0",
+			Parent:    "projects/test/locations/global/apis/sample/versions/1.0.0",
 			ApiSpecId: "openapi.yaml",
 			ApiSpec: &rpc.ApiSpec{
 				MimeType:    "application/x.openapi+gzip;version=3.0.0",
@@ -151,7 +151,7 @@ func TestCRUD(t *testing.T) {
 	// Check the created API.
 	{
 		req := &rpc.GetApiRequest{
-			Name: "projects/test/apis/sample",
+			Name: "projects/test/locations/global/apis/sample",
 		}
 		api, err := registryClient.GetApi(ctx, req)
 		check(t, "error getting api %s", err)
@@ -165,7 +165,7 @@ func TestCRUD(t *testing.T) {
 	// Check the created version.
 	{
 		req := &rpc.GetApiVersionRequest{
-			Name: "projects/test/apis/sample/versions/1.0.0",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0",
 		}
 		version, err := registryClient.GetApiVersion(ctx, req)
 		check(t, "error getting version %s", err)
@@ -180,7 +180,7 @@ func TestCRUD(t *testing.T) {
 	var revision string
 	{
 		req := &rpc.GetApiSpecRequest{
-			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml",
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)
@@ -200,7 +200,7 @@ func TestCRUD(t *testing.T) {
 	// Check the contents of the created spec.
 	{
 		req := &rpc.GetApiSpecContentsRequest{
-			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml/contents",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml/contents",
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
@@ -217,7 +217,7 @@ func TestCRUD(t *testing.T) {
 	// Check the contents of the created revision.
 	{
 		req := &rpc.GetApiSpecContentsRequest{
-			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision + "/contents",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision + "/contents",
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
@@ -235,7 +235,7 @@ func TestCRUD(t *testing.T) {
 	revisionTag := "prod"
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
-			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision,
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision,
 			Tag:  revisionTag,
 		}
 		_, err := registryClient.TagApiSpecRevision(ctx, req)
@@ -244,7 +244,7 @@ func TestCRUD(t *testing.T) {
 	// Check the contents of the tagged revision.
 	{
 		req := &rpc.GetApiSpecContentsRequest{
-			Name: "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revisionTag + "/contents",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revisionTag + "/contents",
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
@@ -258,10 +258,10 @@ func TestCRUD(t *testing.T) {
 			}
 		}
 	}
-	testArtifacts(ctx, registryClient, t, "projects/test")
-	testArtifacts(ctx, registryClient, t, "projects/test/apis/sample")
-	testArtifacts(ctx, registryClient, t, "projects/test/apis/sample/versions/1.0.0")
-	testArtifacts(ctx, registryClient, t, "projects/test/apis/sample/versions/1.0.0/specs/openapi.yaml")
+	testArtifacts(ctx, registryClient, t, "projects/test/locations/global")
+	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample")
+	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample/versions/1.0.0")
+	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml")
 	// Delete the test project.
 	{
 		req := &rpc.DeleteProjectRequest{

--- a/tests/demo/demo_test.go
+++ b/tests/demo/demo_test.go
@@ -75,7 +75,7 @@ func hashForBytes(b []byte) string {
 func listAllSpecs(ctx context.Context, registryClient connection.Client) []*rpc.ApiSpec {
 	specs := make([]*rpc.ApiSpec, 0)
 	req := &rpc.ListApiSpecsRequest{
-		Parent: "projects/demo/apis/-/versions/-",
+		Parent: "projects/demo/locations/global/apis/-/versions/-",
 	}
 	it := registryClient.ListApiSpecs(ctx, req)
 	for {
@@ -92,7 +92,7 @@ func listAllSpecs(ctx context.Context, registryClient connection.Client) []*rpc.
 func listAllSpecRevisionIDs(ctx context.Context, registryClient connection.Client) []string {
 	revisionIDs := make([]string, 0)
 	req := &rpc.ListApiSpecRevisionsRequest{
-		Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+		Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
 	}
 	it := registryClient.ListApiSpecRevisions(ctx, req)
 	for {
@@ -181,7 +181,7 @@ func TestDemo(t *testing.T) {
 	// Create the petstore api.
 	{
 		req := &rpc.CreateApiRequest{
-			Parent: "projects/demo",
+			Parent: "projects/demo/locations/global",
 			ApiId:  "petstore",
 			Api: &rpc.Api{
 				DisplayName:  "Swagger Petstore",
@@ -195,7 +195,7 @@ func TestDemo(t *testing.T) {
 	// Create the petstore 1.0.0 version.
 	{
 		req := &rpc.CreateApiVersionRequest{
-			Parent:       "projects/demo/apis/petstore",
+			Parent:       "projects/demo/locations/global/apis/petstore",
 			ApiVersionId: "1.0.0",
 			ApiVersion:   &rpc.ApiVersion{},
 		}
@@ -207,7 +207,7 @@ func TestDemo(t *testing.T) {
 		buf, err := readAndGZipFile(filepath.Join("testdata", "openapi.yaml@r0"))
 		check(t, "error reading spec", err)
 		req := &rpc.CreateApiSpecRequest{
-			Parent:    "projects/demo/apis/petstore/versions/1.0.0",
+			Parent:    "projects/demo/locations/global/apis/petstore/versions/1.0.0",
 			ApiSpecId: "openapi.yaml",
 			ApiSpec: &rpc.ApiSpec{
 				MimeType: "application/x.openapi+gzip;version=3.0.0",
@@ -229,7 +229,7 @@ func TestDemo(t *testing.T) {
 		check(t, "error reading spec", err)
 		req := &rpc.UpdateApiSpecRequest{
 			ApiSpec: &rpc.ApiSpec{
-				Name:     "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+				Name:     "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
 				Contents: buf.Bytes(),
 			},
 		}
@@ -245,7 +245,7 @@ func TestDemo(t *testing.T) {
 	}
 	if len(revisionIDs) > 0 {
 		req := &rpc.GetApiSpecRequest{
-			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + revisionIDs[len(revisionIDs)-1],
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + revisionIDs[len(revisionIDs)-1],
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)
@@ -266,12 +266,12 @@ func TestDemo(t *testing.T) {
 	// tag a spec revision
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
-			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + originalRevisionID,
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + originalRevisionID,
 			Tag:  "og",
 		}
 		taggedSpec, err := registryClient.TagApiSpecRevision(ctx, req)
 		check(t, "error tagging spec", err)
-		if taggedSpec.Name != "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml@og" {
+		if taggedSpec.Name != "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og" {
 			t.Errorf("Incorrect name of tagged spec: %s", taggedSpec.Name)
 		}
 		if taggedSpec.Hash != originalHash {
@@ -281,12 +281,12 @@ func TestDemo(t *testing.T) {
 	// tag the tagged revision
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
-			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml@og",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og",
 			Tag:  "first",
 		}
 		taggedSpec, err := registryClient.TagApiSpecRevision(ctx, req)
 		check(t, "error tagging spec", err)
-		if taggedSpec.Name != "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml@first" {
+		if taggedSpec.Name != "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@first" {
 			t.Errorf("Incorrect name of tagged spec: %s", taggedSpec.Name)
 		}
 		if taggedSpec.Hash != originalHash {
@@ -296,7 +296,7 @@ func TestDemo(t *testing.T) {
 	// get a spec by its tag
 	{
 		req := &rpc.GetApiSpecRequest{
-			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml@first",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@first",
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)
@@ -307,7 +307,7 @@ func TestDemo(t *testing.T) {
 	// rollback a spec revision (this creates a new revision that's a copy)
 	{
 		req := &rpc.RollbackApiSpecRequest{
-			Name:       "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			Name:       "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
 			RevisionId: "og",
 		}
 		spec, err := registryClient.RollbackApiSpec(ctx, req)
@@ -333,7 +333,7 @@ func TestDemo(t *testing.T) {
 	// delete a spec revision
 	{
 		req := &rpc.DeleteApiSpecRevisionRequest{
-			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml@og",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og",
 		}
 		err := registryClient.DeleteApiSpecRevision(ctx, req)
 		check(t, "error deleting spec revision %s", err)
@@ -355,7 +355,7 @@ func TestDemo(t *testing.T) {
 	// delete the spec
 	{
 		req := &rpc.DeleteApiSpecRequest{
-			Name: "projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
 		}
 		err := registryClient.DeleteApiSpec(ctx, req)
 		check(t, "error deleting spec %s", err)

--- a/tests/filters_test.go
+++ b/tests/filters_test.go
@@ -109,7 +109,7 @@ func TestFilters(t *testing.T) {
 		}
 	}
 	// Create some sample apis.
-	apiParent := "projects/filters"
+	apiParent := "projects/filters/locations/global"
 	for i := 0; i < len(testLabels); i++ {
 		req := &rpc.CreateApiRequest{
 			Parent: apiParent,
@@ -153,7 +153,7 @@ func TestFilters(t *testing.T) {
 		}
 	}
 	// Create some sample versions.
-	versionParent := "projects/filters/apis/1"
+	versionParent := "projects/filters/locations/global/apis/1"
 	for i := 0; i < len(testLabels); i++ {
 		req := &rpc.CreateApiVersionRequest{
 			Parent:       versionParent,
@@ -197,7 +197,7 @@ func TestFilters(t *testing.T) {
 		}
 	}
 	// Create some sample specs.
-	specParent := "projects/filters/apis/1/versions/1"
+	specParent := "projects/filters/locations/global/apis/1/versions/1"
 	for i := 0; i < len(testLabels); i++ {
 		req := &rpc.CreateApiSpecRequest{
 			Parent:    specParent,


### PR DESCRIPTION
This set of changes adds a location identifier to all resource paths below projects. While this doesn't provide direct value to the registry API, it makes it compatible with Google Cloud guidance to explicitly locate all resources under projects. That allows resources to be explicitly stored in regions of the user's choice (including countries). We expect that a registry is a global resource for an organization that will be stored in a single location. In this initial set of changes, we set locations to the "global" identifier, but in the future, this may be made configurable to allow a specific cloud region to be set in the registry instance. A Google-hosted version of the registry server would configure the server to use the desired location identifier (TODO if needed).

With this initial set of changes, all CI tests should pass. Subsequent commits will address issues found when running scripts in the demos directory.