### PR TITLE
Fix some problems with container builds.

### DIFF
--- a/containers/registry-server/Dockerfile
+++ b/containers/registry-server/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 RUN apt-get update
 RUN apt-get install unzip
 

--- a/containers/registry-tools/Dockerfile
+++ b/containers/registry-tools/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 RUN apt-get update
 RUN apt-get install unzip
 

--- a/tools/GENERATE-APG.sh
+++ b/tools/GENERATE-APG.sh
@@ -20,8 +20,8 @@ set -e
 source tools/PROTOS.sh
 clone_common_protos
 
-go install google.golang.org/protobuf/cmd/protoc-gen-go
-go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_cli
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_cli@latest
 
 echo "Generating Go client CLI for ${SERVICE_PROTOS[@]}"
 protoc ${SERVICE_PROTOS[*]} \


### PR DESCRIPTION
- "make clean" should not delete protos.pb (this file is now checked in)
- builds of the registry-tools container need to generate the apg source code.