### PR TITLE
Fix 'registry get ... --contents' for certain artifact types

### DIFF
--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -83,7 +83,7 @@ func styleGuideCommand(ctx context.Context) *cobra.Command {
 					"/locations/global/artifacts/" +
 					styleGuide.GetId(),
 				MimeType: core.MimeTypeForMessageType(
-					"google.cloud.apigee.registry.applications.v1alpha1.styleguide",
+					"google.cloud.apigee.registry.applications.v1alpha1.StyleGuide",
 				),
 				Contents: styleGuideMarshalled,
 			}

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -94,8 +94,14 @@ func PrintArtifactContents(artifact *rpc.Artifact) {
 		unmarshalAndPrint(artifact.GetContents(), &metrics.VersionHistory{})
 	case "google.cloud.apigee.registry.applications.v1alpha1.Index":
 		unmarshalAndPrint(artifact.GetContents(), &rpc.Index{})
+	case "google.cloud.apigee.registry.applications.v1alpha1.Lint":
+		unmarshalAndPrint(artifact.GetContents(), &rpc.Lint{})
+	case "google.cloud.apigee.registry.applications.v1alpha1.Manifest":
+		unmarshalAndPrint(artifact.GetContents(), &rpc.Manifest{})
 	case "google.cloud.apigee.registry.applications.v1alpha1.References":
 		unmarshalAndPrint(artifact.GetContents(), &rpc.References{})
+	case "google.cloud.apigee.registry.applications.v1alpha1.StyleGuide":
+		unmarshalAndPrint(artifact.GetContents(), &rpc.StyleGuide{})
 	case "gnostic.openapiv2.Document":
 		unmarshalAndPrint(artifact.GetContents(), &openapiv2.Document{})
 	case "gnostic.openapiv3.Document":


### PR DESCRIPTION
Encountered this issue while testing some controller use-cases.  Some of the artifact types were not showing the deserialized contents, for example, `registry get projects/demo/locations/global/artifacts/test-manifest --contents` command. 

Solution: They were missing the deserialization logic in `PrintArtifactContents`.