### PR TITLE
Patch apg to make the Admin client use the Registry client configuration

### DIFF
--- a/auth/CLOUDRUN.sh
+++ b/auth/CLOUDRUN.sh
@@ -46,10 +46,3 @@ export APG_REGISTRY_TOKEN=$(gcloud auth print-identity-token ${APG_REGISTRY_CLIE
 
 # Calls don't use an API key.
 unset APG_REGISTRY_API_KEY
-
-# Duplicate the client configuration for the Admin service.
-unset APG_ADMIN_INSECURE
-export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
-export APG_ADMIN_AUDIENCES=$APG_REGISTRY_AUDIENCES
-export APG_ADMIN_TOKEN=$APG_REGISTRY_TOKEN
-unset APG_ADMIN_API_KEY

--- a/auth/ENVOY.sh
+++ b/auth/ENVOY.sh
@@ -43,10 +43,3 @@ export APG_REGISTRY_TOKEN=$(gcloud auth print-identity-token ${APG_REGISTRY_CLIE
 
 # Calls don't use an API key.
 unset APG_REGISTRY_API_KEY
-
-# Duplicate the client configuration for the Admin service.
-export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
-export APG_ADMIN_AUDIENCES=$APG_REGISTRY_AUDIENCES
-export APG_ADMIN_INSECURE=$APG_REGISTRY_INSECURE
-export APG_ADMIN_TOKEN=$APG_REGISTRY_TOKEN
-unset APG_ADMIN_API_KEY

--- a/auth/GKE.sh
+++ b/auth/GKE.sh
@@ -55,10 +55,3 @@ export APG_REGISTRY_TOKEN=$(gcloud auth print-identity-token ${APG_REGISTRY_CLIE
 # Calls don't use an API key.
 unset APG_REGISTRY_API_KEY
 export APG_REGISTRY_INSECURE=1
-
-# Duplicate the client configuration for the Admin service
-export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
-export APG_ADMIN_AUDIENCES=$APG_REGISTRY_AUDIENCES
-export APG_ADMIN_TOKEN=$APG_REGISTRY_TOKEN
-export APG_ADMIN_INSECURE=$APG_REGISTRY_INSECURE
-unset APG_ADMIN_API_KEY

--- a/auth/LOCAL.sh
+++ b/auth/LOCAL.sh
@@ -46,10 +46,3 @@ export APG_REGISTRY_INSECURE=1
 # Local calls don't need authentication.
 unset APG_REGISTRY_TOKEN
 unset APG_REGISTRY_API_KEY
-
-# Duplicate the client configuration for the Admin service.
-export APG_ADMIN_ADDRESS=$APG_REGISTRY_ADDRESS
-export APG_ADMIN_AUDIENCES=$APG_REGISTRY_AUDIENCES
-export APG_ADMIN_INSECURE=$APG_REGISTRY_INSECURE
-unset APG_ADMIN_TOKEN
-unset APG_ADMIN_API_KEY

--- a/cmd/apg/admin_service.go
+++ b/cmd/apg/admin_service.go
@@ -30,22 +30,22 @@ func init() {
 	rootCmd.AddCommand(AdminServiceCmd)
 
 	AdminConfig = viper.New()
-	AdminConfig.SetEnvPrefix("APG_ADMIN")
+	AdminConfig.SetEnvPrefix("APG_REGISTRY")
 	AdminConfig.AutomaticEnv()
 
-	AdminServiceCmd.PersistentFlags().Bool("insecure", false, "Make insecure client connection. Or use APG_ADMIN_INSECURE. Must be used with \"address\" option")
+	AdminServiceCmd.PersistentFlags().Bool("insecure", false, "Make insecure client connection. Or use APG_REGISTRY_INSECURE. Must be used with \"address\" option")
 	AdminConfig.BindPFlag("insecure", AdminServiceCmd.PersistentFlags().Lookup("insecure"))
 	AdminConfig.BindEnv("insecure")
 
-	AdminServiceCmd.PersistentFlags().String("address", "", "Set API address used by client. Or use APG_ADMIN_ADDRESS.")
+	AdminServiceCmd.PersistentFlags().String("address", "", "Set API address used by client. Or use APG_REGISTRY_ADDRESS.")
 	AdminConfig.BindPFlag("address", AdminServiceCmd.PersistentFlags().Lookup("address"))
 	AdminConfig.BindEnv("address")
 
-	AdminServiceCmd.PersistentFlags().String("token", "", "Set Bearer token used by the client. Or use APG_ADMIN_TOKEN.")
+	AdminServiceCmd.PersistentFlags().String("token", "", "Set Bearer token used by the client. Or use APG_REGISTRY_TOKEN.")
 	AdminConfig.BindPFlag("token", AdminServiceCmd.PersistentFlags().Lookup("token"))
 	AdminConfig.BindEnv("token")
 
-	AdminServiceCmd.PersistentFlags().String("api_key", "", "Set API Key used by the client. Or use APG_ADMIN_API_KEY.")
+	AdminServiceCmd.PersistentFlags().String("api_key", "", "Set API Key used by the client. Or use APG_REGISTRY_API_KEY.")
 	AdminConfig.BindPFlag("api_key", AdminServiceCmd.PersistentFlags().Lookup("api_key"))
 	AdminConfig.BindEnv("api_key")
 }

--- a/tools/GENERATE-APG.sh
+++ b/tools/GENERATE-APG.sh
@@ -30,3 +30,16 @@ protoc ${SERVICE_PROTOS[*]} \
   	--go_cli_opt='root=apg' \
   	--go_cli_opt='gapic=github.com/apigee/registry/gapic' \
   	--go_cli_out='cmd/apg'
+
+# Patch the generated CLI to use "APG_REGISTRY" as the prefix for
+# Admin service configuration variables. This causes the Admin service
+# client to be configured with the same variables that configure the
+# Registry service client.
+FILE=cmd/apg/admin_service.go
+sed -i.bak "s/APG_ADMIN/APG_REGISTRY/" "${FILE}"
+rm "${FILE}.bak"
+gofmt -w "${FILE}"
+if grep --quiet APG_ADMIN "${FILE}"; then
+  echo "Patching APG tool failed."
+  exit 1
+fi


### PR DESCRIPTION
This eliminates the use of APG_ADMIN_* variables to configure the Admin service client, replacing them with APG_REGISTRY_* so that both services are configured with the same variables.