### PR TITLE
Fixing some issues found during a recent data plane deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build:
 ifndef REGISTRY_PROJECT_IDENTIFIER
 	@echo "Error! REGISTRY_PROJECT_IDENTIFIER must be set."; exit 1
 endif
-	gcloud builds submit . --substitutions _REGISTRY_PROJECT_IDENTIFIER="${REGISTRY_PROJECT_IDENTIFIER}"
+	gcloud builds submit .
 
 deploy:
 ifndef REGISTRY_PROJECT_IDENTIFIER

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The entry point for the Registry API server itself is
 The following tools are needed to build this software:
 
 - Go 1.17 (recommended) or later.
-- protoc, the Protocol Buffer Compiler, version 3.10 or later.
+- protoc, the Protocol Buffer Compiler, version 3.18.1.
 - make, git, and other elements of common unix build environments.
 
 This repository contains a Makefile that downloads all other dependencies and

--- a/deployments/envoy/envoy-auth.yaml
+++ b/deployments/envoy/envoy-auth.yaml
@@ -57,7 +57,7 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
                       proto_descriptor: "proto.pb"
-                      services: ["google.cloud.apigeeregistry.v1.Registry"]
+                      services: ["google.cloud.apigeeregistry.v1.Registry", "google.cloud.apigeeregistry.v1.Admin"]
                       print_options:
                         add_whitespace: true
                         always_print_primitive_fields: true

--- a/deployments/envoy/envoy-noauth.yaml
+++ b/deployments/envoy/envoy-noauth.yaml
@@ -49,7 +49,7 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
                       proto_descriptor: "proto.pb"
-                      services: ["google.cloud.apigeeregistry.v1.Registry"]
+                      services: ["google.cloud.apigeeregistry.v1.Registry", "google.cloud.apigeeregistry.v1.Admin"]
                       print_options:
                         add_whitespace: true
                         always_print_primitive_fields: true

--- a/deployments/envoy/envoy.yaml
+++ b/deployments/envoy/envoy.yaml
@@ -49,7 +49,7 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
                       proto_descriptor: "proto.pb"
-                      services: ["google.cloud.apigeeregistry.v1.Registry"]
+                      services: ["google.cloud.apigeeregistry.v1.Registry", "google.cloud.apigeeregistry.v1.Admin"]
                       print_options:
                         add_whitespace: true
                         always_print_primitive_fields: true

--- a/tests/demo/walkthrough.sh
+++ b/tests/demo/walkthrough.sh
@@ -35,7 +35,7 @@ apg admin create-project --project_id demo --json
 echo
 echo Add a API to the registry.
 apg registry create-api \
-    --parent projects/demo \
+    --parent projects/demo/locations/global \
     --api_id petstore \
     --api.availability GENERAL \
     --api.recommended_version "1.0.0" \
@@ -44,7 +44,7 @@ apg registry create-api \
 echo
 echo Add a version of the API to the registry.
 apg registry create-api-version \
-    --parent projects/demo/apis/petstore \
+    --parent projects/demo/locations/global/apis/petstore \
     --api_version_id 1.0.0 \
     --api_version.state "PRODUCTION" \
     --json
@@ -52,7 +52,7 @@ apg registry create-api-version \
 echo
 echo Add a spec for the API version that we just added to the registry.
 apg registry create-api-spec \
-    --parent projects/demo/apis/petstore/versions/1.0.0 \
+    --parent projects/demo/locations/global/apis/petstore/versions/1.0.0 \
     --api_spec_id openapi.yaml \
     --api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r0` \
     --json
@@ -60,13 +60,13 @@ apg registry create-api-spec \
 echo
 echo Get the API spec.
 apg registry get-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json
 
 echo
 echo Get the contents of the API spec.
 apg registry get-api-spec-contents \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.data' -r | \
     registry-decode-spec
@@ -74,76 +74,76 @@ apg registry get-api-spec-contents \
 echo
 echo Update an attribute of the spec.
 apg registry update-api-spec \
-	--api_spec.name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
 	--api_spec.mime_type "application/x.openapi+gzip;version=3" \
     --json
 
 echo
 echo Get the modifed API spec.
 apg registry get-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json
 
 echo
 echo Update the spec to new contents.
 apg registry update-api-spec \
-	--api_spec.name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
 	--api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r1` \
     --json
 
 echo
 echo Again update the spec to new contents.
 apg registry update-api-spec \
-	--api_spec.name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
 	--api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r2` \
     --json
 
 echo
 echo Make a third update of the spec contents.
 apg registry update-api-spec \
-	--api_spec.name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
 	--api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r3`
 
 echo
 echo Get the API spec.
 apg registry get-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json
 
 echo
 echo List the revisions of the spec.
 apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json
 
 echo
 echo List just the names of the revisions of the spec.
 apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.apiSpecs[].name' -r 
 
 echo
 echo Get the latest revision of the spec.
 apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.apiSpecs[0].name' -r 
 
 echo
 echo Get the oldest revision of the spec.
 apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.apiSpecs[-1].name' -r 
 
 ORIGINAL=`apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.apiSpecs[-1].name' -r`
 
 ORIGINAL_HASH=`apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.apiSpecs[-1].hash' -r`
 
@@ -154,27 +154,27 @@ apg registry tag-api-spec-revision --name $ORIGINAL --tag og --json
 echo
 echo Get a spec by its tag.
 apg registry get-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml@og \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og \
     --json
 
 echo
 echo Print the hash of the current spec revision.
 apg registry get-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.hash' -r
 
 echo
 echo Rollback to a prior spec revision.
 apg registry rollback-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --revision_id og \
     --json
 
 echo
 echo Print the hash of the current spec revision after the rollback.
 apg registry get-api-spec \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.hash' -r
 
@@ -187,7 +187,7 @@ echo Delete a spec revision.
 apg registry delete-api-spec-revision --name $ORIGINAL
 
 ORIGINAL2=`apg registry list-api-spec-revisions \
-    --name projects/demo/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
     --json | \
     jq '.specs[-1].name' -r`
 
@@ -198,14 +198,14 @@ echo $ORIGINAL2 should not be $ORIGINAL
 echo
 echo Verify that when listing specs, we only get the current revision of each spec.
 apg registry list-api-specs \
-    --parent projects/demo/apis/petstore/versions/1.0.0 \
+    --parent projects/demo/locations/global/apis/petstore/versions/1.0.0 \
     --json
 
 echo
 echo Set some artifacts on entities in the registry.
 # the contents below is the hex-encoding of "https://github.com/OAI/OpenAPI-Specification"
 apg registry create-artifact \
-    --parent projects/demo/apis/petstore \
+    --parent projects/demo/locations/global/apis/petstore \
     --artifact_id source \
     --artifact.mime_type "text/plain" \
     --artifact.contents "68747470733a2f2f6769746875622e636f6d2f4f41492f4f70656e4150492d53706563696669636174696f6e0a" \


### PR DESCRIPTION
`make build` was failing because the `cloubuild.yaml` was updated to use the default `PROJECT_ID` in this [PR](https://github.com/apigee/registry/pull/369/files#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5c). 

Updating the README file Protoc version is required to be `3.18.1` as part of this [PR](https://github.com/apigee/registry/commit/a55ab928c4da8d8d8123887177c5ed16f3a471d0#diff-bfb65189e4c34ea327b657f569d9ca1a2c22f6bd16878aea2aa7a3dd3b9cb164)

Adding `google.cloud.apigeeregistry.v1.Admin` service in the `envoy.yaml` file to support http transcoding for the admin service.

Adding `locations/global` in the path for the demo script at `tests/demo/walkthrough.sh`.