### PR TITLE
Implement API Style Guide Proto definition, and ability to upload API Style Guides in YAML Format

### DIFF
--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"io/ioutil"
@@ -31,14 +32,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func styleGuideRelation(styleGuideName string) string {
-	return "styleguide-" +
-		strings.ReplaceAll(
-			strings.ToLower(styleGuideName), " ", "-",
-		)
+// normalizeArtifactId makes a provided Artifact Id a lower-cased alphanumeric string
+func normalizeArtifactId(resourceName string) string {
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return strings.ToLower(reg.ReplaceAllString(resourceName, ""))
 }
 
-func readStyleGuideProto(filename string) (*rpc.APIStyleGuide, error) {
+func readStyleGuideProto(filename string) (*rpc.StyleGuide, error) {
 
 	yamlBytes, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -46,7 +49,7 @@ func readStyleGuideProto(filename string) (*rpc.APIStyleGuide, error) {
 	}
 
 	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
-	m := &rpc.APIStyleGuide{}
+	m := &rpc.StyleGuide{}
 	err = protojson.Unmarshal(jsonBytes, m)
 
 	if err != nil {
@@ -84,7 +87,7 @@ func styleGuideCommand(ctx context.Context) *cobra.Command {
 				Name: "projects/" +
 					projectID +
 					"/locations/global/artifacts/" +
-					styleGuideRelation(styleGuide.GetName()),
+					normalizeArtifactId(styleGuide.GetName()),
 				MimeType: core.MimeTypeForMessageType(
 					"google.cloud.apigee.registry.applications.v1alpha1.styleguide",
 				),

--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -1,0 +1,104 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"io/ioutil"
+
+	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/rpc"
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func styleGuideRelation(styleGuideName string) string {
+	return "styleguide-" +
+		strings.ReplaceAll(
+			strings.ToLower(styleGuideName), " ", "-",
+		)
+}
+
+func readStyleGuideProto(filename string) (*rpc.APIStyleGuide, error) {
+
+	yamlBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
+	m := &rpc.APIStyleGuide{}
+	err = protojson.Unmarshal(jsonBytes, m)
+
+	if err != nil {
+		return nil, fmt.Errorf("in file %q: %v", filename, err)
+	}
+
+	return m, nil
+}
+
+func styleGuideCommand(ctx context.Context) *cobra.Command {
+	var projectID string
+	cmd := &cobra.Command{
+		Use:   "styleguide FILE_PATH --project_id=value",
+		Short: "Upload an API style guide",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			styleGuidePath := args[0]
+			if styleGuidePath == "" {
+				log.Fatal("Please provide style guide path")
+			}
+
+			styleGuide, err := readStyleGuideProto(styleGuidePath)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			styleGuideData, _ := proto.Marshal(styleGuide)
+
+			ctx := context.Background()
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+
+			artifact := &rpc.Artifact{
+				Name: "projects/" +
+					projectID +
+					"/locations/global/artifacts/" +
+					styleGuideRelation(styleGuide.GetName()),
+				MimeType: core.MimeTypeForMessageType(
+					"google.cloud.apigee.registry.applications.v1alpha1.styleguide",
+				),
+				Contents: styleGuideData,
+			}
+			log.Printf("uploading %s", artifact.Name)
+			err = core.SetArtifact(ctx, client, artifact)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&projectID, "project_id", "", "Project ID to use when storing the styleguide artifact")
+	cmd.MarkFlagRequired("project_id")
+	return cmd
+}

--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
-	"strings"
 
 	"io/ioutil"
 
@@ -31,15 +29,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
-
-// normalizeArtifactId makes a provided Artifact Id a lower-cased alphanumeric string
-func normalizeArtifactId(resourceName string) string {
-	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		log.Fatal(err)
-	}
-	return strings.ToLower(reg.ReplaceAllString(resourceName, ""))
-}
 
 func readStyleGuideProto(filename string) (*rpc.StyleGuide, error) {
 
@@ -87,7 +76,7 @@ func styleGuideCommand(ctx context.Context) *cobra.Command {
 				Name: "projects/" +
 					projectID +
 					"/locations/global/artifacts/" +
-					normalizeArtifactId(styleGuide.GetName()),
+					styleGuide.GetName(),
 				MimeType: core.MimeTypeForMessageType(
 					"google.cloud.apigee.registry.applications.v1alpha1.styleguide",
 				),

--- a/cmd/registry/cmd/upload/upload.go
+++ b/cmd/registry/cmd/upload/upload.go
@@ -31,6 +31,7 @@ func Command(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(csvCommand(ctx))
 	cmd.AddCommand(manifestCommand(ctx))
 	cmd.AddCommand(specCommand(ctx))
+	cmd.AddCommand(styleGuideCommand(ctx))
 
 	return cmd
 }

--- a/google/cloud/apigee/registry/applications/v1alpha1/registry_api_style_guide.proto
+++ b/google/cloud/apigee/registry/applications/v1alpha1/registry_api_style_guide.proto
@@ -1,0 +1,94 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.apigee.registry.applications.v1alpha1;
+
+import "google/api/field_behavior.proto";
+
+option java_package = "com.google.cloud.apigee.registry.applications.v1alpha1";
+option java_multiple_files = true;
+option java_outer_classname = "RegistryAPIStyleGuideProto";
+option go_package = "github.com/apigee/registry/rpc;rpc";
+
+// APIStyleGuide defines a set of guidelines and linters that govern
+// the static analysis of API Specs.
+message APIStyleGuide {
+    // Name of the API Style Guide
+    string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // A list containing style (format) descriptors for this style guide that 
+    // are specified as a Media Type (https://en.wikipedia.org/wiki/Media_type).
+    // Possible values include "application/vnd.apigee.proto", 
+    // "application/vnd.apigee.openapi", and "application/vnd.apigee.graphql",
+    // with possible suffixes representing compression types. These hypothetical
+    // names are defined in the vendor tree defined in RFC6838 
+    // (https://tools.ietf.org/html/rfc6838) and are not final.
+    repeated string mime_types = 2 [
+		(google.api.field_behavior) = REQUIRED
+	];
+
+    // A list of guidelines that are specified by this style guide.
+    repeated Guideline guidelines = 3;
+
+    // A list of linters that this style guide uses.
+    repeated Linter linters = 4;
+}
+
+message Guideline {
+    // Name of the rule that this guideline specifies.
+    string rule_name = 1 [
+		(google.api.field_behavior) = REQUIRED
+	];
+
+    // Name of the linter that enforces this guideline.
+    string linter_name = 2 [
+		(google.api.field_behavior) = REQUIRED
+	];
+
+    // Name of the linter rule that this guideline corresponds to.
+    string linter_rule_name = 3 [
+		(google.api.field_behavior) = REQUIRED
+	];
+
+    // Description of this guideline.
+    string description = 4;
+
+    // Severity of violating this guideline.
+    enum Severity {
+        ERROR = 0;
+        WARNING = 1;
+        INFO = 2;
+        HINT = 3;
+    }
+    Severity severity = 5;
+
+    // Indicates whether the guideline has been deprecated.
+    bool deprecated = 6;
+}
+
+message Linter {
+    // Name of the linter.
+    string name = 1 [
+		(google.api.field_behavior) = REQUIRED
+	];
+
+    // Path to the linter binary executable.
+    string uri = 2 [
+		(google.api.field_behavior) = REQUIRED
+	];
+}

--- a/google/cloud/apigee/registry/applications/v1alpha1/registry_api_style_guide.proto
+++ b/google/cloud/apigee/registry/applications/v1alpha1/registry_api_style_guide.proto
@@ -20,13 +20,13 @@ import "google/api/field_behavior.proto";
 
 option java_package = "com.google.cloud.apigee.registry.applications.v1alpha1";
 option java_multiple_files = true;
-option java_outer_classname = "RegistryAPIStyleGuideProto";
+option java_outer_classname = "RegistryStyleGuideProto";
 option go_package = "github.com/apigee/registry/rpc;rpc";
 
-// APIStyleGuide defines a set of guidelines and linters that govern
+// StyleGuide defines a set of guidelines and linters that govern
 // the static analysis of API Specs.
-message APIStyleGuide {
-    // Name of the API Style Guide
+message StyleGuide {
+    // Resource name of the style guide.
     string name = 1 [
         (google.api.field_behavior) = REQUIRED
     ];
@@ -50,35 +50,48 @@ message APIStyleGuide {
 }
 
 message Guideline {
-    // Name of the rule that this guideline specifies.
-    string rule_name = 1 [
+    // Resource name of the guideline.
+    string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // Human-meaningful name.
+    string display_name = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // A detailed description of the guideline.
+    string description = 3;
+
+    // A list of rules that this guideline specifies.
+    repeated Rule rules = 4;
+
+    // Indicates whether the guideline has been deprecated.
+    bool deprecated = 5;
+}
+
+message Rule {
+    // Name of the rule.
+    string name = 1 [
 		(google.api.field_behavior) = REQUIRED
 	];
 
-    // Name of the linter that enforces this guideline.
+    // Name of the linter that enforces this rule.
     string linter_name = 2 [
 		(google.api.field_behavior) = REQUIRED
 	];
+    
+    // A detailed description of the rule.
+    string description = 3;
 
-    // Name of the linter rule that this guideline corresponds to.
-    string linter_rule_name = 3 [
-		(google.api.field_behavior) = REQUIRED
-	];
-
-    // Description of this guideline.
-    string description = 4;
-
-    // Severity of violating this guideline.
+    // Severity of violating this rule.
     enum Severity {
         ERROR = 0;
         WARNING = 1;
         INFO = 2;
         HINT = 3;
     }
-    Severity severity = 5;
-
-    // Indicates whether the guideline has been deprecated.
-    bool deprecated = 6;
+    Severity severity = 4;
 }
 
 message Linter {
@@ -87,7 +100,7 @@ message Linter {
 		(google.api.field_behavior) = REQUIRED
 	];
 
-    // Path to the linter binary executable.
+    // A uri to the linter source code or documentation.
     string uri = 2 [
 		(google.api.field_behavior) = REQUIRED
 	];

--- a/google/cloud/apigee/registry/applications/v1alpha1/registry_styleguide.proto
+++ b/google/cloud/apigee/registry/applications/v1alpha1/registry_styleguide.proto
@@ -23,7 +23,7 @@ option java_multiple_files = true;
 option java_outer_classname = "RegistryStyleGuideProto";
 option go_package = "github.com/apigee/registry/rpc;rpc";
 
-// StyleGuide defines a set of guidelines and linters that govern
+// StyleGuide defines a set of guidelines, rules, and linters that govern
 // the static analysis of API Specs.
 message StyleGuide {
     // Resource name of the style guide.
@@ -66,23 +66,37 @@ message Guideline {
     // A list of rules that this guideline specifies.
     repeated Rule rules = 4;
 
-    // Indicates whether the guideline has been deprecated.
-    bool deprecated = 5;
+    // Indicates the status of the guideline.
+    enum Status {
+        PROPOSED = 0;
+        ACTIVE = 1;
+        DEPRECATED = 2;
+        DISABLED = 3;
+    }
+    Status status = 5;
 }
 
 message Rule {
-    // Name of the rule.
+    // Resource name of the rule.
     string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // Human-meaningful name.
+    string display_name = 2;
+
+    // A detailed description of the rule.
+    string description = 3;
+
+    // Name of the linter that enforces this rule.
+    string linter = 4 [
 		(google.api.field_behavior) = REQUIRED
 	];
 
-    // Name of the linter that enforces this rule.
-    string linter_name = 2 [
-		(google.api.field_behavior) = REQUIRED
-	];
-    
-    // A detailed description of the rule.
-    string description = 3;
+    // Name of the rule on the linter that enforces it.
+    string linter_rulename = 5 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
     // Severity of violating this rule.
     enum Severity {
@@ -91,7 +105,7 @@ message Rule {
         INFO = 2;
         HINT = 3;
     }
-    Severity severity = 4;
+    Severity severity = 6;
 }
 
 message Linter {

--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -37,6 +37,7 @@ mkdir -p rpc gapic cmd/apg
 ANNOTATIONS="third_party/api-common-protos"
 
 PROTOS=( \
+	google/cloud/apigee/registry/applications/v1alpha1/registry_api_style_guide.proto \
 	google/cloud/apigee/registry/applications/v1alpha1/registry_index.proto \
 	google/cloud/apigee/registry/applications/v1alpha1/registry_lint.proto \
 	google/cloud/apigee/registry/applications/v1alpha1/registry_references.proto \

--- a/tools/COMPILE-PROTOS.sh
+++ b/tools/COMPILE-PROTOS.sh
@@ -37,7 +37,7 @@ mkdir -p rpc gapic cmd/apg
 ANNOTATIONS="third_party/api-common-protos"
 
 PROTOS=( \
-	google/cloud/apigee/registry/applications/v1alpha1/registry_api_style_guide.proto \
+	google/cloud/apigee/registry/applications/v1alpha1/registry_styleguide.proto \
 	google/cloud/apigee/registry/applications/v1alpha1/registry_index.proto \
 	google/cloud/apigee/registry/applications/v1alpha1/registry_lint.proto \
 	google/cloud/apigee/registry/applications/v1alpha1/registry_references.proto \


### PR DESCRIPTION
## Overview:
API Style Guides are a declarative solution to define the static analysis of API specs within a project. An API Style Guide is described by the proto that is defined in this pull request. It contains a list of guidelines along with linters that enforce those guidelines.

This pull request creates the API Style Guide proto, and also implements a CLI to upload YAML files that describe an API Style Guide to the registry, where it is attached as an artifact to a provided project ID.

## Test:

1. Create a file called `styleguide.yaml` in your home directory, with the following contents:
```yaml
name: openapistyleguide
mime_types:
  - application/x.openapi+gzip;version=2
guidelines:
  - name: refproperties
    display_name: Govern Ref Properties
    description: This guideline governs properties for ref fields on specs.
    rules:
      - name: norefsiblings
        description: An object exposing a $ref property cannot be further extended with additional properties.
        linter: spectral
        linter_rulename: no-$ref-siblings
        severity: 1
    status: 1
linters:
  - name: spectral
    uri: https://github.com/stoplightio/spectral
```

2. Ensure that the API Registry Server is running on localhost:8080
3. Run the following commands on the registry:
```bash
apg registry delete-project --name projects/protos

apg registry create-project --project_id protos --insecure --address localhost:8080

registry upload styleguide ~/styleguide.yaml --project_id protos

registry get projects/protos/locations/global/artifacts/openapistyleguide --contents
```