### PR TITLE
Fix Viper reading of custom configurations.

### DIFF
--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -51,11 +52,12 @@ func main() {
 	pflag.Parse()
 
 	if configPath != "" {
-		log.Println("Loading custom")
+		log.Printf("Loading configuration from %s", configPath)
 		f, err := os.Open(configPath)
 		if err != nil {
 			log.Fatalf("Failed to open config file: %s", err)
 		}
+		viper.SetConfigType(strings.TrimLeft(filepath.Ext(configPath), "."))
 		if err := viper.ReadConfig(f); err != nil {
 			log.Fatalf("Failed to read config contents: %s", err)
 		}


### PR DESCRIPTION
registry-server builds were failing in Docker due to improperly-read configuration files. This commit fixes that problem and enhances logging to confirm the path to the config file that is read.

As discussed [here](https://github.com/spf13/viper/issues/316), the viper.ReadConfig() function will fail if the config type is not set. Interestingly, when a configuration file exists in the user's home directory (in ~/.config/registry/registry_server.yaml), that seems to set the config type even when custom configuration files are read. Docker images don't include that file, thus the failure in Docker. To reproduce this outside Docker, remove the "home" config file and try running registry-server with a custom config.

This adds the fix recommended in the Viper issue linked above, an explicit call to viper.SetConfigType() with the file extension of the user-specified config file.