### PR TITLE
Rename docker image target to "registry-server".

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{github.repository_owner}}/registry-backend
+  IMAGE_NAME: ${{github.repository_owner}}/registry-server
 
 
 jobs:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,5 +14,5 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/${PROJECT_ID}/registry-backend', '.']
-images: ['gcr.io/${PROJECT_ID}/registry-backend']
+  args: [ 'build', '-t', 'gcr.io/${PROJECT_ID}/registry-server', '.']
+images: ['gcr.io/${PROJECT_ID}/registry-server']


### PR DESCRIPTION
This updates the product of the docker-publish GitHub action to match the executable name and the container definition in the [containers](https://github.com/apigee/registry/tree/main/containers) directory.

I guess this build is using the Dockerfile at the root of the repo. That's a link to this [Dockerfile](https://github.com/apigee/registry/blob/main/containers/registry-server/Dockerfile) in [containers/registry-server](https://github.com/apigee/registry/tree/main/containers). If possible, it would be good to have a second build that builds the [registry-tools](https://github.com/apigee/registry/blob/main/containers/registry-tools/Dockerfile) container. @giteshk could that be done with this action or would we need to set up another one? 

@shrutiparabgoogle if we built the `registry-tools` image in a GitHub action (see above), we could rewrite the Dockerfile for `registry-linters` to use that one and we could build `registry-linters` in a GitHub action as well. 