### PR TITLE
Manifest fixes for compute lintstats command

### DIFF
--- a/cmd/registry/controller/controller-error-path_test.go
+++ b/cmd/registry/controller/controller-error-path_test.go
@@ -21,10 +21,10 @@ func TestControllerErrors(t *testing.T) {
 				Pattern: "apis/-/versions/-/artifacts/lintstats-gnostic",
 				Dependencies: []*rpc.Dependency{
 					{
-						Pattern: "$resource.spec", // Correct pattern should be: $resource.version/specs/-
+						Pattern: "$resource.spec", // Correct pattern should be: $resource.version
 					},
 				},
-				Action: "registry compute lint $resource.spec --linter gnostic",
+				Action: "registry compute lintstats $resource.spec --linter gnostic",
 			},
 		},
 		{
@@ -48,6 +48,7 @@ func TestControllerErrors(t *testing.T) {
 						Pattern: "$resource.version/artifacts/lint-gnostic", // There is no version level lint-gnostic artifact in the registry
 					},
 				},
+				//Correct action should be "registry compute lintstats $resource.version --linter gnostic"
 				Action: "registry compute lintstats $resource.version/artifacts/lint-gnostic --linter gnostic",
 			},
 		},
@@ -60,7 +61,7 @@ func TestControllerErrors(t *testing.T) {
 						Pattern: "$resource.spec",
 					},
 				},
-				Action: "registry compute lintstats $resource.artifact --linter gnostic", // Correct reference should be: $artifact.spec/artifacts/lint-gnostic
+				Action: "registry compute lintstats $resource.artifact --linter gnostic", // Correct reference should be: $resource.spec
 			},
 		},
 		{
@@ -72,7 +73,7 @@ func TestControllerErrors(t *testing.T) {
 						Pattern: "$resource.spec",
 					},
 				},
-				Action: "registry compute lintstats $resource.specs/artifacts/lint-gnostic --linter gnostic",
+				Action: "registry compute lintstats $resource.specs --linter gnostic",
 			},
 		},
 		{

--- a/cmd/registry/controller/parser.go
+++ b/cmd/registry/controller/parser.go
@@ -225,8 +225,8 @@ func getCommandEntitity(action string) (string, string, error) {
 	}
 
 	// Extract the $resource patterns from action
-	// action = "compute lintstats  $resource.spec/artifacts/lint-gnostic"
-	// This expression will match $resource.spec/
+	// action = "compute lintstats $resource.spec"
+	// This expression will match $resource.spec
 	re := regexp.MustCompile(fmt.Sprintf(`\%s(\.api|\.version|\.spec|\.artifact)($|/| )`, resourceKW))
 	match := re.FindAllString(action, -1)
 	if len(match) == 0 {

--- a/cmd/registry/controller/testdata/manifest.yaml
+++ b/cmd/registry/controller/testdata/manifest.yaml
@@ -27,7 +27,8 @@ generated_resources:
   - pattern: apis/-/versions/-/specs/-/artifacts/lintstats-gnostic
     dependencies:
       - pattern: $resource.spec/artifacts/lint-gnostic
-    action: "registry compute lintstats $resource.spec/artifacts/lint-gnostic --linter gnostic"
+      - pattern: $resource.spec/artifacts/complexity
+    action: "registry compute lintstats $resource.spec --linter gnostic"
   - pattern: apis/-/artifacts/vocabulary
     dependencies:
       - pattern: $resource.api/versions/-/specs/-

--- a/tests/controller/README.md
+++ b/tests/controller/README.md
@@ -68,6 +68,7 @@ generated_resources:
   - pattern: "apis/-/versions/-/specs/-/artifacts/lintstats-spectral"
     dependencies:
       - pattern: "$resource.spec/artifacts/lint-spectral"
+      - pattern: "$resource.spec/artifacts/complexity"
     action: "registry compute lintstats $resource.spec --linter spectral"
   - pattern: "apis/-/versions/-/specs/-/artifacts/vocabulary"
     dependencies:

--- a/tests/controller/testdata/manifest.yaml
+++ b/tests/controller/testdata/manifest.yaml
@@ -22,6 +22,7 @@ generated_resources:
   - pattern: "apis/-/versions/-/specs/-/artifacts/lintstats-spectral"
     dependencies:
       - pattern: "$resource.spec/artifacts/lint-spectral"
+      - pattern: "$resource.spec/artifacts/complexity"
     action: "registry compute lintstats $resource.spec --linter spectral"
   - pattern: "apis/-/versions/-/specs/-/artifacts/vocabulary"
     dependencies:


### PR DESCRIPTION
Somehow missed including the dependency relation between "complexity" and "lintstats". This change fixes this relation in currently defined manifests.