### PR TITLE
Share logger attributes between registry tool and server

### DIFF
--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -94,6 +94,7 @@ func main() {
 	pflag.StringVarP(&configPath, "configuration", "c", "", "The server configuration file to load.")
 	pflag.Parse()
 
+	// Use a default logger configuration until we load the server config.
 	bootLogger := log.NewLogger()
 	if configPath != "" {
 		bootLogger.Infof("Loading configuration from %s", configPath)
@@ -113,6 +114,7 @@ func main() {
 		bootLogger.Fatalf("Invalid configuration: %s", err)
 	}
 
+	// Use logging options from the server config.
 	var (
 		logOpts        = loggerOptions(config.Logging)
 		logger         = log.NewLogger(logOpts...)

--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -100,18 +100,18 @@ func main() {
 		bootLogger.Infof("Loading configuration from %s", configPath)
 		raw, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			bootLogger.Fatalf("Failed to open config file: %s", err)
+			bootLogger.WithError(err).Fatal("Failed to open config file")
 		}
 		// Expand environment variables before unmarshaling.
 		expanded := []byte(os.ExpandEnv(string(raw)))
 		err = yaml.Unmarshal(expanded, &config)
 		if err != nil {
-			bootLogger.Fatalf("Failed to read config file: %s", err)
+			bootLogger.WithError(err).Fatalf("Failed to read config file")
 		}
 	}
 
 	if err := validateConfig(); err != nil {
-		bootLogger.Fatalf("Invalid configuration: %s", err)
+		bootLogger.WithError(err).Fatalf("Invalid configuration")
 	}
 
 	// Use logging options from the server config.
@@ -126,7 +126,7 @@ func main() {
 		Port: config.Port,
 	})
 	if err != nil {
-		logger.Fatalf("Failed to create TCP listener: %s", err)
+		logger.WithError(err).Fatalf("Failed to create TCP listener")
 	}
 	defer listener.Close()
 
@@ -139,7 +139,7 @@ func main() {
 		ProjectID: config.Pubsub.Project,
 	})
 	if err != nil {
-		logger.Fatalf("Failed to create registry server: %s", err)
+		logger.WithError(err).Fatalf("Failed to create registry server")
 	}
 
 	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(logInterceptor))

--- a/cmd/registry/cmd/compute/conformance/api_linter_plugin.go
+++ b/cmd/registry/cmd/compute/conformance/api_linter_plugin.go
@@ -19,8 +19,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 )
 
@@ -156,8 +156,11 @@ func (*concreteApiLinterRunner) Run(specPath string) ([]*rpc.LintProblem, error)
 		return parseLinterOutput(data)
 	}
 
+	// TODO: Replace this new instance with a logger inherited from the context.
+	logger := log.NewLogger()
+
 	// Unpack api-common-protos and try again if failure occurred
-	log.Info("API-linter failed due to an import error, unpacking API common protos and retrying.")
+	logger.Info("API-linter failed due to an import error, unpacking API common protos and retrying.")
 	if err = unpackApiCommonProtos(specDirectory); err == nil {
 		data, err = createAndRunApiLinterCommand(specDirectory, specName)
 		if err == nil {
@@ -165,7 +168,7 @@ func (*concreteApiLinterRunner) Run(specPath string) ([]*rpc.LintProblem, error)
 		}
 	}
 
-	log.Info("API-linter failed due to an import error, unpacking GoogleAPIs and retrying.")
+	logger.Info("API-linter failed due to an import error, unpacking GoogleAPIs and retrying.")
 	if err = unpackGoogleApisProtos(specDirectory); err == nil {
 		data, err = createAndRunApiLinterCommand(specDirectory, specName)
 		if err == nil {

--- a/cmd/registry/cmd/compute/descriptor.go
+++ b/cmd/registry/cmd/compute/descriptor.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -39,12 +39,12 @@ func descriptorCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			// Initialize task queue.
 			taskQueue, wait := core.WorkerPool(ctx, 64)
@@ -59,7 +59,7 @@ func descriptorCommand(ctx context.Context) *cobra.Command {
 					}
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to list specs")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
 				}
 			}
 		},
@@ -85,7 +85,7 @@ func (task *computeDescriptorTask) Run(ctx context.Context) error {
 	}
 	name := spec.GetName()
 	relation := "descriptor"
-	log.Debugf("Computing %s/artifacts/%s", name, relation)
+	log.Debugf(ctx, "Computing %s/artifacts/%s", name, relation)
 	data, err := core.GetBytesForSpec(ctx, task.client, spec)
 	if err != nil {
 		return nil

--- a/cmd/registry/cmd/compute/index.go
+++ b/cmd/registry/cmd/compute/index.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -35,12 +35,12 @@ func indexCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			// Initialize task queue.
 			taskQueue, wait := core.WorkerPool(ctx, 64)
@@ -56,7 +56,7 @@ func indexCommand(ctx context.Context) *cobra.Command {
 					}
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to list specs")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
 				}
 			}
 		},
@@ -85,7 +85,7 @@ func (task *computeIndexTask) Run(ctx context.Context) error {
 		return nil
 	}
 	relation := "index"
-	log.Debugf("Computing %s/artifacts/%s", spec.Name, relation)
+	log.Debugf(ctx, "Computing %s/artifacts/%s", spec.Name, relation)
 	var index *rpc.Index
 	if core.IsProto(spec.GetMimeType()) && core.IsZipArchive(spec.GetMimeType()) {
 		index, err = core.NewIndexFromZippedProtos(data)

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -44,17 +44,17 @@ func lintStatsCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			adminClient, err := connection.NewAdminClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			// Generate tasks.
@@ -62,7 +62,7 @@ func lintStatsCommand(ctx context.Context) *cobra.Command {
 
 			err = matchAndHandleLintStatsCmd(ctx, client, adminClient, name, filter, linter)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to match or handle command")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to match or handle command")
 			}
 		},
 	}
@@ -109,7 +109,7 @@ func computeLintStatsSpecs(ctx context.Context,
 
 	return core.ListSpecs(ctx, client, spec, filter, func(spec *rpc.ApiSpec) {
 		// Iterate through a collection of specs and evaluate each.
-		log.Debug(spec.GetName())
+		log.Debug(ctx, spec.GetName())
 		// get the lint results
 		request := rpc.GetArtifactContentsRequest{
 			Name: spec.Name + "/artifacts/" + lintRelation(linter),
@@ -177,7 +177,7 @@ func computeLintStatsProjects(ctx context.Context,
 		}
 		// Store the aggregate stats on this project
 		_ = storeLintStatsArtifact(ctx, client, project.GetName()+"/locations/global", linter, project_stats)
-		log.Debug(project.GetName())
+		log.Debug(ctx, project.GetName())
 	})
 }
 
@@ -197,7 +197,7 @@ func computeLintStatsAPIs(ctx context.Context,
 		}
 		// Store the aggregate stats on this api
 		_ = storeLintStatsArtifact(ctx, client, api.GetName(), linter, api_stats)
-		log.Debug(api.GetName())
+		log.Debug(ctx, api.GetName())
 	})
 }
 
@@ -217,7 +217,7 @@ func computeLintStatsVersions(ctx context.Context,
 		}
 		// Store the aggregate stats on this version
 		_ = storeLintStatsArtifact(ctx, client, version.GetName(), linter, version_stats)
-		log.Debug(version.GetName())
+		log.Debug(ctx, version.GetName())
 	})
 }
 

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -35,12 +35,12 @@ func referencesCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			// Initialize task queue.
 			taskQueue, wait := core.WorkerPool(ctx, 64)
@@ -56,7 +56,7 @@ func referencesCommand(ctx context.Context) *cobra.Command {
 					}
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to list specs")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to list specs")
 				}
 			}
 		},
@@ -81,7 +81,7 @@ func (task *computeReferencesTask) Run(ctx context.Context) error {
 		return err
 	}
 	relation := "references"
-	log.Debugf("Computing %s/artifacts/%s", spec.Name, relation)
+	log.Debugf(ctx, "Computing %s/artifacts/%s", spec.Name, relation)
 	var references *rpc.References
 	if core.IsProto(spec.MimeType) && core.IsZipArchive(spec.MimeType) {
 		data, err := core.GetBytesForSpec(ctx, task.client, spec)

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -36,7 +36,7 @@ func versionsCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			// Initialize task queue.
 			taskQueue, wait := core.WorkerPool(ctx, 64)
@@ -52,7 +52,7 @@ func versionsCommand(ctx context.Context) *cobra.Command {
 					}
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to list APIs")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to list APIs")
 				}
 			}
 		},
@@ -87,7 +87,7 @@ func (task *countVersionsTask) Run(ctx context.Context) error {
 			return err
 		}
 	}
-	log.Debugf("%d\t%s", count, task.apiName)
+	log.Debugf(ctx, "%d\t%s", count, task.apiName)
 	subject := task.apiName
 	relation := "versionCount"
 	artifact := &rpc.Artifact{

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -36,7 +36,7 @@ func Command(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			// Initialize task queue.
@@ -45,7 +45,7 @@ func Command(ctx context.Context) *cobra.Command {
 
 			err = matchAndHandleDeleteCmd(ctx, client, taskQueue, args[0], filter)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to match or handle command")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to match or handle command")
 			}
 		},
 	}
@@ -65,7 +65,7 @@ func (task *deleteTask) String() string {
 }
 
 func (task *deleteTask) Run(ctx context.Context) error {
-	log.Debugf("Deleting %s %s", task.resourceKind, task.resourceName)
+	log.Debugf(ctx, "Deleting %s %s", task.resourceKind, task.resourceName)
 	switch task.resourceKind {
 	case "api":
 		return task.client.DeleteApi(ctx, &rpc.DeleteApiRequest{Name: task.resourceName})

--- a/cmd/registry/cmd/export/yaml.go
+++ b/cmd/registry/cmd/export/yaml.go
@@ -15,9 +15,9 @@
 package export
 
 import (
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -32,12 +32,12 @@ func yamlCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			adminClient, err := connection.NewAdminClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			var name string
@@ -50,31 +50,31 @@ func yamlCommand(ctx context.Context) *cobra.Command {
 					core.ExportYAMLForProject(ctx, client, adminClient, message)
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to export project YAML")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to export project YAML")
 				}
 			} else if api, err := names.ParseApi(name); err == nil {
 				_, err = core.GetAPI(ctx, client, api, func(message *rpc.Api) {
 					core.ExportYAMLForAPI(ctx, client, message)
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to export API YAML")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to export API YAML")
 				}
 			} else if version, err := names.ParseVersion(name); err == nil {
 				_, err = core.GetVersion(ctx, client, version, func(message *rpc.ApiVersion) {
 					core.ExportYAMLForVersion(ctx, client, message)
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to export version YAML")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to export version YAML")
 				}
 			} else if spec, err := names.ParseSpec(name); err == nil {
 				_, err = core.GetSpec(ctx, client, spec, false, func(message *rpc.ApiSpec) {
 					core.ExportYAMLForSpec(ctx, client, message)
 				})
 				if err != nil {
-					log.WithError(err).Fatal("Failed to export spec YAML")
+					log.FromContext(ctx).WithError(err).Fatal("Failed to export spec YAML")
 				}
 			} else {
-				log.Fatalf("Unsupported entity %+s", name)
+				log.Fatalf(ctx, "Unsupported entity %+s", name)
 			}
 		},
 	}

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -17,9 +17,9 @@ package get
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
 )
@@ -33,11 +33,11 @@ func Command(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			adminClient, err := connection.NewAdminClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			var name string
@@ -65,10 +65,10 @@ func Command(ctx context.Context) *cobra.Command {
 					_, err2 = core.GetArtifact(ctx, client, artifact, getContents, core.PrintArtifactDetail)
 				}
 			} else {
-				log.Debugf("Unsupported entity %+v", args)
+				log.Debugf(ctx, "Unsupported entity %+v", args)
 			}
 			if err2 != nil {
-				log.WithError(err2).Debugf("Failed to get resource")
+				log.FromContext(ctx).WithError(err2).Debugf("Failed to get resource")
 			}
 		},
 	}

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -49,17 +49,17 @@ func collectInputIndexes(ctx context.Context, client connection.Client, args []s
 					vocab := &rpc.Index{}
 					err := proto.Unmarshal(artifact.GetContents(), vocab)
 					if err != nil {
-						log.WithError(err).Debug("Failed to unmarshal contents")
+						log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
 					} else {
 						inputNames = append(inputNames, artifact.Name)
 						inputs = append(inputs, vocab)
 					}
 				} else {
-					log.Debugf("Skipping, not an index: %s", artifact.Name)
+					log.Debugf(ctx, "Skipping, not an index: %s", artifact.Name)
 				}
 			})
 			if err != nil {
-				log.WithError(err).Fatal("Failed to list artifacts")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to list artifacts")
 			}
 		}
 	}
@@ -72,11 +72,11 @@ func setIndexToArtifact(ctx context.Context, client connection.Client, output *r
 	relation := parts[1]
 	messageData, err := proto.Marshal(output)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to marshal output proto")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to marshal output proto")
 	}
 	messageData, err = core.GZippedBytes(messageData)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to compress artifact contents")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to compress artifact contents")
 	}
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
@@ -85,6 +85,6 @@ func setIndexToArtifact(ctx context.Context, client connection.Client, output *r
 	}
 	err = core.SetArtifact(ctx, client, artifact)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to save artifact")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to save artifact")
 	}
 }

--- a/cmd/registry/cmd/index/union.go
+++ b/cmd/registry/cmd/index/union.go
@@ -17,9 +17,9 @@ package index
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/spf13/cobra"
 )
 
@@ -36,12 +36,12 @@ func unionCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			_, inputs := collectInputIndexes(ctx, client, args, filter)
 			index := core.IndexUnion(inputs)

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -42,7 +42,7 @@ func Command(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			taskQueue, wait := core.WorkerPool(ctx, 64)
@@ -56,10 +56,10 @@ func Command(ctx context.Context) *cobra.Command {
 				} else {
 					pair := strings.Split(operation, "=")
 					if len(pair) != 2 {
-						log.Fatalf("%q must have the form \"key=value\" (value can be empty) or \"key-\" (to remove the key)", operation)
+						log.Fatalf(ctx, "%q must have the form \"key=value\" (value can be empty) or \"key-\" (to remove the key)", operation)
 					}
 					if pair[0] == "" {
-						log.Fatalf("%q is invalid because it specifies an empty key", operation)
+						log.Fatalf(ctx, "%q is invalid because it specifies an empty key", operation)
 					}
 					valuesToSet[pair[0]] = pair[1]
 				}
@@ -68,7 +68,7 @@ func Command(ctx context.Context) *cobra.Command {
 
 			err = matchAndHandleLabelCmd(ctx, client, taskQueue, args[0], filter, labeling)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to match or handle command")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to match or handle command")
 			}
 		},
 	}
@@ -168,7 +168,7 @@ func (task *labelApiTask) Run(ctx context.Context) error {
 	var err error
 	task.api.Labels, err = task.labeling.Apply(task.api.Labels)
 	if err != nil {
-		log.WithError(err).Errorf("Invalid labelling")
+		log.FromContext(ctx).WithError(err).Errorf("Invalid labelling")
 		return nil
 	}
 	_, err = task.client.UpdateApi(ctx,
@@ -195,7 +195,7 @@ func (task *labelVersionTask) Run(ctx context.Context) error {
 	var err error
 	task.version.Labels, err = task.labeling.Apply(task.version.Labels)
 	if err != nil {
-		log.WithError(err).Errorf("Invalid labelling")
+		log.FromContext(ctx).WithError(err).Errorf("Invalid labelling")
 		return nil
 	}
 	_, err = task.client.UpdateApiVersion(ctx,
@@ -222,7 +222,7 @@ func (task *labelSpecTask) Run(ctx context.Context) error {
 	var err error
 	task.spec.Labels, err = task.labeling.Apply(task.spec.Labels)
 	if err != nil {
-		log.WithError(err).Errorf("Invalid labelling")
+		log.FromContext(ctx).WithError(err).Errorf("Invalid labelling")
 		return nil
 	}
 	_, err = task.client.UpdateApiSpec(ctx,

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
 )
@@ -34,15 +34,15 @@ func Command(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			adminClient, err := connection.NewAdminClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			err = matchAndHandleListCmd(ctx, client, adminClient, args[0], filter)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to match or handle command")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to match or handle command")
 			}
 		},
 	}

--- a/cmd/registry/cmd/root.go
+++ b/cmd/registry/cmd/root.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
-	"github.com/apex/log/handlers/text"
 	"github.com/apigee/registry/cmd/registry/cmd/annotate"
 	"github.com/apigee/registry/cmd/registry/cmd/compute"
 	"github.com/apigee/registry/cmd/registry/cmd/delete"
@@ -31,6 +29,7 @@ import (
 	"github.com/apigee/registry/cmd/registry/cmd/resolve"
 	"github.com/apigee/registry/cmd/registry/cmd/upload"
 	"github.com/apigee/registry/cmd/registry/cmd/vocabulary"
+	"github.com/apigee/registry/log"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
@@ -41,12 +40,11 @@ func Command(ctx context.Context) *cobra.Command {
 		Short: "A simple and eclectic utility for working with the API Registry",
 	}
 
-	// Initialize global default logger.
-	logger := &log.Logger{
-		Level:   log.DebugLevel,
-		Handler: text.Default,
-	}
-	log.Log = logger.WithField("uid", fmt.Sprintf("%.8s", uuid.New()))
+	// Bind a logger instance to the local context with metadata for outbound requests.
+	logger := log.NewLogger(log.DebugLevel)
+	ctx = log.NewOutboundContext(log.NewContext(ctx, logger), log.Metadata{
+		UID: fmt.Sprintf("%.8s", uuid.New()),
+	})
 
 	cmd.AddCommand(annotate.Command(ctx))
 	cmd.AddCommand(compute.Command(ctx))

--- a/cmd/registry/cmd/root.go
+++ b/cmd/registry/cmd/root.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"context"
-
 	"fmt"
 
 	"github.com/apex/log"
@@ -37,22 +36,17 @@ import (
 )
 
 func Command(ctx context.Context) *cobra.Command {
-	var logID string
 	var cmd = &cobra.Command{
 		Use:   "registry",
 		Short: "A simple and eclectic utility for working with the API Registry",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			// Initialize global default logger with unique process identifier.
-			if len(logID) == 0 {
-				logID = fmt.Sprintf("[ %.8s ] ", uuid.New())
-			}
-			logger := &log.Logger{
-				Level:   log.DebugLevel,
-				Handler: text.Default,
-			}
-			log.Log = logger.WithField("uid", logID)
-		},
 	}
+
+	// Initialize global default logger.
+	logger := &log.Logger{
+		Level:   log.DebugLevel,
+		Handler: text.Default,
+	}
+	log.Log = logger.WithField("uid", fmt.Sprintf("%.8s", uuid.New()))
 
 	cmd.AddCommand(annotate.Command(ctx))
 	cmd.AddCommand(compute.Command(ctx))
@@ -66,6 +60,5 @@ func Command(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(upload.Command(ctx))
 	cmd.AddCommand(vocabulary.Command(ctx))
 
-	cmd.PersistentFlags().StringVar(&logID, "log-id", "", "Assign an ID which gets attached to the log produced")
 	return cmd
 }

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/nsf/jsondiff"
 	"github.com/spf13/cobra"
@@ -36,12 +36,12 @@ func discoveryCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			projectID, err := cmd.Flags().GetString("project-id")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get project-id from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get project-id from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			// create a queue for upload tasks and wait for the workers to finish after filling it.
@@ -50,7 +50,7 @@ func discoveryCommand(ctx context.Context) *cobra.Command {
 
 			discoveryResponse, err := discovery.FetchList()
 			if err != nil {
-				log.WithError(err).Fatal("Failed to fetch discovery list")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to fetch discovery list")
 			}
 
 			// Create an upload job for each API.
@@ -85,11 +85,11 @@ func (task *uploadDiscoveryTask) String() string {
 }
 
 func (task *uploadDiscoveryTask) Run(ctx context.Context) error {
-	log.Infof("Uploading apis/%s/versions/%s/specs/%s", task.apiID, task.versionID, task.specID)
+	log.Infof(ctx, "Uploading apis/%s/versions/%s/specs/%s", task.apiID, task.versionID, task.specID)
 	// Fetch (and compress) the contents of the discovery doc.
 	// Do this first in case the doc URL is invalid; we ignore these errors.
 	if err := task.fetchDiscoveryDoc(); err != nil {
-		log.WithError(err).Warn("Failed to download discovery doc")
+		log.FromContext(ctx).WithError(err).Warn("Failed to download discovery doc")
 		return nil
 	}
 	// If the API does not exist, create it.
@@ -123,11 +123,11 @@ func (task *uploadDiscoveryTask) createAPI(ctx context.Context) error {
 		},
 	})
 	if err == nil {
-		log.Debugf("Created %s", response.Name)
+		log.Debugf(ctx, "Created %s", response.Name)
 	} else if core.AlreadyExists(err) {
-		log.Debugf("Found %s", task.apiName())
+		log.Debugf(ctx, "Found %s", task.apiName())
 	} else {
-		log.WithError(err).Debugf("Failed to create API %s", task.apiName())
+		log.FromContext(ctx).WithError(err).Debugf("Failed to create API %s", task.apiName())
 		return fmt.Errorf("Failed to create %s, %s", task.apiName(), err)
 	}
 
@@ -147,9 +147,9 @@ func (task *uploadDiscoveryTask) createVersion(ctx context.Context) error {
 		ApiVersion:   &rpc.ApiVersion{},
 	})
 	if err != nil {
-		log.WithError(err).Debugf("Failed to create version %s", task.versionName())
+		log.FromContext(ctx).WithError(err).Debugf("Failed to create version %s", task.versionName())
 	} else {
-		log.Debugf("Created %s", response.Name)
+		log.Debugf(ctx, "Created %s", response.Name)
 	}
 
 	return nil
@@ -173,9 +173,9 @@ func (task *uploadDiscoveryTask) createSpec(ctx context.Context) error {
 		},
 	})
 	if err != nil {
-		log.WithError(err).Debugf("Error %s [contents-length: %d]", task.specName(), len(task.contents))
+		log.FromContext(ctx).WithError(err).Debugf("Error %s [contents-length: %d]", task.specName(), len(task.contents))
 	} else {
-		log.Debugf("Created %s", response.Name)
+		log.Debugf(ctx, "Created %s", response.Name)
 	}
 
 	return nil
@@ -217,9 +217,9 @@ func (task *uploadDiscoveryTask) updateSpec(ctx context.Context) error {
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"contents"}},
 	})
 	if err != nil {
-		log.WithError(err).Debugf("Error %s [contents-length: %d]", task.specName(), len(docZipped))
+		log.FromContext(ctx).WithError(err).Debugf("Error %s [contents-length: %d]", task.specName(), len(docZipped))
 	} else if response.RevisionId != refSpec.RevisionId {
-		log.Debugf("Updated %s", response.Name)
+		log.Debugf(ctx, "Updated %s", response.Name)
 	}
 
 	return nil

--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -60,21 +60,21 @@ func styleGuideCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			styleGuidePath := args[0]
 			if styleGuidePath == "" {
-				log.Fatal("Please provide style guide path")
+				log.Fatal(ctx, "Please provide style guide path")
 			}
 
 			styleGuide, err := readStyleGuideProto(styleGuidePath)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to read style guide")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to read style guide")
 			}
 			styleGuideMarshalled, err := proto.Marshal(styleGuide)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to encode style guide")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to encode style guide")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
 			artifact := &rpc.Artifact{
@@ -87,10 +87,10 @@ func styleGuideCommand(ctx context.Context) *cobra.Command {
 				),
 				Contents: styleGuideMarshalled,
 			}
-			log.Debugf("Uploading %s", artifact.Name)
+			log.Debugf(ctx, "Uploading %s", artifact.Name)
 			err = core.SetArtifact(ctx, client, artifact)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to save artifact")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to save artifact")
 			}
 		},
 	}

--- a/cmd/registry/cmd/vocabulary/difference.go
+++ b/cmd/registry/cmd/vocabulary/difference.go
@@ -17,9 +17,9 @@ package vocabulary
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/google/gnostic/metrics/vocabulary"
 	"github.com/spf13/cobra"
 )
@@ -32,15 +32,15 @@ func differenceCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 			output, err := cmd.Flags().GetString("output")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get output from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
 			}
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			_, inputs := collectInputVocabularies(ctx, client, args, filter)
 			vocab := vocabulary.Difference(inputs)

--- a/cmd/registry/cmd/vocabulary/intersection.go
+++ b/cmd/registry/cmd/vocabulary/intersection.go
@@ -17,9 +17,9 @@ package vocabulary
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/google/gnostic/metrics/vocabulary"
 	"github.com/spf13/cobra"
 )
@@ -32,15 +32,15 @@ func intersectionCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 			output, err := cmd.Flags().GetString("output")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get output from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
 			}
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			_, inputs := collectInputVocabularies(ctx, client, args, filter)
 			vocab := vocabulary.Intersection(inputs)

--- a/cmd/registry/cmd/vocabulary/union.go
+++ b/cmd/registry/cmd/vocabulary/union.go
@@ -17,9 +17,9 @@ package vocabulary
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/google/gnostic/metrics/vocabulary"
 	"github.com/spf13/cobra"
 )
@@ -32,15 +32,15 @@ func unionCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 			output, err := cmd.Flags().GetString("output")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get output from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
 			}
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			_, inputs := collectInputVocabularies(ctx, client, args, filter)
 			vocab := vocabulary.Union(inputs)

--- a/cmd/registry/cmd/vocabulary/unique.go
+++ b/cmd/registry/cmd/vocabulary/unique.go
@@ -19,9 +19,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/google/gnostic/metrics/vocabulary"
 	"github.com/spf13/cobra"
 )
@@ -35,16 +35,16 @@ func uniqueCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 
 			if strings.Contains(outputID, "/") {
-				log.Fatal("output-id must specify an artifact id (final segment only) and not a full name.")
+				log.Fatal(ctx, "output-id must specify an artifact id (final segment only) and not a full name.")
 			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			names, inputs := collectInputVocabularies(ctx, client, args, filter)
 			list := vocabulary.FilterCommon(inputs)

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/google/gnostic/metrics/vocabulary"
 	"github.com/spf13/cobra"
 )
@@ -33,15 +33,15 @@ func versionsCommand(ctx context.Context) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get filter from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
 			output, err := cmd.Flags().GetString("output")
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get output from flags")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get output from flags")
 			}
 			client, err := connection.NewClient(ctx)
 			if err != nil {
-				log.WithError(err).Fatal("Failed to get client")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			names, inputs := collectInputVocabularies(ctx, client, args, filter)
 

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
@@ -56,17 +56,17 @@ func collectInputVocabularies(ctx context.Context, client connection.Client, arg
 					vocab := &metrics.Vocabulary{}
 					err := proto.Unmarshal(artifact.GetContents(), vocab)
 					if err != nil {
-						log.WithError(err).Debug("Failed to unmarshal contents")
+						log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal contents")
 					} else {
 						inputNames = append(inputNames, artifact.Name)
 						inputs = append(inputs, vocab)
 					}
 				} else {
-					log.Debugf("Skipping, not a vocabulary: %s", artifact.Name)
+					log.Debugf(ctx, "Skipping, not a vocabulary: %s", artifact.Name)
 				}
 			})
 			if err != nil {
-				log.WithError(err).Fatal("Failed to list artifacts")
+				log.FromContext(ctx).WithError(err).Fatal("Failed to list artifacts")
 			}
 		}
 	}
@@ -81,9 +81,9 @@ func setVocabularyToArtifact(ctx context.Context, client connection.Client, outp
 	var err error
 	messageData, err = core.GZippedBytes(messageData)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to compress artifact")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to compress artifact")
 	}
-	log.Debugf("Saving vocabulary data (%d bytes)", len(messageData))
+	log.Debugf(ctx, "Saving vocabulary data (%d bytes)", len(messageData))
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
 		MimeType: core.MimeTypeForMessageType("gnostic.metrics.Vocabulary+gzip"),
@@ -91,7 +91,7 @@ func setVocabularyToArtifact(ctx context.Context, client connection.Client, outp
 	}
 	err = core.SetArtifact(ctx, client, artifact)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to save artifact")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to save artifact")
 	}
 }
 
@@ -107,6 +107,6 @@ func setVersionHistoryToArtifact(ctx context.Context, client connection.Client, 
 	}
 	err := core.SetArtifact(ctx, client, artifact)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to save artifact")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to save artifact")
 	}
 }

--- a/cmd/registry/controller/controller.go
+++ b/cmd/registry/controller/controller.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 )
 
@@ -38,17 +38,17 @@ func ProcessManifest(
 
 	var actions []*Action
 	for _, resource := range manifest.GeneratedResources {
-		log.Debugf("Processing entry: %v", resource)
+		log.Debugf(ctx, "Processing entry: %v", resource)
 
 		err := ValidateResourceEntry(resource)
 		if err != nil {
-			log.WithError(err).Debugf("Skipping resource: %q invalid resource pattern", resource)
+			log.FromContext(ctx).WithError(err).Debugf("Skipping resource: %q invalid resource pattern", resource)
 			continue
 		}
 
 		newActions, err := processManifestResource(ctx, client, projectID, resource)
 		if err != nil {
-			log.WithError(err).Debugf("Skipping resource: %q", resource)
+			log.FromContext(ctx).WithError(err).Debugf("Skipping resource: %q", resource)
 			continue
 		}
 		actions = append(actions, newActions...)
@@ -227,7 +227,7 @@ func generateActions(
 				resourceName, err := resourceNameFromGroupKey(
 					resourcePattern, groupKey)
 				if err != nil {
-					log.Debugf("skipping entry for %q, cannot derive target resource name for pattern: %q", groupKey, resourcePattern)
+					log.Debugf(ctx, "skipping entry for %q, cannot derive target resource name for pattern: %q", groupKey, resourcePattern)
 					continue
 				}
 				cmd, err := generateCommand(generatedResource.Action, resourceName)

--- a/cmd/registry/controller/local-tasks.go
+++ b/cmd/registry/controller/local-tasks.go
@@ -64,7 +64,7 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 
 	// first party registry commands
 	if strings.HasPrefix(task.Action.Command, "registry") {
-		fullCmd := append(strings.Fields(task.Action.Command), fmt.Sprintf("--log-id=%s", task.TaskID))
+		fullCmd := strings.Fields(task.Action.Command)
 
 		cmd := exec.Command(fullCmd[0], fullCmd[1:]...)
 		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
@@ -76,9 +76,7 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 	} else { //third party commands
 		fullCmd := strings.Fields(task.Action.Command)
 		cmdLogger := &logWriter{
-			logger: log.WithFields(log.Fields{
-				"uid": task.TaskID,
-			}),
+			logger: logger,
 		}
 
 		cmd := exec.Command(fullCmd[0], fullCmd[1:]...)

--- a/cmd/registry/controller/local-tasks.go
+++ b/cmd/registry/controller/local-tasks.go
@@ -22,16 +22,16 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/protobuf/proto"
 )
 
 // Implement io.Writer interface https://pkg.go.dev/io#Writer
 type logWriter struct {
-	logger *log.Entry
+	logger log.Logger
 }
 
 func (w logWriter) Write(p []byte) (n int, err error) {
@@ -52,7 +52,7 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 	// The monitoring metrics/dashboards are built on top of the format of the log messages here.
 	// Check the metric filters before making any changes to the format.
 	// Location: registry/deployments/controller/dashboard/*
-	logger := log.WithFields(log.Fields{
+	logger := log.FromContext(ctx).WithFields(map[string]interface{}{
 		"action": fmt.Sprintf("{%s}", task.Action.Command),
 		"taskID": fmt.Sprintf("{%s}", task.TaskID),
 	})
@@ -103,7 +103,7 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 func touchArtifact(ctx context.Context, artifactName, action string) error {
 	client, err := connection.NewClient(ctx)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to get client")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 	}
 
 	messageData, _ := proto.Marshal(&rpc.Receipt{Action: action})

--- a/cmd/registry/core/details-proto.go
+++ b/cmd/registry/core/details-proto.go
@@ -15,13 +15,14 @@
 package core
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/apex/log"
+	"github.com/apigee/registry/log"
 	"github.com/yoheimuta/go-protoparser/v4/parser"
 
 	protoparser "github.com/yoheimuta/go-protoparser/v4"
@@ -35,7 +36,7 @@ type Details struct {
 }
 
 // NewDetailsFromZippedProtos returns a Details structure describing a spec.
-func NewDetailsFromZippedProtos(b []byte) (*Details, error) {
+func NewDetailsFromZippedProtos(ctx context.Context, b []byte) (*Details, error) {
 	// create a tmp directory
 	dname, err := ioutil.TempDir("", "registry-protos-")
 	if err != nil {
@@ -64,7 +65,7 @@ func NewDetailsFromZippedProtos(b []byte) (*Details, error) {
 			return nil
 		})
 	if err != nil {
-		log.WithError(err).Debug("Failed to walk directory")
+		log.FromContext(ctx).WithError(err).Debug("Failed to walk directory")
 	}
 	if len(details) == 1 {
 		return details[0], nil

--- a/cmd/registry/core/projects.go
+++ b/cmd/registry/core/projects.go
@@ -17,8 +17,8 @@ package core
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 )
 
@@ -31,9 +31,9 @@ func EnsureProjectExists(ctx context.Context, client *gapic.AdminClient, project
 		}
 
 		if _, err := client.CreateProject(ctx, req); err != nil {
-			log.WithError(err).Fatal("Failed to create project")
+			log.FromContext(ctx).WithError(err).Fatal("Failed to create project")
 		}
 	} else if err != nil {
-		log.WithError(err).Fatal("GetProject returned error during project existence check")
+		log.FromContext(ctx).WithError(err).Fatal("GetProject returned error during project existence check")
 	}
 }

--- a/cmd/registry/core/specs.go
+++ b/cmd/registry/core/specs.go
@@ -19,8 +19,8 @@ import (
 	"compress/gzip"
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/protobuf/proto"
 )
@@ -50,10 +50,10 @@ func UploadBytesForSpec(ctx context.Context, client connection.Client, parent, s
 	var buf bytes.Buffer
 	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	if _, err := zw.Write(messageData); err != nil {
-		log.WithError(err).Fatal("Failed to gzip spec contents")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to gzip spec contents")
 	}
 	if err := zw.Close(); err != nil {
-		log.WithError(err).Fatal("Failed to finish gzipping spec contents")
+		log.FromContext(ctx).WithError(err).Fatal("Failed to finish gzipping spec contents")
 	}
 
 	request := &rpc.UpdateApiSpecRequest{

--- a/cmd/registry/core/tasks.go
+++ b/cmd/registry/core/tasks.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/apex/log"
+	"github.com/apigee/registry/log"
 )
 
 // Task is a generic interface for a runnable operation
@@ -58,7 +58,7 @@ func worker(ctx context.Context, wg *sync.WaitGroup, taskQueue <-chan Task) {
 			return
 		default:
 			if err := task.Run(ctx); err != nil {
-				log.WithError(err).Fatalf("Task failed: %s", task)
+				log.FromContext(ctx).WithError(err).Fatalf("Task failed: %s", task)
 			}
 		}
 	}

--- a/cmd/registry/core/zip.go
+++ b/cmd/registry/core/zip.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/apex/log"
 )
 
 // UnzipArchiveToPath will decompress a zip archive, writing all files and folders
@@ -86,7 +84,6 @@ func ZipArchiveOfPath(path, prefix string) (buf bytes.Buffer, err error) {
 			return nil
 		}
 		if err = addFileToZip(zipWriter, p, prefix); err != nil {
-			log.WithError(err).Debugf("Failed to add file to zip")
 			return err
 		}
 		return nil

--- a/cmd/registry/googleauth/client.go
+++ b/cmd/registry/googleauth/client.go
@@ -42,7 +42,8 @@ func GetAuthenticatedClient(ctx context.Context) (*http.Client, error) {
 	}
 	// Create configuration for specified scopes.
 	// If you modify these scopes, delete your previously saved token.
-	config, err := google.ConfigFromJSON(b, "https://www.googleapis.com/auth/spreadsheets")
+	config, err := google.ConfigFromJSON(b,
+		"https://www.googleapis.com/auth/spreadsheets")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/plugins/registry-lint-api-linter/main.go
+++ b/cmd/registry/plugins/registry-lint-api-linter/main.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/apex/log"
 	lint "github.com/apigee/registry/cmd/registry/plugins/linter"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 )
 
@@ -101,8 +101,11 @@ func (*concreteApiLinterLintCommandExecuter) Execute(specPath string) ([]*rpc.Li
 		return parseLinterOutput(data)
 	}
 
+	// TODO: Replace this new instance with a logger inherited from the context.
+	logger := log.NewLogger()
+
 	// Unpack api-common-protos and try again if failure occurred
-	log.Info("API-linter failed due to an import error, unpacking API common protos and retrying.")
+	logger.Info("API-linter failed due to an import error, unpacking API common protos and retrying.")
 	if err = unpackApiCommonProtos(specDirectory); err == nil {
 		data, err = createAndRunApiLinterCommand(specDirectory, specName)
 		if err == nil {
@@ -110,7 +113,7 @@ func (*concreteApiLinterLintCommandExecuter) Execute(specPath string) ([]*rpc.Li
 		}
 	}
 
-	log.Info("API-linter failed due to an import error, unpacking GoogleAPIs and retrying.")
+	logger.Info("API-linter failed due to an import error, unpacking GoogleAPIs and retrying.")
 	if err = unpackGoogleApisProtos(specDirectory); err == nil {
 		data, err = createAndRunApiLinterCommand(specDirectory, specName)
 		if err == nil {

--- a/log/README.md
+++ b/log/README.md
@@ -1,0 +1,3 @@
+# log
+
+This package provides logging for the Registry project. See https://pkg.go.dev/github.com/apigee/registry/log for package documentation and examples.

--- a/log/apex.go
+++ b/log/apex.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	apex "github.com/apex/log"
+)
+
+func newApexLogger(opts ...Option) apexAdapter {
+	adapter := apexAdapter{
+		entry: &apex.Entry{
+			Logger: new(apex.Logger),
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&adapter)
+	}
+
+	return adapter
+}
+
+type apexAdapter struct {
+	entry *apex.Entry
+}
+
+func (l apexAdapter) Fatal(msg string) {
+	l.entry.Fatal(msg)
+}
+
+func (l apexAdapter) Fatalf(msg string, v ...interface{}) {
+	l.entry.Fatalf(msg, v...)
+}
+
+func (l apexAdapter) Error(msg string) {
+	l.entry.Error(msg)
+}
+
+func (l apexAdapter) Errorf(msg string, v ...interface{}) {
+	l.entry.Errorf(msg, v...)
+}
+
+func (l apexAdapter) Warn(msg string) {
+	l.entry.Warn(msg)
+}
+
+func (l apexAdapter) Warnf(msg string, v ...interface{}) {
+	l.entry.Warnf(msg, v...)
+}
+
+func (l apexAdapter) Info(msg string) {
+	l.entry.Info(msg)
+}
+
+func (l apexAdapter) Infof(msg string, v ...interface{}) {
+	l.entry.Infof(msg, v...)
+}
+
+func (l apexAdapter) Debug(msg string) {
+	l.entry.Debug(msg)
+}
+
+func (l apexAdapter) Debugf(msg string, v ...interface{}) {
+	l.entry.Debugf(msg, v...)
+}
+
+func (l apexAdapter) WithError(err error) Logger {
+	return apexAdapter{
+		entry: l.entry.WithError(err),
+	}
+}
+
+func (l apexAdapter) WithField(k string, v interface{}) Logger {
+	return apexAdapter{
+		entry: l.entry.WithField(k, v),
+	}
+}
+
+func (l apexAdapter) WithFields(fields map[string]interface{}) Logger {
+	return apexAdapter{
+		entry: l.entry.WithFields(apex.Fields(fields)),
+	}
+}

--- a/log/context.go
+++ b/log/context.go
@@ -1,0 +1,87 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// Metadata provides fields for multi-process log organization.
+type Metadata struct {
+	// UID is a unique identifier for logs. It can be used to group sets of related logs.
+	UID string
+}
+
+// Identifiers for logging fields stored in gRPC metadata.
+const (
+	uidKey = "logging_uid"
+)
+
+// NewOutboundContext returns a new context with the provided metadata attached.
+// This can be used to preserve the provided fields across gRPC calls.
+func NewOutboundContext(ctx context.Context, md Metadata) context.Context {
+	if outbound, ok := metadata.FromOutgoingContext(ctx); ok {
+		outbound.Set(uidKey, md.UID)
+		return metadata.NewOutgoingContext(ctx, outbound)
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, uidKey, md.UID)
+}
+
+// loggerKey is an unexported type used to attach loggers as context values.
+type loggerKey struct{}
+
+// NewContext returns a new context that can be used to retrieve the provided logger.
+// This can be used to share a logger instance as the context passes through a single process.
+func NewContext(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+// FromContext returns a logger from the provided context.
+// Options will be applied to a default configuration if the context doesn't have an associated logger.
+func FromContext(ctx context.Context, opts ...Option) Logger {
+	logger, ok := ctx.Value(loggerKey{}).(Logger)
+	if !ok {
+		logger = NewLogger(opts...)
+	}
+
+	// Include metadata that was added locally to the context but hasn't been sent yet.
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		return withMetadataFields(logger, md)
+	}
+
+	return logger
+}
+
+// WithInboundFields returns a new logger including fields from the incoming context's metadata.
+func WithInboundFields(ctx context.Context, logger Logger) Logger {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		return withMetadataFields(logger, md)
+	}
+
+	return logger
+}
+
+func withMetadataFields(l Logger, md metadata.MD) Logger {
+	fields := make(map[string]interface{}, 1)
+	if vals, ok := md[uidKey]; ok {
+		// When we add metadata to the context we ensure it only has one value.
+		fields["uid"] = vals[0]
+	}
+
+	return l.WithFields(fields)
+}

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/apigee/registry/log"
+	"google.golang.org/grpc/metadata"
+)
+
+func ExampleNewOutboundContext() {
+	ctx := log.NewOutboundContext(context.Background(), log.Metadata{
+		UID: "test_uid",
+	})
+
+	var (
+		// Buffer to hold logs.
+		buf bytes.Buffer
+		// Logger that writes JSON entries to a buffer.
+		logger = log.NewLogger(log.JSONFormat(&buf))
+		// Struct to hold the parsed log entry.
+		entry struct {
+			Fields map[string]interface{} `json:"fields"`
+		}
+	)
+
+	// "Call" a server that prints a log message.
+	grpcFakeCall(ctx, func(ctx context.Context) {
+		log.WithInboundFields(ctx, logger).Info("Print a server log with the unique ID")
+		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+			panic(err)
+		}
+
+		// Output: Unique ID = test_uid
+		fmt.Printf("Unique ID = %v", entry.Fields["uid"])
+	})
+}
+
+// Converts outgoing gRPC metadata (if present) to incoming metadata before calling the handler.
+func grpcFakeCall(ctx context.Context, handler func(context.Context)) {
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		ctx = metadata.NewIncomingContext(ctx, md) // Set incoming context with caller's outgoing metadata.
+	}
+
+	ctx = metadata.NewOutgoingContext(ctx, metadata.MD{}) // Clear outgoing context.
+	handler(ctx)
+}

--- a/log/interceptor/interceptor.go
+++ b/log/interceptor/interceptor.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/apigee/registry/log"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type (
+	resourceOperation   interface{ GetName() string }
+	collectionOperation interface{ GetParent() string }
+)
+
+// CallLogger returns a gRPC server interceptor for logging API operations.
+func CallLogger(opts ...log.Option) grpc.UnaryServerInterceptor {
+	// Create a logger scoped to this interceptor, configured with the provided options.
+	// Each request will share this logger as a base template.
+	sharedLogger := log.NewLogger(opts...)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		reqInfo := map[string]interface{}{
+			"request_id": fmt.Sprintf("%.8s", uuid.New()),
+			"method":     filepath.Base(info.FullMethod),
+		}
+
+		if r, ok := req.(resourceOperation); ok {
+			reqInfo["resource"] = r.GetName()
+		}
+
+		if r, ok := req.(collectionOperation); ok {
+			reqInfo["collection"] = r.GetParent()
+		}
+
+		// Bind request-scoped and inbound attributes to the context logger before handling the request.
+		logger := log.WithInboundFields(ctx, sharedLogger).WithFields(reqInfo)
+		ctx = log.NewContext(ctx, logger)
+
+		logger.Info("Handling request.")
+		start := time.Now()
+		resp, err := handler(ctx, req)
+
+		respInfo := map[string]interface{}{
+			"duration":    time.Since(start),
+			"status_code": status.Code(err),
+		}
+
+		if r, ok := resp.(resourceOperation); err == nil && ok {
+			respInfo["resource"] = r.GetName()
+		}
+
+		// Bind response details before logging a response.
+		logger = logger.WithFields(respInfo)
+
+		// Error messages may include a status code, but we want to log messages and codes separately.
+		if err != nil {
+			st, _ := status.FromError(err)
+			unwrapped := errors.New(st.Message())
+			logger = logger.WithError(unwrapped)
+		}
+
+		switch status.Code(err) {
+		case codes.OK:
+			logger.Info("Success.")
+		case codes.Internal:
+			logger.Error("Internal error.")
+		case codes.Unknown:
+			logger.Error("Unknown error.")
+		default:
+			logger.Info("User error.")
+		}
+
+		return resp, err
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"os"
+)
+
+// Logger describes the interface of a structured logger.
+type Logger interface {
+	Fatal(string)
+	Fatalf(string, ...interface{})
+
+	Error(string)
+	Errorf(string, ...interface{})
+
+	Warn(string)
+	Warnf(string, ...interface{})
+
+	Info(string)
+	Infof(string, ...interface{})
+
+	Debug(string)
+	Debugf(string, ...interface{})
+
+	WithError(error) Logger
+	WithField(string, interface{}) Logger
+	WithFields(map[string]interface{}) Logger
+}
+
+var defaultOptions = []Option{
+	TextFormat(os.Stderr),
+	InfoLevel,
+}
+
+// NewLogger returns a logger configured with the provided options.
+func NewLogger(opts ...Option) Logger {
+	opts = append(defaultOptions, opts...) // Override defaults with user options.
+	return newApexLogger(opts...)
+}
+
+func Fatal(ctx context.Context, msg string) {
+	FromContext(ctx).Fatal(msg)
+}
+
+func Fatalf(ctx context.Context, msg string, v ...interface{}) {
+	FromContext(ctx).Fatalf(msg, v...)
+}
+
+func Error(ctx context.Context, msg string) {
+	FromContext(ctx).Error(msg)
+}
+
+func Errorf(ctx context.Context, msg string, v ...interface{}) {
+	FromContext(ctx).Errorf(msg, v...)
+}
+
+func Warn(ctx context.Context, msg string) {
+	FromContext(ctx).Warn(msg)
+}
+
+func Warnf(ctx context.Context, msg string, v ...interface{}) {
+	FromContext(ctx).Warnf(msg, v...)
+}
+
+func Info(ctx context.Context, msg string) {
+	FromContext(ctx).Info(msg)
+}
+
+func Infof(ctx context.Context, msg string, v ...interface{}) {
+	FromContext(ctx).Infof(msg, v...)
+}
+
+func Debug(ctx context.Context, msg string) {
+	FromContext(ctx).Debug(msg)
+}
+
+func Debugf(ctx context.Context, msg string, v ...interface{}) {
+	FromContext(ctx).Debugf(msg, v...)
+}

--- a/log/option.go
+++ b/log/option.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+
+	apex "github.com/apex/log"
+	"github.com/apex/log/handlers/json"
+	"github.com/apex/log/handlers/text"
+)
+
+// Options configure the logger.
+type Option func(*apexAdapter)
+
+// Configures the logger to print logs with a minimum severity level.
+var (
+	DebugLevel Option = func(l *apexAdapter) {
+		l.entry.Logger.Level = apex.DebugLevel
+	}
+
+	InfoLevel Option = func(l *apexAdapter) {
+		l.entry.Logger.Level = apex.InfoLevel
+	}
+
+	WarnLevel Option = func(l *apexAdapter) {
+		l.entry.Logger.Level = apex.WarnLevel
+	}
+
+	ErrorLevel Option = func(l *apexAdapter) {
+		l.entry.Logger.Level = apex.ErrorLevel
+	}
+
+	FatalLevel Option = func(l *apexAdapter) {
+		l.entry.Logger.Level = apex.FatalLevel
+	}
+)
+
+// JSONFormat configures the logger to print logs as JSON.
+func JSONFormat(w io.Writer) Option {
+	return func(l *apexAdapter) {
+		l.entry.Logger.Handler = json.New(w)
+	}
+}
+
+// TextFormat configures the logger to print logs as human-friendly text.
+func TextFormat(w io.Writer) Option {
+	return func(l *apexAdapter) {
+		l.entry.Logger.Handler = text.New(w)
+	}
+}

--- a/server/registry/internal/storage/gorm/logger.go
+++ b/server/registry/internal/storage/gorm/logger.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/apex/log"
+	"github.com/apigee/registry/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
 type gormLogger struct {
-	Logger        log.Interface
+	Logger        log.Logger
 	SlowThreshold time.Duration
 }
 
@@ -53,16 +53,16 @@ func (l gormLogger) Error(context.Context, string, ...interface{}) {
 
 func (l gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
 	sql, _ := fc()
-	entry := l.Logger.WithFields(log.Fields{
+	logger := l.Logger.WithFields(map[string]interface{}{
 		"query":    sql,
 		"duration": time.Since(begin),
 	})
 
 	if err != nil && err != gorm.ErrRecordNotFound {
-		entry.WithError(err).Error("Failed database operation.")
+		logger.WithError(err).Error("Failed database operation.")
 	} else if time.Since(begin) > l.SlowThreshold {
-		entry.Warn("Slow database operation.")
+		logger.Warn("Slow database operation.")
 	} else {
-		entry.Debug("Database operation.")
+		logger.Debug("Database operation.")
 	}
 }

--- a/server/registry/notifications.go
+++ b/server/registry/notifications.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,11 +29,11 @@ import (
 const TopicName = "registry-events"
 
 func (s *RegistryServer) notify(ctx context.Context, change rpc.Notification_Change, resource string) {
-	logger := s.logger(ctx)
 	if !s.notifyEnabled {
 		return
 	}
 
+	logger := log.FromContext(ctx)
 	if s.projectID == "" {
 		logger.Warn("Notifications are enabled but project ID is not set. Skipping notification.")
 		return

--- a/server/registry/server.go
+++ b/server/registry/server.go
@@ -16,19 +16,11 @@ package registry
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"path/filepath"
-	"time"
 
 	"github.com/apex/log"
-	"github.com/apex/log/handlers/json"
-	"github.com/apex/log/handlers/text"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/internal/storage"
-	"github.com/google/uuid"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -80,90 +72,6 @@ func (s *RegistryServer) getStorageClient(ctx context.Context) (*storage.Client,
 
 func (s *RegistryServer) logger(ctx context.Context) log.Interface {
 	return log.FromContext(ctx)
-}
-
-func (s *RegistryServer) LoggingInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	logger := new(log.Logger)
-	switch s.loggingLevel {
-	case "debug":
-		logger.Level = log.DebugLevel
-	case "info":
-		logger.Level = log.InfoLevel
-	case "warn":
-		logger.Level = log.WarnLevel
-	case "error":
-		logger.Level = log.ErrorLevel
-	case "fatal":
-		logger.Level = log.FatalLevel
-	default:
-		logger.Level = log.InfoLevel
-	}
-
-	switch s.loggingFormat {
-	case "json":
-		logger.Handler = json.Default
-	case "text":
-		logger.Handler = text.Default
-	default:
-		logger.Handler = text.Default
-	}
-
-	reqInfo := log.Fields{
-		"request_id": fmt.Sprintf("%.8s", uuid.New()),
-		"method":     filepath.Base(info.FullMethod),
-	}
-
-	type (
-		resourceOp   interface{ GetName() string }
-		collectionOp interface{ GetParent() string }
-	)
-
-	switch r := req.(type) {
-	case resourceOp:
-		reqInfo["resource"] = r.GetName()
-	case collectionOp:
-		reqInfo["collection"] = r.GetParent()
-	}
-
-	// Bind request-scoped attributes to the context logger before handling the request.
-	reqLogger := logger.WithFields(reqInfo)
-	ctx = log.NewContext(ctx, reqLogger)
-
-	reqLogger.Info("Handling request.")
-	start := time.Now()
-	resp, err := handler(ctx, req)
-
-	respInfo := log.Fields{
-		"duration":    time.Since(start),
-		"status_code": status.Code(err),
-	}
-
-	if r, ok := resp.(resourceOp); err == nil && ok {
-		respInfo["resource"] = r.GetName()
-	}
-
-	// Bind response details before logging a response.
-	respLogger := reqLogger.WithFields(respInfo)
-
-	// Error messages may include a status code, but we want to log messages and codes separately.
-	if err != nil {
-		st, _ := status.FromError(err)
-		unwrapped := errors.New(st.Message())
-		respLogger = respLogger.WithError(unwrapped)
-	}
-
-	switch status.Code(err) {
-	case codes.OK:
-		respLogger.Info("Success.")
-	case codes.Internal:
-		respLogger.Error("Internal error.")
-	case codes.Unknown:
-		respLogger.Error("Unknown error.")
-	default:
-		respLogger.Info("User error.")
-	}
-
-	return resp, err
 }
 
 func isNotFound(err error) bool {

--- a/server/registry/server.go
+++ b/server/registry/server.go
@@ -17,7 +17,6 @@ package registry
 import (
 	"context"
 
-	"github.com/apex/log"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/internal/storage"
 
@@ -40,8 +39,6 @@ type RegistryServer struct {
 	database      string
 	dbConfig      string
 	notifyEnabled bool
-	loggingLevel  string
-	loggingFormat string
 	projectID     string
 
 	rpc.UnimplementedRegistryServer
@@ -52,8 +49,6 @@ func New(config Config) *RegistryServer {
 	s := &RegistryServer{
 		database:      config.Database,
 		dbConfig:      config.DBConfig,
-		loggingLevel:  config.LogLevel,
-		loggingFormat: config.LogFormat,
 		notifyEnabled: config.Notify,
 		projectID:     config.ProjectID,
 	}
@@ -68,10 +63,6 @@ func New(config Config) *RegistryServer {
 
 func (s *RegistryServer) getStorageClient(ctx context.Context) (*storage.Client, error) {
 	return storage.NewClient(ctx, s.database, s.dbConfig)
-}
-
-func (s *RegistryServer) logger(ctx context.Context) log.Interface {
-	return log.FromContext(ctx)
 }
 
 func isNotFound(err error) bool {


### PR DESCRIPTION
Registry tool commands have a unique ID attached to their logs. This change allows that ID (and potentially other information) to be passed to the server. For example, here's a command that makes an API call.

```
$ registry get projects/p
  DEBUG[0000] Failed to get resource    error=rpc error: code = NotFound desc = project "projects/p" not found in database uid=5434deea
```

The server logs associated with this command can be found by searching for the matching `uid`.

```
  INFO[0004] Handling request.         method=GetProject request_id=cdf11306 resource=projects/p uid=5434deea
  DEBUG[0004] Database operation.       duration=120.276µs method=GetProject query=SELECT * FROM `projects` WHERE key = "projects/p" ORDER BY `projects`.`key` LIMIT 1 request_id=cdf11306 resource=projects/p uid=5434deea
  INFO[0004] User error.               duration=4.387131ms error=project "projects/p" not found in database method=GetProject request_id=cdf11306 resource=projects/p status_code=NotFound uid=5434deea
```

Fixes #317.