### PR TITLE
Update GAPIC config: 20s timeouts, additional retries

### DIFF
--- a/gapic/grpc_service_config.json
+++ b/gapic/grpc_service_config.json
@@ -6,15 +6,17 @@
             "service": "google.cloud.apigeeregistry.v1.Registry"
           }
         ],
-        "timeout": "10s",
+        "timeout": "20s",
         "retryPolicy": {
           "initialBackoff": "0.200s",
           "maxBackoff": "10s",
           "backoffMultiplier": 1.3,
           "retryableStatusCodes": [
+            "ABORTED",
+            "CANCELLED",
             "UNAVAILABLE"
           ]
         }
-      }     
-    ]     
+      }
+    ]
   }

--- a/gapic/registry_client.go
+++ b/gapic/registry_client.go
@@ -94,6 +94,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListApis: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -105,6 +107,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetApi: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -116,6 +120,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		CreateApi: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -127,6 +133,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		UpdateApi: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -138,6 +146,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteApi: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -149,6 +159,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListApiVersions: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -160,6 +172,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetApiVersion: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -171,6 +185,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		CreateApiVersion: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -182,6 +198,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		UpdateApiVersion: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -193,6 +211,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteApiVersion: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -204,6 +224,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListApiSpecs: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -215,6 +237,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetApiSpec: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -226,6 +250,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetApiSpecContents: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -237,6 +263,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		CreateApiSpec: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -248,6 +276,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		UpdateApiSpec: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -259,6 +289,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteApiSpec: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -270,6 +302,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		TagApiSpecRevision: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -281,6 +315,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListApiSpecRevisions: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -292,6 +328,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		RollbackApiSpec: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -303,6 +341,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteApiSpecRevision: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -314,6 +354,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListApiDeployments: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -325,6 +367,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetApiDeployment: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -336,6 +380,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		CreateApiDeployment: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -347,6 +393,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		UpdateApiDeployment: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -358,6 +406,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteApiDeployment: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -369,6 +419,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		TagApiDeploymentRevision: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -380,6 +432,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListApiDeploymentRevisions: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -391,6 +445,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		RollbackApiDeployment: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -402,6 +458,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteApiDeploymentRevision: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -413,6 +471,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ListArtifacts: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -424,6 +484,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetArtifact: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -435,6 +497,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		GetArtifactContents: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -446,6 +510,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		CreateArtifact: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -457,6 +523,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		ReplaceArtifact: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -468,6 +536,8 @@ func defaultRegistryCallOptions() *RegistryCallOptions {
 		DeleteArtifact: []gax.CallOption{
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
+					codes.Aborted,
+					codes.Canceled,
 					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    200 * time.Millisecond,
@@ -871,7 +941,7 @@ func (c *registryGRPCClient) ListApis(ctx context.Context, req *rpcpb.ListApisRe
 
 func (c *registryGRPCClient) GetApi(ctx context.Context, req *rpcpb.GetApiRequest, opts ...gax.CallOption) (*rpcpb.Api, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -892,7 +962,7 @@ func (c *registryGRPCClient) GetApi(ctx context.Context, req *rpcpb.GetApiReques
 
 func (c *registryGRPCClient) CreateApi(ctx context.Context, req *rpcpb.CreateApiRequest, opts ...gax.CallOption) (*rpcpb.Api, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -913,7 +983,7 @@ func (c *registryGRPCClient) CreateApi(ctx context.Context, req *rpcpb.CreateApi
 
 func (c *registryGRPCClient) UpdateApi(ctx context.Context, req *rpcpb.UpdateApiRequest, opts ...gax.CallOption) (*rpcpb.Api, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -934,7 +1004,7 @@ func (c *registryGRPCClient) UpdateApi(ctx context.Context, req *rpcpb.UpdateApi
 
 func (c *registryGRPCClient) DeleteApi(ctx context.Context, req *rpcpb.DeleteApiRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -995,7 +1065,7 @@ func (c *registryGRPCClient) ListApiVersions(ctx context.Context, req *rpcpb.Lis
 
 func (c *registryGRPCClient) GetApiVersion(ctx context.Context, req *rpcpb.GetApiVersionRequest, opts ...gax.CallOption) (*rpcpb.ApiVersion, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1016,7 +1086,7 @@ func (c *registryGRPCClient) GetApiVersion(ctx context.Context, req *rpcpb.GetAp
 
 func (c *registryGRPCClient) CreateApiVersion(ctx context.Context, req *rpcpb.CreateApiVersionRequest, opts ...gax.CallOption) (*rpcpb.ApiVersion, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1037,7 +1107,7 @@ func (c *registryGRPCClient) CreateApiVersion(ctx context.Context, req *rpcpb.Cr
 
 func (c *registryGRPCClient) UpdateApiVersion(ctx context.Context, req *rpcpb.UpdateApiVersionRequest, opts ...gax.CallOption) (*rpcpb.ApiVersion, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1058,7 +1128,7 @@ func (c *registryGRPCClient) UpdateApiVersion(ctx context.Context, req *rpcpb.Up
 
 func (c *registryGRPCClient) DeleteApiVersion(ctx context.Context, req *rpcpb.DeleteApiVersionRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1119,7 +1189,7 @@ func (c *registryGRPCClient) ListApiSpecs(ctx context.Context, req *rpcpb.ListAp
 
 func (c *registryGRPCClient) GetApiSpec(ctx context.Context, req *rpcpb.GetApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1140,7 +1210,7 @@ func (c *registryGRPCClient) GetApiSpec(ctx context.Context, req *rpcpb.GetApiSp
 
 func (c *registryGRPCClient) GetApiSpecContents(ctx context.Context, req *rpcpb.GetApiSpecContentsRequest, opts ...gax.CallOption) (*httpbodypb.HttpBody, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1161,7 +1231,7 @@ func (c *registryGRPCClient) GetApiSpecContents(ctx context.Context, req *rpcpb.
 
 func (c *registryGRPCClient) CreateApiSpec(ctx context.Context, req *rpcpb.CreateApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1182,7 +1252,7 @@ func (c *registryGRPCClient) CreateApiSpec(ctx context.Context, req *rpcpb.Creat
 
 func (c *registryGRPCClient) UpdateApiSpec(ctx context.Context, req *rpcpb.UpdateApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1203,7 +1273,7 @@ func (c *registryGRPCClient) UpdateApiSpec(ctx context.Context, req *rpcpb.Updat
 
 func (c *registryGRPCClient) DeleteApiSpec(ctx context.Context, req *rpcpb.DeleteApiSpecRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1220,7 +1290,7 @@ func (c *registryGRPCClient) DeleteApiSpec(ctx context.Context, req *rpcpb.Delet
 
 func (c *registryGRPCClient) TagApiSpecRevision(ctx context.Context, req *rpcpb.TagApiSpecRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1285,7 +1355,7 @@ func (c *registryGRPCClient) ListApiSpecRevisions(ctx context.Context, req *rpcp
 
 func (c *registryGRPCClient) RollbackApiSpec(ctx context.Context, req *rpcpb.RollbackApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1306,7 +1376,7 @@ func (c *registryGRPCClient) RollbackApiSpec(ctx context.Context, req *rpcpb.Rol
 
 func (c *registryGRPCClient) DeleteApiSpecRevision(ctx context.Context, req *rpcpb.DeleteApiSpecRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1371,7 +1441,7 @@ func (c *registryGRPCClient) ListApiDeployments(ctx context.Context, req *rpcpb.
 
 func (c *registryGRPCClient) GetApiDeployment(ctx context.Context, req *rpcpb.GetApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1392,7 +1462,7 @@ func (c *registryGRPCClient) GetApiDeployment(ctx context.Context, req *rpcpb.Ge
 
 func (c *registryGRPCClient) CreateApiDeployment(ctx context.Context, req *rpcpb.CreateApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1413,7 +1483,7 @@ func (c *registryGRPCClient) CreateApiDeployment(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) UpdateApiDeployment(ctx context.Context, req *rpcpb.UpdateApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1434,7 +1504,7 @@ func (c *registryGRPCClient) UpdateApiDeployment(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) DeleteApiDeployment(ctx context.Context, req *rpcpb.DeleteApiDeploymentRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1451,7 +1521,7 @@ func (c *registryGRPCClient) DeleteApiDeployment(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) TagApiDeploymentRevision(ctx context.Context, req *rpcpb.TagApiDeploymentRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1516,7 +1586,7 @@ func (c *registryGRPCClient) ListApiDeploymentRevisions(ctx context.Context, req
 
 func (c *registryGRPCClient) RollbackApiDeployment(ctx context.Context, req *rpcpb.RollbackApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1537,7 +1607,7 @@ func (c *registryGRPCClient) RollbackApiDeployment(ctx context.Context, req *rpc
 
 func (c *registryGRPCClient) DeleteApiDeploymentRevision(ctx context.Context, req *rpcpb.DeleteApiDeploymentRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1602,7 +1672,7 @@ func (c *registryGRPCClient) ListArtifacts(ctx context.Context, req *rpcpb.ListA
 
 func (c *registryGRPCClient) GetArtifact(ctx context.Context, req *rpcpb.GetArtifactRequest, opts ...gax.CallOption) (*rpcpb.Artifact, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1623,7 +1693,7 @@ func (c *registryGRPCClient) GetArtifact(ctx context.Context, req *rpcpb.GetArti
 
 func (c *registryGRPCClient) GetArtifactContents(ctx context.Context, req *rpcpb.GetArtifactContentsRequest, opts ...gax.CallOption) (*httpbodypb.HttpBody, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1644,7 +1714,7 @@ func (c *registryGRPCClient) GetArtifactContents(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) CreateArtifact(ctx context.Context, req *rpcpb.CreateArtifactRequest, opts ...gax.CallOption) (*rpcpb.Artifact, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1665,7 +1735,7 @@ func (c *registryGRPCClient) CreateArtifact(ctx context.Context, req *rpcpb.Crea
 
 func (c *registryGRPCClient) ReplaceArtifact(ctx context.Context, req *rpcpb.ReplaceArtifactRequest, opts ...gax.CallOption) (*rpcpb.Artifact, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1686,7 +1756,7 @@ func (c *registryGRPCClient) ReplaceArtifact(ctx context.Context, req *rpcpb.Rep
 
 func (c *registryGRPCClient) DeleteArtifact(ctx context.Context, req *rpcpb.DeleteArtifactRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 10000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}


### PR DESCRIPTION
Update GAPIC configuration to increase timeouts to 20s and retry two additional gRPC response codes (Abort, Cancelled).

In testing with hosted deployments, "Abort" codes are returned when prerequisite operations have failed to complete. Retrying these aborted calls generally succeeds. "Cancelled" codes are returned when calls are rate-limited. Again, retrying these callsl generally succeeds (with appropriate backoffs, which are built into the GAPICs).

The timeout increase works around issues where proxies preemptively expire cancel requests with timeouts that are considered too short.