### PR TITLE
Implement a framework through which an arbitrary linter plugin can be created

### DIFF
--- a/cmd/registry/plugins/linter/lint_framework.go
+++ b/cmd/registry/plugins/linter/lint_framework.go
@@ -1,4 +1,4 @@
-package lint
+package linter
 
 import (
 	"fmt"

--- a/cmd/registry/plugins/linter/linter_plugin_runner.go
+++ b/cmd/registry/plugins/linter/linter_plugin_runner.go
@@ -1,4 +1,4 @@
-package lint
+package linter
 
 import "github.com/apigee/registry/rpc"
 

--- a/cmd/registry/plugins/registry-lint-sample/main.go
+++ b/cmd/registry/plugins/registry-lint-sample/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 
-	lint "github.com/apigee/registry/cmd/registry/plugins/linter"
+	"github.com/apigee/registry/cmd/registry/plugins/linter"
 	"github.com/apigee/registry/rpc"
 )
 
@@ -49,5 +49,5 @@ func (*SampleLinterRunner) Run(req *rpc.LinterRequest) (*rpc.LinterResponse, err
 }
 
 func main() {
-	lint.Lint(&SampleLinterRunner{})
+	linter.Lint(&SampleLinterRunner{})
 }


### PR DESCRIPTION
## Summary
In the previous pull request (#346) I implemented a linter plugin for a sample linter. However, there are many functions here that are common across many linter plugins, including but not limited to Spectral and API linter. For this reason, we should create a framework/common library through which the linter can be invoked, and abstract away the part from the user that deals with IO streams. In doing so, the user simply implements a runnable interface which includes a function that takes in a linter request and returns a linter response, and passes it to a library-provided function which will do all the IO stream operations and handle errors.