### PR TITLE
Fix dockerfiles for build process changes.

### DIFF
--- a/containers/registry-server/Dockerfile
+++ b/containers/registry-server/Dockerfile
@@ -37,7 +37,7 @@ RUN go mod download
 COPY . ./
 
 # Compile protos.
-RUN make protos
+#RUN make protos
 
 # Build registry-server.
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry-server ./cmd/registry-server

--- a/containers/registry-server/Dockerfile
+++ b/containers/registry-server/Dockerfile
@@ -36,9 +36,6 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . ./
 
-# Compile protos.
-#RUN make protos
-
 # Build registry-server.
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry-server ./cmd/registry-server
 

--- a/containers/registry-tools/Dockerfile
+++ b/containers/registry-tools/Dockerfile
@@ -36,9 +36,6 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . ./
 
-# Compile protos.
-RUN make protos
-
 # Build registry.
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry ./cmd/registry
 


### PR DESCRIPTION
Removes "make protos" steps from the dockerfiles for registry-server and registry-tools - protos are now precompiled and in the repo and these steps fail for our current build configuration.