### PR TITLE
Fix artifact creation problem, test artifact creation for all parent types

### DIFF
--- a/server/registry/actions_artifacts.go
+++ b/server/registry/actions_artifacts.go
@@ -37,6 +37,8 @@ func parseArtifactParent(name string) (artifactParent, error) {
 		return s, nil
 	} else if v, err := names.ParseVersion(name); err == nil {
 		return v, nil
+	} else if d, err := names.ParseDeployment(name); err == nil {
+		return d, nil
 	} else if a, err := names.ParseApi(name); err == nil {
 		return a, nil
 	} else if p, err := names.ParseProjectWithLocation(name); err == nil {

--- a/server/registry/actions_artifacts_test.go
+++ b/server/registry/actions_artifacts_test.go
@@ -36,12 +36,12 @@ var (
 func TestCreateArtifact(t *testing.T) {
 	tests := []struct {
 		desc string
-		seed *rpc.Project
+		seed seeder.RegistryResource
 		req  *rpc.CreateArtifactRequest
 		want *rpc.Artifact
 	}{
 		{
-			desc: "fully populated resource",
+			desc: "create project artifact",
 			seed: &rpc.Project{Name: "projects/my-project"},
 			req: &rpc.CreateArtifactRequest{
 				Parent:     "projects/my-project/locations/global",
@@ -60,13 +60,93 @@ func TestCreateArtifact(t *testing.T) {
 				Hash:      sha256hash(artifactContents),
 			},
 		},
+		{
+			desc: "create api artifact",
+			seed: &rpc.Api{Name: "projects/my-project/locations/global/apis/my-api"},
+			req: &rpc.CreateArtifactRequest{
+				Parent:     "projects/my-project/locations/global/apis/my-api",
+				ArtifactId: "my-artifact",
+				Artifact: &rpc.Artifact{
+					MimeType:  "application/json",
+					SizeBytes: int32(len(artifactContents)),
+					Hash:      sha256hash(artifactContents),
+					Contents:  artifactContents,
+				},
+			},
+			want: &rpc.Artifact{
+				Name:      "projects/my-project/locations/global/apis/my-api/artifacts/my-artifact",
+				MimeType:  "application/json",
+				SizeBytes: int32(len(artifactContents)),
+				Hash:      sha256hash(artifactContents),
+			},
+		},
+		{
+			desc: "create version artifact",
+			seed: &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/my-api/versions/my-version"},
+			req: &rpc.CreateArtifactRequest{
+				Parent:     "projects/my-project/locations/global/apis/my-api/versions/my-version",
+				ArtifactId: "my-artifact",
+				Artifact: &rpc.Artifact{
+					MimeType:  "application/json",
+					SizeBytes: int32(len(artifactContents)),
+					Hash:      sha256hash(artifactContents),
+					Contents:  artifactContents,
+				},
+			},
+			want: &rpc.Artifact{
+				Name:      "projects/my-project/locations/global/apis/my-api/versions/my-version/artifacts/my-artifact",
+				MimeType:  "application/json",
+				SizeBytes: int32(len(artifactContents)),
+				Hash:      sha256hash(artifactContents),
+			},
+		},
+		{
+			desc: "create deployment artifact",
+			seed: &rpc.ApiDeployment{Name: "projects/my-project/locations/global/apis/my-api/deployments/my-deployment"},
+			req: &rpc.CreateArtifactRequest{
+				Parent:     "projects/my-project/locations/global/apis/my-api/deployments/my-deployment",
+				ArtifactId: "my-artifact",
+				Artifact: &rpc.Artifact{
+					MimeType:  "application/json",
+					SizeBytes: int32(len(artifactContents)),
+					Hash:      sha256hash(artifactContents),
+					Contents:  artifactContents,
+				},
+			},
+			want: &rpc.Artifact{
+				Name:      "projects/my-project/locations/global/apis/my-api/deployments/my-deployment/artifacts/my-artifact",
+				MimeType:  "application/json",
+				SizeBytes: int32(len(artifactContents)),
+				Hash:      sha256hash(artifactContents),
+			},
+		},
+		{
+			desc: "create spec artifact",
+			seed: &rpc.ApiSpec{Name: "projects/my-project/locations/global/apis/my-api/versions/my-version/specs/my-spec"},
+			req: &rpc.CreateArtifactRequest{
+				Parent:     "projects/my-project/locations/global/apis/my-api/versions/my-version/specs/my-spec",
+				ArtifactId: "my-artifact",
+				Artifact: &rpc.Artifact{
+					MimeType:  "application/json",
+					SizeBytes: int32(len(artifactContents)),
+					Hash:      sha256hash(artifactContents),
+					Contents:  artifactContents,
+				},
+			},
+			want: &rpc.Artifact{
+				Name:      "projects/my-project/locations/global/apis/my-api/versions/my-version/specs/my-spec/artifacts/my-artifact",
+				MimeType:  "application/json",
+				SizeBytes: int32(len(artifactContents)),
+				Hash:      sha256hash(artifactContents),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			ctx := context.Background()
 			server := defaultTestServer(t)
-			if err := seeder.SeedProjects(ctx, server, test.seed); err != nil {
+			if err := seeder.SeedRegistry(ctx, server, test.seed); err != nil {
 				t.Fatalf("Setup/Seeding: Failed to seed registry: %s", err)
 			}
 


### PR DESCRIPTION
This fixes a problem creating artifacts discovered by @Krpate - we were failing to create artifacts when their parent type was "ApiDeployment". With the (small) fix, I've added artifact creation tests for all parent types (we had tests for project parents; the new tests cover APIs, versions, deployments, and specs).