### PR TITLE
Fixed the type for ApiDeployment

### DIFF
--- a/google/cloud/apigeeregistry/v1/registry_models.proto
+++ b/google/cloud/apigeeregistry/v1/registry_models.proto
@@ -239,7 +239,7 @@ message ApiSpec {
 // endpoint address changes.
 message ApiDeployment {
   option (google.api.resource) = {
-    type: "registry.googleapis.com/ApiDeployment"
+    type: "apigeeregistry.googleapis.com/ApiDeployment"
     pattern: "projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}"
   };
 


### PR DESCRIPTION
Came across this error when I was trying to generate typescript client from the proto definitions