### PR TITLE
Implement a sample linter for OpenAPI that enforces rules on descriptions

### DIFF
--- a/cmd/registry/plugins/registry-lint-api-linter/main.go
+++ b/cmd/registry/plugins/registry-lint-api-linter/main.go
@@ -51,7 +51,7 @@ func (linter *apiLinterRunner) RunImpl(
 	lintFiles := make([]*rpc.LintFile, 0)
 
 	// Traverse the files in the directory
-	err := filepath.Walk(req.GetSpecPath(), func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(req.GetSpecDirectory(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/plugins/registry-lint-api-linter/main.go
+++ b/cmd/registry/plugins/registry-lint-api-linter/main.go
@@ -51,7 +51,7 @@ func (linter *apiLinterRunner) RunImpl(
 	lintFiles := make([]*rpc.LintFile, 0)
 
 	// Traverse the files in the directory
-	err := filepath.Walk(req.GetSpecDirectory(), func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(req.GetSpecPath(), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/README.md
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/README.md
@@ -1,0 +1,4 @@
+The sample OpenAPI linter in this directory enforces the following rules:
+
+`description-less-than-1000-chars`: Ensures that description fields in the OpenAPI spec are less than 1000 characters.
+`description-contains-no-tags`: Ensures that description fields in the OpenAPI spec contain no tags (such as HTML tags).

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main.go
@@ -151,7 +151,7 @@ func getDescriptionsFromSpecHelper(node *yaml.Node, results *[]*DescriptionField
 func enforceDescriptionLessThan1000Chars(descriptions *[]*DescriptionField) []*rpc.LintProblem {
 	problems := make([]*rpc.LintProblem, 0)
 	for _, description := range *descriptions {
-		if len(description.Description) >= 100 {
+		if len(description.Description) >= 1000 {
 			problems = append(problems, &rpc.LintProblem{
 				Message: fmt.Sprintf(
 					"Description field should be less than 1000 chars, currently it is\n %s\n",

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main.go
@@ -1,0 +1,224 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/apex/log"
+	lint "github.com/apigee/registry/cmd/registry/plugins/linter"
+	"github.com/apigee/registry/rpc"
+	"gopkg.in/yaml.v3"
+)
+
+// spectralLintCommandExecuter is an interface through which the Spectral command executes.
+type spectralLintCommandExecuter interface {
+	// Runs the spectral linter with a provided spec and configuration path
+	Execute(specPath string, ruleIds []string) ([]*rpc.LintProblem, error)
+}
+
+type DescriptionField struct {
+	LineNumber   int
+	ColumnNumber int
+	Description  string
+}
+
+// sampleOpenApiLinterRunner implements the LinterRunner interface for the Spectral linter.
+type sampleOpenApiLinterRunner struct{}
+
+// concreteSampleOpenApiLintCommandExecuter implements the spectralLintCommandExecuter interface
+// for the Spectral linter.
+type concreteSampleOpenApiLintCommandExecuter struct{}
+
+const descriptionLessThan1000CharsRuleId = "description-less-than-1000-chars"
+const descriptionContainsNoTagsRuleId = "description-contains-no-tags"
+
+func (linter *sampleOpenApiLinterRunner) Run(req *rpc.LinterRequest) (*rpc.LinterResponse, error) {
+	log.Info("Running")
+	return linter.RunImpl(req, &concreteSampleOpenApiLintCommandExecuter{})
+}
+
+func (linter *sampleOpenApiLinterRunner) RunImpl(
+	req *rpc.LinterRequest,
+	executer spectralLintCommandExecuter,
+) (*rpc.LinterResponse, error) {
+	lintFiles := make([]*rpc.LintFile, 0)
+
+	// Traverse the files in the directory
+	err := filepath.Walk(req.GetSpecDirectory(), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Async API and Open API specs are YAML files
+		if !strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") {
+			return nil
+		}
+
+		// Execute the spectral linter.
+		problems, err := executer.Execute(path, req.GetRuleIds())
+		if err != nil {
+			return err
+		}
+
+		// Formulate the response.
+		lintFiles = append(lintFiles, &rpc.LintFile{
+			FilePath: path,
+			Problems: problems,
+		})
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &rpc.LinterResponse{
+		Lint: &rpc.Lint{
+			Name:  "registry-lint-spectral",
+			Files: lintFiles,
+		},
+	}, nil
+}
+
+func (*concreteSampleOpenApiLintCommandExecuter) Execute(specPath string, ruleIds []string) ([]*rpc.LintProblem, error) {
+	// Create a temporary destination directory to store the output.
+	root, err := ioutil.TempDir("", "spectral-output-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(root)
+
+	log.Info(specPath)
+	specFile, err := ioutil.ReadFile(specPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsedNode yaml.Node
+	err = yaml.Unmarshal(specFile, &parsedNode)
+	if err != nil {
+		log.Fatalf("Unmarshal node: %v", err)
+	}
+
+	problems := make([]*rpc.LintProblem, 0)
+	for _, ruleId := range ruleIds {
+		lintProblems, err := lintWithRule(&parsedNode, ruleId)
+		if err != nil {
+			log.Errorf("Error while linting %s", err)
+			continue
+		}
+		problems = append(problems, lintProblems...)
+	}
+
+	return problems, nil
+}
+
+func getDescriptionsFromSpec(node *yaml.Node) []*DescriptionField {
+	results := make([]*DescriptionField, 0)
+	getDescriptionsFromSpecHelper(node, &results)
+	return results
+}
+
+func getDescriptionsFromSpecHelper(node *yaml.Node, results *[]*DescriptionField) {
+	var prev *yaml.Node = nil
+	for _, child := range node.Content {
+		if prev != nil && prev.Kind == yaml.ScalarNode && prev.Value == "description" {
+			*results = append(*results, &DescriptionField{
+				LineNumber:   child.Line,
+				ColumnNumber: child.Column,
+				Description:  child.Value,
+			})
+		}
+
+		if child.Kind != yaml.ScalarNode {
+			getDescriptionsFromSpecHelper(child, results)
+		}
+
+		prev = child
+	}
+}
+
+func enforceDescriptionLessThan1000Chars(descriptions *[]*DescriptionField) []*rpc.LintProblem {
+	problems := make([]*rpc.LintProblem, 0)
+	for _, description := range *descriptions {
+		if len(description.Description) >= 100 {
+			problems = append(problems, &rpc.LintProblem{
+				Message: fmt.Sprintf(
+					"Description field should be less than 1000 chars, currently it is\n %s\n",
+					description.Description,
+				),
+				RuleId:     descriptionLessThan1000CharsRuleId,
+				Suggestion: "Ensure that your description field is less than 1000 chars in length.",
+				Location: &rpc.LintLocation{
+					StartPosition: &rpc.LintPosition{
+						LineNumber:   int32(description.LineNumber),
+						ColumnNumber: int32(description.ColumnNumber),
+					},
+				},
+			})
+		}
+	}
+	return problems
+}
+
+func enforceDescriptionContainsNoTagsRuleId(descriptions *[]*DescriptionField) []*rpc.LintProblem {
+	problems := make([]*rpc.LintProblem, 0)
+	for _, description := range *descriptions {
+		r, err := regexp.Compile(".*<[^>]*>.*")
+		if err != nil {
+			continue
+		}
+		if r.MatchString(description.Description) {
+			problems = append(problems, &rpc.LintProblem{
+				Message: fmt.Sprintf(
+					"Description field should not contain any tags, currently it is\n %s\n",
+					description.Description,
+				),
+				RuleId:     descriptionContainsNoTagsRuleId,
+				Suggestion: "Ensure that your description field does not contain any tags (regex <[^>]*>)",
+				Location: &rpc.LintLocation{
+					StartPosition: &rpc.LintPosition{
+						LineNumber:   int32(description.LineNumber),
+						ColumnNumber: int32(description.ColumnNumber),
+					},
+				},
+			})
+		}
+	}
+	return problems
+}
+
+func lintWithRule(node *yaml.Node, ruleId string) ([]*rpc.LintProblem, error) {
+	descriptions := getDescriptionsFromSpec(node)
+
+	if ruleId == descriptionLessThan1000CharsRuleId {
+		return enforceDescriptionLessThan1000Chars(&descriptions), nil
+	} else if ruleId == descriptionContainsNoTagsRuleId {
+		return enforceDescriptionContainsNoTagsRuleId(&descriptions), nil
+	}
+
+	return nil, fmt.Errorf("unsupported rule id %s", ruleId)
+}
+
+func main() {
+	lint.Main(&sampleOpenApiLinterRunner{})
+}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main.go
@@ -28,8 +28,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// spectralLintCommandExecuter is an interface through which the Spectral command executes.
-type spectralLintCommandExecuter interface {
+// sampleOpenApiLintCommandExecuter is an interface through which the Spectral command executes.
+type sampleOpenApiLintCommandExecuter interface {
 	// Runs the spectral linter with a provided spec and configuration path
 	Execute(specPath string, ruleIds []string) ([]*rpc.LintProblem, error)
 }
@@ -43,7 +43,7 @@ type DescriptionField struct {
 // sampleOpenApiLinterRunner implements the LinterRunner interface for the Spectral linter.
 type sampleOpenApiLinterRunner struct{}
 
-// concreteSampleOpenApiLintCommandExecuter implements the spectralLintCommandExecuter interface
+// concreteSampleOpenApiLintCommandExecuter implements the sampleOpenApiLintCommandExecuter interface
 // for the Spectral linter.
 type concreteSampleOpenApiLintCommandExecuter struct{}
 
@@ -57,7 +57,7 @@ func (linter *sampleOpenApiLinterRunner) Run(req *rpc.LinterRequest) (*rpc.Linte
 
 func (linter *sampleOpenApiLinterRunner) RunImpl(
 	req *rpc.LinterRequest,
-	executer spectralLintCommandExecuter,
+	executer sampleOpenApiLintCommandExecuter,
 ) (*rpc.LinterResponse, error) {
 	lintFiles := make([]*rpc.LintFile, 0)
 

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main.go
@@ -28,9 +28,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// sampleOpenApiLintCommandExecuter is an interface through which the Spectral command executes.
+// sampleOpenApiLintCommandExecuter is an interface through which the Sample OpenAPI linter executes.
 type sampleOpenApiLintCommandExecuter interface {
-	// Runs the spectral linter with a provided spec and configuration path
+	// Runs the sample OpenAPI linter with a provided spec and configuration path
 	Execute(specPath string, ruleIds []string) ([]*rpc.LintProblem, error)
 }
 
@@ -40,18 +40,17 @@ type DescriptionField struct {
 	Description  string
 }
 
-// sampleOpenApiLinterRunner implements the LinterRunner interface for the Spectral linter.
+// sampleOpenApiLinterRunner implements the LinterRunner interface for the sample OpenAPI linter.
 type sampleOpenApiLinterRunner struct{}
 
 // concreteSampleOpenApiLintCommandExecuter implements the sampleOpenApiLintCommandExecuter interface
-// for the Spectral linter.
+// for the sample OpenAPI linter.
 type concreteSampleOpenApiLintCommandExecuter struct{}
 
 const descriptionLessThan1000CharsRuleId = "description-less-than-1000-chars"
 const descriptionContainsNoTagsRuleId = "description-contains-no-tags"
 
 func (linter *sampleOpenApiLinterRunner) Run(req *rpc.LinterRequest) (*rpc.LinterResponse, error) {
-	log.Info("Running")
 	return linter.RunImpl(req, &concreteSampleOpenApiLintCommandExecuter{})
 }
 
@@ -72,7 +71,7 @@ func (linter *sampleOpenApiLinterRunner) RunImpl(
 			return nil
 		}
 
-		// Execute the spectral linter.
+		// Execute the linter.
 		problems, err := executer.Execute(path, req.GetRuleIds())
 		if err != nil {
 			return err
@@ -93,21 +92,13 @@ func (linter *sampleOpenApiLinterRunner) RunImpl(
 
 	return &rpc.LinterResponse{
 		Lint: &rpc.Lint{
-			Name:  "registry-lint-spectral",
+			Name:  "registry-lint-openapi-sample",
 			Files: lintFiles,
 		},
 	}, nil
 }
 
 func (*concreteSampleOpenApiLintCommandExecuter) Execute(specPath string, ruleIds []string) ([]*rpc.LintProblem, error) {
-	// Create a temporary destination directory to store the output.
-	root, err := ioutil.TempDir("", "spectral-output-")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(root)
-
-	log.Info(specPath)
 	specFile, err := ioutil.ReadFile(specPath)
 	if err != nil {
 		return nil, err

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
@@ -1,0 +1,140 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockSampleOpenApiExecuter implements the spectral runner interface.
+// It returns mock results according to data provided in tests.
+type mockSampleOpenApiExecuter struct {
+	mock.Mock
+	results []*rpc.LintProblem
+	err     error
+}
+
+func (runner *mockSampleOpenApiExecuter) Execute(
+	spec string,
+	ruleIds []string,
+) ([]*rpc.LintProblem, error) {
+	return runner.results, runner.err
+}
+
+func NewMockSampleOpenAPIExecuter(
+	results []*rpc.LintProblem,
+	err error,
+) sampleOpenApiLintCommandExecuter {
+	return &mockSampleOpenApiExecuter{
+		results: results,
+		err:     err,
+	}
+}
+
+func setupFakeSpec() (path string, err error) {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", err
+	}
+
+	f, err := ioutil.TempFile(tempDir, "*.yaml")
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), err
+}
+
+func TestSpectralPluginLintSpec(t *testing.T) {
+	specDirectory, err := setupFakeSpec()
+	defer os.RemoveAll(specDirectory)
+	assert.Equal(t, err, nil)
+	lintSpecTests := []struct {
+		linter           *sampleOpenApiLinterRunner
+		request          *rpc.LinterRequest
+		executer         sampleOpenApiLintCommandExecuter
+		expectedResponse *rpc.LinterResponse
+		expectedError    error
+	}{
+		{
+			&sampleOpenApiLinterRunner{},
+			&rpc.LinterRequest{
+				SpecDirectory: specDirectory,
+			},
+			NewMockSampleOpenAPIExecuter(
+				[]*rpc.LintProblem{
+					{
+						Message: "test",
+						RuleId:  "test",
+						Location: &rpc.LintLocation{
+							StartPosition: &rpc.LintPosition{
+								LineNumber:   1,
+								ColumnNumber: 1,
+							},
+						},
+					},
+				},
+				nil,
+			),
+			&rpc.LinterResponse{
+				Lint: &rpc.Lint{
+					Name: "registry-lint-openapi-sample",
+					Files: []*rpc.LintFile{
+						{
+							FilePath: specDirectory,
+							Problems: []*rpc.LintProblem{
+								{
+									Message: "test",
+									RuleId:  "test",
+									Location: &rpc.LintLocation{
+										StartPosition: &rpc.LintPosition{
+											LineNumber:   1,
+											ColumnNumber: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			&sampleOpenApiLinterRunner{},
+			&rpc.LinterRequest{
+				SpecDirectory: specDirectory,
+			},
+			NewMockSampleOpenAPIExecuter(
+				[]*rpc.LintProblem{},
+				errors.New("test"),
+			),
+			nil,
+			errors.New("test"),
+		},
+	}
+
+	for _, tt := range lintSpecTests {
+		response, err := tt.linter.RunImpl(tt.request, tt.executer)
+		assert.Equal(t, tt.expectedError, err)
+		assert.EqualValues(t, tt.expectedResponse, response)
+	}
+}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// mockSampleOpenApiExecuter implements the spectral runner interface.
+// mockSampleOpenApiExecuter implements the Sample OpenAPI runner interface.
 // It returns mock results according to data provided in tests.
 type mockSampleOpenApiExecuter struct {
 	mock.Mock
@@ -63,7 +63,7 @@ func setupFakeSpec() (path string, err error) {
 	return f.Name(), err
 }
 
-func TestSpectralPluginLintSpec(t *testing.T) {
+func TestRunImpl(t *testing.T) {
 	specDirectory, err := setupFakeSpec()
 	defer os.RemoveAll(specDirectory)
 	assert.Equal(t, err, nil)

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
@@ -78,6 +78,10 @@ func TestRunDescriptionContainsNoTagsRule(t *testing.T) {
 									LineNumber:   10,
 									ColumnNumber: 30,
 								},
+								EndPosition: &rpc.LintPosition{
+									LineNumber:   11,
+									ColumnNumber: 0,
+								},
 							},
 						},
 					},
@@ -146,6 +150,10 @@ func TestRunDescriptionLessThan1000CharsRule(t *testing.T) {
 								StartPosition: &rpc.LintPosition{
 									LineNumber:   10,
 									ColumnNumber: 30,
+								},
+								EndPosition: &rpc.LintPosition{
+									LineNumber:   11,
+									ColumnNumber: 0,
 								},
 							},
 						},


### PR DESCRIPTION
## Summary
The following pull request creates a sample OpenAPI linter which serves as a proof-of-concept for custom linter creation in the API Registry. It lints two rules:
- `description-less-than-1000-chars`: Ensures that description fields in the OpenAPI spec are less than 1000 characters.
- `description-contains-no-tags`: Ensures that description fields in the OpenAPI spec contain no tags (such as HTML tags).

## Test
- Have registry running on `localhost:8080`.
- Place [the following OpenAPI Sample spec](https://gist.github.com/muhammadharis/13f1681ad65bf6a59366f3068748c0d8) into ~/petstore.yaml 
- Run `LOCAL.sh`
- Ensure that the following style guide is located under `~/styleguide.yaml`:
```yaml
id: openapistyleguide
mime_types:
  - application/x.openapi+gzip;version=2
  - application/x.openapi+gzip;version=3
guidelines:
  - id: Description
    display_name: Govern Description Properties
    description: This guideline governs properties for ref fields on specs.
    rules:
      - id: DescriptionLessThan1000Chars
        description: Description fields should be less than 1000 chars
        linter: openapi-sample
        linter_rulename: description-less-than-1000-chars
        severity: ERROR

      - id: DescriptionContainsNoTags
        description: Description fields should not contain tags
        linter: openapi-sample
        linter_rulename: description-contains-no-tags
        severity: ERROR
    status: ACTIVE
linters:
  - name: openapi-sample
```


Run the following series of commands:

```bash
apg admin delete-project --name projects/example

apg admin create-project --project_id example --insecure --address localhost:8080

apg registry create-api --api_id petstore --parent=projects/example/locations/global

apg registry create-api-version --api_version_id v1 --parent=projects/example/locations/global/apis/petstore

registry upload spec --version=projects/example/locations/global/apis/petstore/versions/v1 --style=openapi ~/petstore.yaml

registry upload styleguide ~/styleguide.yaml --project-id=example

registry compute conformance projects/test/locations/global/apis/petstore/versions/v1/specs/petstore.yaml

registry get projects/example/locations/global/apis/petstore/versions/v1/specs/petstore.yaml/artifacts/conformance-openapistyleguide --contents
```

Ensure that the output matches [the following gist](https://gist.github.com/muhammadharis/7ed03bf240d6b34cbcf97a89f6c2718e).

## Running Unit Tests
`go test -timeout 30s github.com/apigee/registry/cmd/registry/plugins/registry-lint-openapi-sample`