### PR TITLE
Refactor 'name' field to ID on style guide and manifest proto definition

### DIFF
--- a/cmd/registry/cmd/resolve/testdata/manifest.yaml
+++ b/cmd/registry/cmd/resolve/testdata/manifest.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/complexity
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('openapi')"
-  action: "registry compute complexity $resource.spec"
+  - pattern: apis/-/versions/-/specs/-/artifacts/complexity
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('openapi')"
+    action: "registry compute complexity $resource.spec"

--- a/cmd/registry/cmd/resolve/testdata/manifest_receipt.yaml
+++ b/cmd/registry/cmd/resolve/testdata/manifest_receipt.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/test-receipt-artifact
-  receipt: true
-  dependencies:
-  - pattern: $resource.spec
-  action: "echo test-receipt-artifact"
+  - pattern: apis/-/versions/-/specs/-/artifacts/test-receipt-artifact
+    receipt: true
+    dependencies:
+      - pattern: $resource.spec
+    action: "echo test-receipt-artifact"

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -85,7 +85,7 @@ func manifestCommand(ctx context.Context) *cobra.Command {
 			}
 
 			artifact := &rpc.Artifact{
-				Name:     "projects/" + projectID + "/locations/global/artifacts/" + manifest.Id,
+				Name:     "projects/" + projectID + "/locations/global/artifacts/" + manifest.GetId(),
 				MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.Manifest"),
 				Contents: manifestData,
 			}

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -85,7 +85,7 @@ func manifestCommand(ctx context.Context) *cobra.Command {
 			}
 
 			artifact := &rpc.Artifact{
-				Name:     "projects/" + projectID + "/locations/global/artifacts/" + manifest.Name,
+				Name:     "projects/" + projectID + "/locations/global/artifacts/" + manifest.Id,
 				MimeType: core.MimeTypeForMessageType("google.cloud.apigee.registry.applications.v1alpha1.Manifest"),
 				Contents: manifestData,
 			}

--- a/cmd/registry/cmd/upload/manifest_test.go
+++ b/cmd/registry/cmd/upload/manifest_test.go
@@ -41,7 +41,7 @@ func TestManifestUpload(t *testing.T) {
 			project:  "upload-manifest-demo",
 			filePath: filepath.Join("testdata", "manifest.yaml"),
 			want: &rpc.Manifest{
-				Name: "test-manifest",
+				Id: "test-manifest",
 				GeneratedResources: []*rpc.GeneratedResource{
 					{
 						Pattern: "apis/-/versions/-/specs/-/artifacts/complexity",

--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -81,7 +81,7 @@ func styleGuideCommand(ctx context.Context) *cobra.Command {
 				Name: "projects/" +
 					projectID +
 					"/locations/global/artifacts/" +
-					styleGuide.GetName(),
+					styleGuide.GetId(),
 				MimeType: core.MimeTypeForMessageType(
 					"google.cloud.apigee.registry.applications.v1alpha1.styleguide",
 				),

--- a/cmd/registry/cmd/upload/styleguide_test.go
+++ b/cmd/registry/cmd/upload/styleguide_test.go
@@ -41,18 +41,18 @@ func TestStyleGuideUpload(t *testing.T) {
 			project:  "upload-styleguide-demo",
 			filePath: filepath.Join("testdata", "styleguide.yaml"),
 			want: &rpc.StyleGuide{
-				Name: "test-styleguide",
+				Id: "test-styleguide",
 				MimeTypes: []string{
 					"application/x.openapi+gzip;version=2",
 				},
 				Guidelines: []*rpc.Guideline{
 					{
-						Name:        "refproperties",
+						Id:          "refproperties",
 						DisplayName: "Govern Ref Properties",
 						Description: "This guideline governs properties for ref fields on specs.",
 						Rules: []*rpc.Rule{
 							{
-								Name:           "norefsiblings",
+								Id:             "norefsiblings",
 								Description:    "An object exposing a $ref property cannot be further extended with additional properties.",
 								Linter:         "spectral",
 								LinterRulename: "no-$ref-siblings",

--- a/cmd/registry/cmd/upload/testdata/manifest.yaml
+++ b/cmd/registry/cmd/upload/testdata/manifest.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/complexity
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('openapi')"
-  action: "compute complexity $resource.spec"
+  - pattern: apis/-/versions/-/specs/-/artifacts/complexity
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('openapi')"
+    action: "compute complexity $resource.spec"

--- a/cmd/registry/cmd/upload/testdata/styleguide.yaml
+++ b/cmd/registry/cmd/upload/testdata/styleguide.yaml
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: test-styleguide
+id: test-styleguide
 mime_types:
   - application/x.openapi+gzip;version=2
 guidelines:
-  - name: refproperties
+  - id: refproperties
     display_name: Govern Ref Properties
     description: This guideline governs properties for ref fields on specs.
     rules:
-      - name: norefsiblings
+      - id: norefsiblings
         description: An object exposing a $ref property cannot be further extended with additional properties.
         linter: spectral
         linter_rulename: no-$ref-siblings

--- a/cmd/registry/controller/controller_test.go
+++ b/cmd/registry/controller/controller_test.go
@@ -156,7 +156,7 @@ func TestArtifacts(t *testing.T) {
 			test.setup(ctx, registryClient)
 
 			manifest := &rpc.Manifest{
-				Name: "controller-test",
+				Id: "controller-test",
 				GeneratedResources: []*rpc.GeneratedResource{
 					{
 						Pattern: "apis/-/versions/-/specs/-/artifacts/lint-gnostic",
@@ -283,7 +283,7 @@ func TestAggregateArtifacts(t *testing.T) {
 
 			manifest := &rpc.Manifest{
 
-				Name: "controller-test",
+				Id: "controller-test",
 				GeneratedResources: []*rpc.GeneratedResource{
 					{
 						Pattern: "apis/-/artifacts/vocabulary",
@@ -454,7 +454,7 @@ func TestDerivedArtifacts(t *testing.T) {
 			test.setup(ctx, registryClient)
 
 			manifest := &rpc.Manifest{
-				Name: "controller-test",
+				Id: "controller-test",
 				GeneratedResources: []*rpc.GeneratedResource{
 					{
 						Pattern: "apis/-/versions/-/specs/-/artifacts/summary",
@@ -540,7 +540,7 @@ func TestReceiptArtifacts(t *testing.T) {
 			test.setup(ctx, registryClient)
 
 			manifest := &rpc.Manifest{
-				Name: "controller-test",
+				Id: "controller-test",
 				GeneratedResources: []*rpc.GeneratedResource{
 					{
 						Pattern: "apis/-/versions/-/specs/-/artifacts/custom-artifact",
@@ -642,7 +642,7 @@ func TestReceiptAggArtifacts(t *testing.T) {
 			test.setup(ctx, registryClient)
 
 			manifest := &rpc.Manifest{
-				Name: "controller-test",
+				Id: "controller-test",
 				GeneratedResources: []*rpc.GeneratedResource{
 					{
 						Pattern: "artifacts/search-index",

--- a/cmd/registry/controller/testdata/manifest.yaml
+++ b/cmd/registry/controller/testdata/manifest.yaml
@@ -12,32 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/lint-gnostic
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('openapi')"
-  action: "registry compute lint $resource.spec --linter gnostic"
-- pattern: apis/-/versions/-/specs/-/artifacts/lint-aip
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('protobuf')"
-  action: "registry compute lint $resource.spec --linter aip"
-- pattern: apis/-/versions/-/specs/-/artifacts/lintstats-gnostic
-  dependencies:
-  - pattern: $resource.spec/artifacts/lint-gnostic
-  action: "registry compute lintstats $resource.spec/artifacts/lint-gnostic --linter gnostic"
-- pattern: apis/-/artifacts/vocabulary
-  dependencies:
-  - pattern: $resource.api/versions/-/specs/-
-  action: "registry compute vocabulary $resource.api"
-- pattern: apis/-/versions/-/artifacts/vocabulary
-  dependencies:
-  - pattern: $resource.version/-/specs/-
-  action: "registry compute vocabulary $resource.version"
-- pattern: apis/-/versions/-/specs/-/artifacts/score
-  dependencies:
-  - pattern: $resource.spec/artifacts/lint-gnostic
-  - pattern: $resource.spec/artifacts/complexity
-  action: "registry compute score $resource.spec/artifacts/lint-gnostic $resource.spec/artifacts/complexity" 
+  - pattern: apis/-/versions/-/specs/-/artifacts/lint-gnostic
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('openapi')"
+    action: "registry compute lint $resource.spec --linter gnostic"
+  - pattern: apis/-/versions/-/specs/-/artifacts/lint-aip
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('protobuf')"
+    action: "registry compute lint $resource.spec --linter aip"
+  - pattern: apis/-/versions/-/specs/-/artifacts/lintstats-gnostic
+    dependencies:
+      - pattern: $resource.spec/artifacts/lint-gnostic
+    action: "registry compute lintstats $resource.spec/artifacts/lint-gnostic --linter gnostic"
+  - pattern: apis/-/artifacts/vocabulary
+    dependencies:
+      - pattern: $resource.api/versions/-/specs/-
+    action: "registry compute vocabulary $resource.api"
+  - pattern: apis/-/versions/-/artifacts/vocabulary
+    dependencies:
+      - pattern: $resource.version/-/specs/-
+    action: "registry compute vocabulary $resource.version"
+  - pattern: apis/-/versions/-/specs/-/artifacts/score
+    dependencies:
+      - pattern: $resource.spec/artifacts/lint-gnostic
+      - pattern: $resource.spec/artifacts/complexity
+    action: "registry compute score $resource.spec/artifacts/lint-gnostic $resource.spec/artifacts/complexity"

--- a/cmd/registry/controller/testdata/manifest_e2e.yaml
+++ b/cmd/registry/controller/testdata/manifest_e2e.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/complexity
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('openapi')"
-  action: "registry compute complexity $resource.spec"
+  - pattern: apis/-/versions/-/specs/-/artifacts/complexity
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('openapi')"
+    action: "registry compute complexity $resource.spec"

--- a/cmd/registry/controller/testdata/manifest_test.yaml
+++ b/cmd/registry/controller/testdata/manifest_test.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/lint-gnostic
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('openapi')"
-  action: "registry compute lint $resource.spec --linter gnostic"
+  - pattern: apis/-/versions/-/specs/-/artifacts/lint-gnostic
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('openapi')"
+    action: "registry compute lint $resource.spec --linter gnostic"

--- a/google/cloud/apigee/registry/applications/v1alpha1/registry_manifest.proto
+++ b/google/cloud/apigee/registry/applications/v1alpha1/registry_manifest.proto
@@ -27,7 +27,7 @@ option go_package = "github.com/apigee/registry/rpc;rpc";
 // in a registry and is used by the controller to keep these resources up-to-date.
 message Manifest {
   // Name of manifest entry
-  string name = 1 [
+  string id = 1 [
 		(google.api.field_behavior) = REQUIRED
 	];
   // List of Generated resources.

--- a/google/cloud/apigee/registry/applications/v1alpha1/registry_styleguide.proto
+++ b/google/cloud/apigee/registry/applications/v1alpha1/registry_styleguide.proto
@@ -26,8 +26,13 @@ option go_package = "github.com/apigee/registry/rpc;rpc";
 // StyleGuide defines a set of guidelines and linters that govern the
 // static analysis of API Specs with specified mime types.
 message StyleGuide {
-    // Resource name of the style guide.
-    string name = 1 [
+    // Identifier of the style guide.
+    string id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // Human-meaningful name of the style guide.
+    string display_name = 2 [
         (google.api.field_behavior) = REQUIRED
     ];
 
@@ -39,26 +44,26 @@ message StyleGuide {
     // with possible suffixes representing compression types. These hypothetical
     // names are defined in the vendor tree defined in RFC6838 
     // (https://tools.ietf.org/html/rfc6838) and are not final.
-    repeated string mime_types = 2 [
+    repeated string mime_types = 3 [
 		(google.api.field_behavior) = REQUIRED
 	];
 
     // A list of guidelines that are specified by this style guide.
-    repeated Guideline guidelines = 3;
+    repeated Guideline guidelines = 4;
 
     // A list of linters that this style guide uses.
-    repeated Linter linters = 4;
+    repeated Linter linters = 5;
 }
 
 // Guideline defines a set of rules that achieve a common design
 // goal for API specs.
 message Guideline {
-    // Resource name of the guideline.
-    string name = 1 [
+    // Identifier of the guideline.
+    string id = 1 [
         (google.api.field_behavior) = REQUIRED
     ];
 
-    // Human-meaningful name.
+    // Human-meaningful name of the guideline.
     string display_name = 2 [
         (google.api.field_behavior) = REQUIRED
     ];
@@ -95,12 +100,12 @@ message Guideline {
 // Rule is a specific design rule that can be applied to an API spec,
 // and is enforced by a specified linter.
 message Rule {
-    // Resource name of the rule.
-    string name = 1 [
+    // Identifier of the rule.
+    string id = 1 [
         (google.api.field_behavior) = REQUIRED
     ];
 
-    // Human-meaningful name.
+    // Human-meaningful name of the rule.
     string display_name = 2;
 
     // A detailed description of the rule.

--- a/tests/controller/testdata/manifest.yaml
+++ b/tests/controller/testdata/manifest.yaml
@@ -12,27 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "test-manifest"
+id: "test-manifest"
 generated_resources:
-- pattern: apis/-/versions/-/specs/-/artifacts/lint-gnostic
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('openapi')"
-  action: "registry compute lint $resource.spec --linter gnostic"
-- pattern: apis/-/versions/-/specs/-/artifacts/lint-aip
-  dependencies:
-  - pattern: $resource.spec
-    filter: "mime_type.contains('protobuf')"
-  action: "registry compute lint $resource.spec --linter aip"
-- pattern: apis/-/versions/-/specs/-/artifacts/lintstats-gnostic
-  dependencies:
-  - pattern: $resource.spec/artifacts/lint-gnostic
-  action: "registry compute lintstats $resource.spec --linter gnostic"
-- pattern: apis/-/versions/-/specs/-/artifacts/vocabulary
-  dependencies:
-  - pattern: $resource.spec
-  action: "registry compute vocabulary $resource.spec"
-- pattern: apis/-/versions/-/specs/-/artifacts/complexity
-  dependencies:
-  - pattern: $resource.spec
-  action: "registry compute complexity $resource.spec" 
+  - pattern: apis/-/versions/-/specs/-/artifacts/lint-gnostic
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('openapi')"
+    action: "registry compute lint $resource.spec --linter gnostic"
+  - pattern: apis/-/versions/-/specs/-/artifacts/lint-aip
+    dependencies:
+      - pattern: $resource.spec
+        filter: "mime_type.contains('protobuf')"
+    action: "registry compute lint $resource.spec --linter aip"
+  - pattern: apis/-/versions/-/specs/-/artifacts/lintstats-gnostic
+    dependencies:
+      - pattern: $resource.spec/artifacts/lint-gnostic
+    action: "registry compute lintstats $resource.spec --linter gnostic"
+  - pattern: apis/-/versions/-/specs/-/artifacts/vocabulary
+    dependencies:
+      - pattern: $resource.spec
+    action: "registry compute vocabulary $resource.spec"
+  - pattern: apis/-/versions/-/specs/-/artifacts/complexity
+    dependencies:
+      - pattern: $resource.spec
+    action: "registry compute complexity $resource.spec"


### PR DESCRIPTION
## Summary
In the registry, the convention that we use is that `name` fields are typically given to resource names. A resource name is one that matches: `projects/{project_id}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}/artifacts/{artifact}`.

However, in the case of manifests and style guides, the `name` field is actually being used as an identifier rather than an actual resource name. Thus, we should correct our terminology and call them what they really are, `id`s.

## Test
Existing unit tests should pass. There is no extra manual test that needs to be done, since all of the tests pertaining to this are automated.