### PR TITLE
Log database operations at the "Debug" level.

### DIFF
--- a/server/registry/internal/storage/gorm/logger.go
+++ b/server/registry/internal/storage/gorm/logger.go
@@ -63,6 +63,6 @@ func (l gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql s
 	} else if time.Since(begin) > l.SlowThreshold {
 		entry.Warn("Slow database operation.")
 	} else {
-		entry.Info("Database operation.")
+		entry.Debug("Database operation.")
 	}
 }


### PR DESCRIPTION
This will reduce the verbosity of default server logs and make it easier to observe API calls (logged at the Info level) but still allow database operations to be observed when the level is set to Debug.