### PR TITLE
Require "global" as the location when parsing project names with location

### DIFF
--- a/server/registry/names/project.go
+++ b/server/registry/names/project.go
@@ -69,7 +69,7 @@ func projectRegexp() *regexp.Regexp {
 
 // projectWithLocationRegexp returns a regular expression that matches a project resource name followed by a location.
 func projectWithLocationRegexp() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s$", identifier, identifier))
+	return regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s$", identifier, Location))
 }
 
 // ParseProject parses the name of a project.


### PR DESCRIPTION
We noticed that CreateAPI calls were accepting arbitrary location values, where all others required that the location be "global". In the future, we may expand our support to allow arbitrary locations, but for consistency, this corrects the regex used to parse located projects so that the location value must be "global".

Verified manually with:
```
apg registry create-api --parent projects/openapi/locations/invalid --api_id test
```