### PR TITLE
Add CRUD benchmarks for API methods

### DIFF
--- a/tests/benchmark/apis_test.go
+++ b/tests/benchmark/apis_test.go
@@ -1,0 +1,157 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/rpc"
+	"github.com/google/uuid"
+)
+
+const (
+	rootResource = "projects/bench/locations/global"
+)
+
+func uniqueID() string {
+	return fmt.Sprintf("%.8s", uuid.New())
+}
+
+func BenchmarkCreateApi(b *testing.B) {
+	ctx := context.Background()
+	client, err := connection.NewClient(ctx)
+	if err != nil {
+		b.Fatalf("Setup: Failed to create client: %s", err)
+	}
+
+	reqs := make([]*rpc.CreateApiRequest, b.N)
+	for i := 0; i < b.N; i++ {
+		reqs[i] = &rpc.CreateApiRequest{
+			Parent: rootResource,
+			ApiId:  uniqueID(),
+			Api:    &rpc.Api{},
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := client.CreateApi(ctx, reqs[i]); err != nil {
+			b.Errorf("CreateApi(%+v) returned unexpected error: %s", reqs[i], err)
+		}
+	}
+}
+
+func BenchmarkGetApi(b *testing.B) {
+	ctx := context.Background()
+	client, err := connection.NewClient(ctx)
+	if err != nil {
+		b.Fatalf("Setup: Failed to create client: %s", err)
+	}
+
+	reqs := make([]*rpc.GetApiRequest, b.N)
+	for i := 0; i < b.N; i++ {
+		api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
+			Parent: rootResource,
+			ApiId:  uniqueID(),
+			Api:    &rpc.Api{},
+		})
+		if err != nil {
+			b.Fatalf("Setup: Failed to create API: %s", err)
+		}
+
+		reqs[i] = &rpc.GetApiRequest{
+			Name: api.GetName(),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := client.GetApi(ctx, reqs[i]); err != nil {
+			b.Errorf("GetApi(%q) returned unexpected error: %s", reqs[i].GetName(), err)
+		}
+	}
+}
+
+func BenchmarkListApis(b *testing.B) {
+	b.Skip("TODO: Create ListApi benchmark test")
+}
+
+func BenchmarkUpdateApi(b *testing.B) {
+	ctx := context.Background()
+	client, err := connection.NewClient(ctx)
+	if err != nil {
+		b.Fatalf("Setup: Failed to create client: %s", err)
+	}
+
+	reqs := make([]*rpc.UpdateApiRequest, b.N)
+	for i := 0; i < b.N; i++ {
+		api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
+			Parent: rootResource,
+			ApiId:  uniqueID(),
+			Api:    &rpc.Api{},
+		})
+		if err != nil {
+			b.Fatalf("Setup: Failed to create API: %s", err)
+		}
+
+		reqs[i] = &rpc.UpdateApiRequest{
+			Api: &rpc.Api{
+				Name:        api.GetName(),
+				Description: uniqueID(),
+			},
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := client.UpdateApi(ctx, reqs[i]); err != nil {
+			b.Errorf("UpdateApi(%+v) returned unexpected error: %s", reqs[i], err)
+		}
+	}
+}
+
+func BenchmarkDeleteApi(b *testing.B) {
+	ctx := context.Background()
+	client, err := connection.NewClient(ctx)
+	if err != nil {
+		b.Fatalf("Setup: Failed to create client: %s", err)
+	}
+
+	reqs := make([]*rpc.DeleteApiRequest, b.N)
+	for i := 0; i < b.N; i++ {
+		api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
+			Parent: rootResource,
+			ApiId:  uniqueID(),
+			Api:    &rpc.Api{},
+		})
+		if err != nil {
+			b.Fatalf("Setup: Failed to create API: %s", err)
+		}
+
+		reqs[i] = &rpc.DeleteApiRequest{
+			Name: api.GetName(),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := client.DeleteApi(ctx, reqs[i]); err != nil {
+			b.Errorf("DeleteApi(%q) returned unexpected error: %s", reqs[i].GetName(), err)
+		}
+	}
+}

--- a/tests/benchmark/apis_test.go
+++ b/tests/benchmark/apis_test.go
@@ -39,35 +39,25 @@ func BenchmarkCreateApi(b *testing.B) {
 		b.Fatalf("Setup: Failed to create client: %s", err)
 	}
 
-	var (
-		creates = make([]*rpc.CreateApiRequest, b.N)
-		deletes = make([]*rpc.DeleteApiRequest, b.N)
-	)
-
+	b.StopTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		creates[i] = &rpc.CreateApiRequest{
+		req := &rpc.CreateApiRequest{
 			Parent: rootResource,
 			ApiId:  uniqueID(),
 			Api:    &rpc.Api{},
 		}
-	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		resp, err := client.CreateApi(ctx, creates[i])
+		b.StartTimer()
+		api, err := client.CreateApi(ctx, req)
+		b.StopTimer()
+
 		if err != nil {
-			b.Errorf("CreateApi(%+v) returned unexpected error: %s", creates[i], err)
+			b.Errorf("CreateApi(%+v) returned unexpected error: %s", req, err)
 		}
 
-		deletes[i] = &rpc.DeleteApiRequest{
-			Name: resp.GetName(),
-		}
-	}
-	b.StopTimer()
-
-	for i := 0; i < b.N; i++ {
-		if err := client.DeleteApi(ctx, deletes[i]); err != nil {
-			b.Errorf("Cleanup: DeleteApi(%q) returned unexpected error: %s", deletes[i].GetName(), err)
+		if err := client.DeleteApi(ctx, &rpc.DeleteApiRequest{Name: api.GetName()}); err != nil {
+			b.Errorf("Cleanup: DeleteApi(%q) returned unexpected error: %s", api.GetName(), err)
 		}
 	}
 }
@@ -79,11 +69,8 @@ func BenchmarkGetApi(b *testing.B) {
 		b.Fatalf("Setup: Failed to create client: %s", err)
 	}
 
-	var (
-		gets    = make([]*rpc.GetApiRequest, b.N)
-		deletes = make([]*rpc.DeleteApiRequest, b.N)
-	)
-
+	b.StopTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
 			Parent: rootResource,
@@ -94,26 +81,20 @@ func BenchmarkGetApi(b *testing.B) {
 			b.Fatalf("Setup: Failed to create API: %s", err)
 		}
 
-		gets[i] = &rpc.GetApiRequest{
+		req := &rpc.GetApiRequest{
 			Name: api.GetName(),
 		}
 
-		deletes[i] = &rpc.DeleteApiRequest{
-			Name: api.GetName(),
-		}
-	}
+		b.StartTimer()
+		_, err = client.GetApi(ctx, req)
+		b.StopTimer()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := client.GetApi(ctx, gets[i]); err != nil {
-			b.Errorf("GetApi(%q) returned unexpected error: %s", gets[i].GetName(), err)
+		if err != nil {
+			b.Errorf("GetApi(%+v) returned unexpected error: %s", req, err)
 		}
-	}
-	b.StopTimer()
 
-	for i := 0; i < b.N; i++ {
-		if err := client.DeleteApi(ctx, deletes[i]); err != nil {
-			b.Errorf("Cleanup: DeleteApi(%q) returned unexpected error: %s", deletes[i].GetName(), err)
+		if err := client.DeleteApi(ctx, &rpc.DeleteApiRequest{Name: api.GetName()}); err != nil {
+			b.Errorf("Cleanup: DeleteApi(%q) returned unexpected error: %s", api.GetName(), err)
 		}
 	}
 }
@@ -129,11 +110,8 @@ func BenchmarkUpdateApi(b *testing.B) {
 		b.Fatalf("Setup: Failed to create client: %s", err)
 	}
 
-	var (
-		updates = make([]*rpc.UpdateApiRequest, b.N)
-		deletes = make([]*rpc.DeleteApiRequest, b.N)
-	)
-
+	b.StopTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
 			Parent: rootResource,
@@ -144,29 +122,23 @@ func BenchmarkUpdateApi(b *testing.B) {
 			b.Fatalf("Setup: Failed to create API: %s", err)
 		}
 
-		updates[i] = &rpc.UpdateApiRequest{
+		req := &rpc.UpdateApiRequest{
 			Api: &rpc.Api{
 				Name:        api.GetName(),
 				Description: uniqueID(),
 			},
 		}
 
-		deletes[i] = &rpc.DeleteApiRequest{
-			Name: api.GetName(),
-		}
-	}
+		b.StartTimer()
+		_, err = client.UpdateApi(ctx, req)
+		b.StopTimer()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := client.UpdateApi(ctx, updates[i]); err != nil {
-			b.Errorf("UpdateApi(%+v) returned unexpected error: %s", updates[i], err)
+		if err != nil {
+			b.Errorf("UpdateApi(%+v) returned unexpected error: %s", req, err)
 		}
-	}
-	b.StopTimer()
 
-	for i := 0; i < b.N; i++ {
-		if err := client.DeleteApi(ctx, deletes[i]); err != nil {
-			b.Errorf("Cleanup: DeleteApi(%q) returned unexpected error: %s", deletes[i].GetName(), err)
+		if err := client.DeleteApi(ctx, &rpc.DeleteApiRequest{Name: api.GetName()}); err != nil {
+			b.Errorf("Cleanup: DeleteApi(%q) returned unexpected error: %s", api.GetName(), err)
 		}
 	}
 }
@@ -178,7 +150,8 @@ func BenchmarkDeleteApi(b *testing.B) {
 		b.Fatalf("Setup: Failed to create client: %s", err)
 	}
 
-	deletes := make([]*rpc.DeleteApiRequest, b.N)
+	b.StopTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
 			Parent: rootResource,
@@ -189,15 +162,16 @@ func BenchmarkDeleteApi(b *testing.B) {
 			b.Fatalf("Setup: Failed to create API: %s", err)
 		}
 
-		deletes[i] = &rpc.DeleteApiRequest{
+		req := &rpc.DeleteApiRequest{
 			Name: api.GetName(),
 		}
-	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := client.DeleteApi(ctx, deletes[i]); err != nil {
-			b.Errorf("DeleteApi(%q) returned unexpected error: %s", deletes[i].GetName(), err)
+		b.StartTimer()
+		err = client.DeleteApi(ctx, req)
+		b.StopTimer()
+
+		if err != nil {
+			b.Errorf("DeleteApi(%+v) returned unexpected error: %s", req, err)
 		}
 	}
 }


### PR DESCRIPTION
After discussing some ideas for benchmarking the performance of our API
methods I wanted to see how Go's benchmark package would work. This
change includes some simple examples for the API resource's CRUD methods.

These benchmarks don't examine the response for correctness (aside from
an error check) because it might significantly affect the performance.
The benchmarks don't need to (and shouldn't) test the correctness of
responses because other test suites already check this.

The tests can executed using `go test -bench=. ./tests/benchmark/...` or
compiled using `go test -c ./tests/benchmark/...` and executed using the
resulting binary with the `test.bench=.` flag.

Example benchmark output:

```
goos: darwin
goarch: amd64
pkg: github.com/apigee/registry/tests/benchmark
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkCreateApi-12    	     152	   7968111 ns/op
BenchmarkGetApi-12       	     198	   6026086 ns/op
BenchmarkUpdateApi-12    	     157	   7667434 ns/op
BenchmarkDeleteApi-12    	      94	  11900588 ns/op
PASS
```