### PR TITLE
Fix GitHub container registry addresses

### DIFF
--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -18,7 +18,7 @@ inputs:
   registry:
     description: 'Image registry to use'
     required: true
-    default: 'gchr.io'
+    default: 'ghcr.io'
   username:
     description: 'Username to the image registry'
     required: true

--- a/containers/registry-linter/Dockerfile
+++ b/containers/registry-linter/Dockerfile
@@ -18,7 +18,7 @@
 # Make sure REGISTRY_PROJECT_IDENTIFIER is set
 
 # Build stage
-ARG REGISTRY_TOOL_IMAGE="gchr.io/apigee/registry-tools:latest"
+ARG REGISTRY_TOOL_IMAGE="ghcr.io/apigee/registry-tools:latest"
 
 FROM golang:alpine as builder
 


### PR DESCRIPTION
I don't see any runs for this action in our [history](https://github.com/apigee/registry/actions) but it looks like it will fail if it ever runs because these addresses point to an available domain name gchr.io, not the ghcr.io domain used by GitHub's container registry.