### PR TITLE
Structured logging for the registry server

### DIFF
--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/apex/log"
 	"github.com/apigee/registry/server"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
@@ -88,7 +88,7 @@ func main() {
 	pflag.Parse()
 
 	if configPath != "" {
-		log.Printf("Loading configuration from %s", configPath)
+		log.Infof("Loading configuration from %s", configPath)
 		raw, err := ioutil.ReadFile(configPath)
 		if err != nil {
 			log.Fatalf("Failed to open config file: %s", err)
@@ -105,7 +105,7 @@ func main() {
 		log.Fatalf("Invalid configuration: %s", err)
 	}
 
-	log.Printf("Configured port %d", config.Port)
+	log.Infof("Configured port %d", config.Port)
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{
 		Port: config.Port,
 	})
@@ -123,7 +123,7 @@ func main() {
 	})
 
 	go srv.Start(context.Background(), listener)
-	log.Printf("Listening on %s", listener.Addr())
+	log.Infof("Listening on %s", listener.Addr())
 
 	// Wait for an interruption signal.
 	done := make(chan os.Signal, 1)

--- a/server/actions_apis.go
+++ b/server/actions_apis.go
@@ -73,7 +73,7 @@ func (s *RegistryServer) CreateApi(ctx context.Context, req *rpc.CreateApiReques
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_CREATED, name.String())
+	s.notify(ctx, rpc.Notification_CREATED, name.String())
 	return message, nil
 }
 
@@ -99,7 +99,7 @@ func (s *RegistryServer) DeleteApi(ctx context.Context, req *rpc.DeleteApiReques
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_DELETED, name.String())
+	s.notify(ctx, rpc.Notification_DELETED, name.String())
 	return &emptypb.Empty{}, nil
 }
 
@@ -211,6 +211,6 @@ func (s *RegistryServer) UpdateApi(ctx context.Context, req *rpc.UpdateApiReques
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_UPDATED, name.String())
+	s.notify(ctx, rpc.Notification_UPDATED, name.String())
 	return message, nil
 }

--- a/server/actions_artifacts.go
+++ b/server/actions_artifacts.go
@@ -106,7 +106,7 @@ func (s *RegistryServer) CreateArtifact(ctx context.Context, req *rpc.CreateArti
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_CREATED, name.String())
+	s.notify(ctx, rpc.Notification_CREATED, name.String())
 	return artifact.Message(), nil
 }
 
@@ -132,7 +132,7 @@ func (s *RegistryServer) DeleteArtifact(ctx context.Context, req *rpc.DeleteArti
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_DELETED, name.String())
+	s.notify(ctx, rpc.Notification_DELETED, name.String())
 	return &emptypb.Empty{}, nil
 }
 
@@ -280,6 +280,6 @@ func (s *RegistryServer) ReplaceArtifact(ctx context.Context, req *rpc.ReplaceAr
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_UPDATED, name.String())
+	s.notify(ctx, rpc.Notification_UPDATED, name.String())
 	return artifact.Message(), nil
 }

--- a/server/actions_projects.go
+++ b/server/actions_projects.go
@@ -54,7 +54,7 @@ func (s *RegistryServer) CreateProject(ctx context.Context, req *rpc.CreateProje
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_CREATED, name.String())
+	s.notify(ctx, rpc.Notification_CREATED, name.String())
 	return project.Message(), nil
 }
 
@@ -80,7 +80,7 @@ func (s *RegistryServer) DeleteProject(ctx context.Context, req *rpc.DeleteProje
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_DELETED, name.String())
+	s.notify(ctx, rpc.Notification_DELETED, name.String())
 	return &emptypb.Empty{}, nil
 }
 
@@ -171,6 +171,6 @@ func (s *RegistryServer) UpdateProject(ctx context.Context, req *rpc.UpdateProje
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_UPDATED, name.String())
+	s.notify(ctx, rpc.Notification_UPDATED, name.String())
 	return project.Message(), nil
 }

--- a/server/actions_spec_revisions.go
+++ b/server/actions_spec_revisions.go
@@ -105,7 +105,7 @@ func (s *RegistryServer) DeleteApiSpecRevision(ctx context.Context, req *rpc.Del
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_DELETED, name.String())
+	s.notify(ctx, rpc.Notification_DELETED, name.String())
 	return &emptypb.Empty{}, nil
 }
 
@@ -156,7 +156,7 @@ func (s *RegistryServer) TagApiSpecRevision(ctx context.Context, req *rpc.TagApi
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_UPDATED, name.String())
+	s.notify(ctx, rpc.Notification_UPDATED, name.String())
 	return message, nil
 }
 
@@ -206,6 +206,6 @@ func (s *RegistryServer) RollbackApiSpec(ctx context.Context, req *rpc.RollbackA
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_CREATED, rollback.RevisionName())
+	s.notify(ctx, rpc.Notification_CREATED, rollback.RevisionName())
 	return message, nil
 }

--- a/server/actions_specs.go
+++ b/server/actions_specs.go
@@ -83,7 +83,7 @@ func (s *RegistryServer) createSpec(ctx context.Context, name names.Spec, body *
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_CREATED, spec.RevisionName())
+	s.notify(ctx, rpc.Notification_CREATED, spec.RevisionName())
 	return message, nil
 }
 
@@ -109,7 +109,7 @@ func (s *RegistryServer) DeleteApiSpec(ctx context.Context, req *rpc.DeleteApiSp
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_DELETED, name.String())
+	s.notify(ctx, rpc.Notification_DELETED, name.String())
 	return &emptypb.Empty{}, nil
 }
 
@@ -323,7 +323,7 @@ func (s *RegistryServer) UpdateApiSpec(ctx context.Context, req *rpc.UpdateApiSp
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_UPDATED, spec.RevisionName())
+	s.notify(ctx, rpc.Notification_UPDATED, spec.RevisionName())
 	return message, nil
 }
 

--- a/server/actions_versions.go
+++ b/server/actions_versions.go
@@ -73,7 +73,7 @@ func (s *RegistryServer) CreateApiVersion(ctx context.Context, req *rpc.CreateAp
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_CREATED, name.String())
+	s.notify(ctx, rpc.Notification_CREATED, name.String())
 	return message, nil
 }
 
@@ -99,7 +99,7 @@ func (s *RegistryServer) DeleteApiVersion(ctx context.Context, req *rpc.DeleteAp
 		return nil, err
 	}
 
-	_ = s.notify(ctx, rpc.Notification_DELETED, name.String())
+	s.notify(ctx, rpc.Notification_DELETED, name.String())
 	return &emptypb.Empty{}, nil
 }
 
@@ -211,6 +211,6 @@ func (s *RegistryServer) UpdateApiVersion(ctx context.Context, req *rpc.UpdateAp
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	_ = s.notify(ctx, rpc.Notification_UPDATED, name.String())
+	s.notify(ctx, rpc.Notification_UPDATED, name.String())
 	return message, nil
 }

--- a/server/internal/storage/gorm/client.go
+++ b/server/internal/storage/gorm/client.go
@@ -17,10 +17,10 @@ package gorm
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 
 	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
+	"github.com/apex/log"
 	"github.com/apigee/registry/server/internal/storage/models"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -169,7 +169,7 @@ func (c *Client) Put(ctx context.Context, k *Key, v interface{}) (*Key, error) {
 		if rowsAffected == 0 {
 			err := tx.Create(v).Error
 			if err != nil {
-				log.Printf("CREATE ERROR %s", err.Error())
+				log.WithError(err).Infof("CREATE ERROR")
 			}
 		}
 		return nil
@@ -253,7 +253,7 @@ func (c *Client) Run(ctx context.Context, q *Query) *Iterator {
 		_ = op.Find(&v).Error
 		return &Iterator{Client: c, Values: v, Index: 0}
 	default:
-		log.Printf("Unable to run query for kind %s", q.Kind)
+		log.Infof("Unable to run query for kind %s", q.Kind)
 		return nil
 	}
 }

--- a/server/internal/storage/gorm/client.go
+++ b/server/internal/storage/gorm/client.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
-	"github.com/apex/log"
 	"github.com/apigee/registry/server/internal/storage/models"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -167,10 +166,7 @@ func (c *Client) Put(ctx context.Context, k *Key, v interface{}) (*Key, error) {
 		// Update all fields from model: https://gorm.io/docs/update.html#Update-Selected-Fields
 		rowsAffected := tx.Model(v).Select("*").Where("key = ?", k.Name).Updates(v).RowsAffected
 		if rowsAffected == 0 {
-			err := tx.Create(v).Error
-			if err != nil {
-				log.WithError(err).Infof("CREATE ERROR")
-			}
+			tx.Create(v)
 		}
 		return nil
 	})
@@ -253,7 +249,6 @@ func (c *Client) Run(ctx context.Context, q *Query) *Iterator {
 		_ = op.Find(&v).Error
 		return &Iterator{Client: c, Values: v, Index: 0}
 	default:
-		log.Infof("Unable to run query for kind %s", q.Kind)
 		return nil
 	}
 }

--- a/server/internal/storage/gorm/query.go
+++ b/server/internal/storage/gorm/query.go
@@ -14,10 +14,6 @@
 
 package gorm
 
-import (
-	"github.com/apex/log"
-)
-
 // Query represents a query in a storage provider.
 type Query struct {
 	Kind         string
@@ -54,8 +50,6 @@ func (q *Query) Require(name string, value interface{}) *Query {
 		name = "revision_id"
 	case "ArtifactID":
 		name = "artifact_id"
-	default:
-		log.Fatalf("UNEXPECTED REQUIRE TYPE: %s", name)
 	}
 	q.Requirements = append(q.Requirements, &Requirement{Name: name, Value: value})
 	return q

--- a/server/internal/storage/gorm/query.go
+++ b/server/internal/storage/gorm/query.go
@@ -15,7 +15,7 @@
 package gorm
 
 import (
-	"log"
+	"github.com/apex/log"
 )
 
 // Query represents a query in a storage provider.

--- a/server/notifications.go
+++ b/server/notifications.go
@@ -16,17 +16,15 @@ package server
 
 import (
 	"context"
-	"log"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/apex/log"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-const verbose = false
 
 const TopicName = "registry-events"
 
@@ -69,10 +67,8 @@ func (s *RegistryServer) notify(ctx context.Context, change rpc.Notification_Cha
 	}
 
 	notificationTotal++
-	if verbose {
-		log.Printf("^^ [%03d] %+s", notificationTotal, msg)
-		log.Printf("Published a message with a message ID: %s", id)
-	}
+	log.Infof("^^ [%03d] %+s", notificationTotal, msg)
+	log.Infof("Published a message with a message ID: %s", id)
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -16,11 +16,11 @@ package server
 
 import (
 	"context"
-	"log"
 	"net"
 	"path/filepath"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/internal/storage"
 
@@ -118,15 +118,15 @@ func (s *RegistryServer) Start(ctx context.Context, listener net.Listener) {
 func (s *RegistryServer) logHandler(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	method := filepath.Base(info.FullMethod)
 	if s.loggingLevel >= loggingInfo {
-		log.Printf(">> %s", method)
+		log.Infof(">> %s", method)
 	}
 	resp, err := handler(ctx, req)
 	if isNotFound(err) && s.loggingLevel >= loggingDebug {
 		// Only log "not found" at DEBUG and higher.
-		log.Printf("[%s] %s", method, err.Error())
+		log.WithError(err).Infof("[%s]", method)
 	} else if err != nil && s.loggingLevel >= loggingError {
 		// Log all other problems at ERROR and higher.
-		log.Printf("[%s] %s", method, err.Error())
+		log.WithError(err).Infof("[%s]", method)
 	}
 	return resp, err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -161,7 +161,7 @@ func (s *RegistryServer) loggingInterceptor(ctx context.Context, req interface{}
 		"status_code": status.Code(err),
 	}
 
-	if r, ok := resp.(resourceOp); ok {
+	if r, ok := resp.(resourceOp); err == nil && ok {
 		respInfo["resource"] = r.GetName()
 	}
 


### PR DESCRIPTION
This PR addresses most features of #318 and #319. 

Notably this does not make the log output format configurable which means Cloud Logging may not even recognize that the logs are structured. It also doesn't include any logging for database interactions in the server. These features are important to add before closing those issues, but this PR stands on its own without them.