### PR TITLE
Pin the Go version used for CI to 1.15.*

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.15.15
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.15
+        go-version: 1.15.*
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2


### PR DESCRIPTION
Temporary change to keep CI working while we make changes needed for 1.16 and 1.17 