### PR TITLE
Exec cmd

### DIFF
--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/conformance"
 	"github.com/apigee/registry/cmd/registry/core"
-	"github.com/apigee/registry/cmd/registry/conformance"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"

--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/conformance"
 	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/cmd/registry/conformance"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -15,11 +15,14 @@
 package conformance
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
@@ -32,7 +35,7 @@ func conformanceReportName(specName, styleguideName string) string {
 	return fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideName)
 }
 
-func initializeConformanceReport(specName string, styleguideId string) *rpc.ConformanceReport {
+func initializeConformanceReport(specName, styleguideId string) *rpc.ConformanceReport {
 	// Create an empty conformance report.
 	conformanceReport := &rpc.ConformanceReport{
 		Name:           conformanceReportName(specName, styleguideId),
@@ -107,33 +110,12 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Generate conformance report
+	// Run the linters and compute conformance report
 	conformanceReport := initializeConformanceReport(task.Spec.GetName(), task.StyleguideId)
-	err = task.computeConformanceReport(ctx, root, conformanceReport)
-	if err != nil {
-		log.Errorf(ctx,
-			"Failed to compute the conformance for spec %s: %s",
-			task.Spec.GetName(),
-			err,
-		)
-		return err
-	}
-
-	return task.storeConformanceReport(ctx, conformanceReport)
-}
-
-func (task *ComputeConformanceTask) computeConformanceReport(
-	ctx context.Context,
-	specDirectory string,
-	conformanceReport *rpc.ConformanceReport,
-) error {
-
-	guidelineReportsMap := make(map[string]*rpc.GuidelineReport)
-
-	// Iterate over all the linters, and lint.
+	guidelineReportsMap := make(map[string]int)
 	for _, metadata := range task.LintersMetadata {
 
-		linterResponse, err := invokeLinter(ctx, specDirectory, metadata)
+		linterResponse, err := task.invokeLinter(ctx, root, metadata)
 		// If a linter returned an error, we shouldn't stop linting completely across all linters and
 		// discard the conformance report for this spec. We should log but still continue, because there
 		// may still be useful information from other linters that we may be discarding.
@@ -142,51 +124,114 @@ func (task *ComputeConformanceTask) computeConformanceReport(
 			continue
 		}
 
-		// Process linterResponse to generate conformance report
-		lintFiles := linterResponse.Lint.GetFiles()
-
-		for _, lintFile := range lintFiles {
-			lintProblems := lintFile.GetProblems()
-
-			// Iterate over the list of problems returned by the linter.
-			for _, problem := range lintProblems {
-				ruleMetadata, ok := metadata.rulesMetadata[problem.GetRuleId()]
-				if !ok {
-					// If a problem the linter returned isn't one that we expect
-					// then we should ignore it
-					continue
-				}
-
-				guideline := ruleMetadata.guideline
-				guidelineRule := ruleMetadata.guidelineRule
-
-				// Check if the guideline report for the guideline which contains this rule
-				// has already been initialized. If it hasn't then create one.
-				guidelineReport, ok := guidelineReportsMap[guideline.GetId()]
-				if !ok {
-					guidelineReport = initializeGuidelineReport(guideline.GetId())
-					guidelineReportsMap[guideline.GetId()] = guidelineReport
-
-					// Create a new entry in the conformance report
-					guidelineGroup := conformanceReport.GuidelineReportGroups[guideline.Status]
-					guidelineGroup.GuidelineReports = append(guidelineGroup.GuidelineReports, guidelineReport)
-				}
-
-				ruleReport := &rpc.RuleReport{
-					RuleId:     guidelineRule.GetId(),
-					SpecName:   task.Spec.GetName(),
-					FileName:   filepath.Base(lintFile.GetFilePath()),
-					Suggestion: problem.Suggestion,
-					Location:   problem.Location,
-				}
-				// Add the rule report to the appropriate guideline report.
-				ruleGroup := guidelineReport.RuleReportGroups[guidelineRule.Severity]
-				ruleGroup.RuleReports = append(ruleGroup.RuleReports, ruleReport)
-			}
-		}
+		task.computeConformanceReport(ctx, conformanceReport, guidelineReportsMap, linterResponse, metadata)
 	}
 
-	return nil
+	return task.storeConformanceReport(ctx, conformanceReport)
+}
+
+func (task *ComputeConformanceTask) invokeLinter(
+	ctx context.Context,
+	specDirectory string,
+	metadata *linterMetadata) (*rpc.LinterResponse, error) {
+
+	// Formulate the request.
+	requestBytes, err := proto.Marshal(&rpc.LinterRequest{
+		SpecDirectory: specDirectory,
+		RuleIds:       metadata.rules,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed marshaling linterRequest, Error: %s ", err)
+	}
+
+	executableName := getLinterBinaryName(metadata.name)
+	cmd := exec.Command(executableName)
+	cmd.Stdin = bytes.NewReader(requestBytes)
+	cmd.Stderr = os.Stderr
+
+	pluginStartTime := time.Now()
+	// Run the linter.
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("Running the plugin %s return error: %s", executableName, err)
+	}
+
+	pluginElapsedTime := time.Since(pluginStartTime)
+	log.Debugf(ctx, "Plugin %s ran in time %s", executableName, pluginElapsedTime)
+
+	// Unmarshal the output bytes into a response object. If there's a failure, log and continue.
+	linterResponse := &rpc.LinterResponse{}
+	err = proto.Unmarshal(output, linterResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Failed unmarshaling LinterResponse (plugins must write log messages to stderr, not stdout): %s", err)
+	}
+
+	// Check if there were any errors in the plugin.
+	if len(linterResponse.GetErrors()) > 0 {
+		return nil, fmt.Errorf("Plugin %s encountered errors: %v", executableName, linterResponse.GetErrors())
+	}
+
+	return linterResponse, nil
+}
+
+func (task *ComputeConformanceTask) computeConformanceReport(
+	ctx context.Context,
+	conformanceReport *rpc.ConformanceReport,
+	guidelineReportsMap map[string]int,
+	linterResponse *rpc.LinterResponse,
+	linterMetadata *linterMetadata,
+) {
+
+	// Process linterResponse to generate conformance report
+	lintFiles := linterResponse.Lint.GetFiles()
+
+	for _, lintFile := range lintFiles {
+		lintProblems := lintFile.GetProblems()
+
+		// Iterate over the list of problems returned by the linter.
+		for _, problem := range lintProblems {
+			ruleMetadata, ok := linterMetadata.rulesMetadata[problem.GetRuleId()]
+			if !ok {
+				// If a problem the linter returned isn't one that we expect
+				// then we should ignore it
+				continue
+			}
+
+			guideline := ruleMetadata.guideline
+			guidelineRule := ruleMetadata.guidelineRule
+
+			// Check if the guideline report for the guideline which contains this rule
+			// has already been initialized. If it hasn't then create one.
+			reportIndex, ok := guidelineReportsMap[guideline.GetId()]
+			if !ok {
+				guidelineReport := initializeGuidelineReport(guideline.GetId())
+
+				// Create a new entry in the conformance report
+				guidelineGroup := conformanceReport.GuidelineReportGroups[guideline.GetStatus()]
+				guidelineGroup.GuidelineReports = append(guidelineGroup.GuidelineReports, guidelineReport)
+
+				// Store the index of this new entry in the map
+				reportIndex = len(guidelineGroup.GuidelineReports) - 1
+				guidelineReportsMap[guideline.GetId()] = reportIndex
+			}
+
+			ruleReport := &rpc.RuleReport{
+				RuleId:     guidelineRule.GetId(),
+				SpecName:   task.Spec.GetName(),
+				FileName:   filepath.Base(lintFile.GetFilePath()),
+				Suggestion: problem.Suggestion,
+				Location:   problem.Location,
+			}
+			// Add the rule report to the appropriate guideline report.
+			guidelineGroup := conformanceReport.GuidelineReportGroups[guideline.GetStatus()]
+			if reportIndex >= len(guidelineGroup.GuidelineReports) {
+				log.Errorf(ctx, "Incorrect data in conformance report. Cannot attach entry for %s", guideline.GetId())
+				continue
+			}
+			ruleGroup := guidelineGroup.GuidelineReports[reportIndex].RuleReportGroups[guidelineRule.GetSeverity()]
+			ruleGroup.RuleReports = append(ruleGroup.RuleReports, ruleReport)
+		}
+	}
 }
 
 func (task *ComputeConformanceTask) storeConformanceReport(

--- a/cmd/registry/conformance/conformance-task_test.go
+++ b/cmd/registry/conformance/conformance-task_test.go
@@ -1,0 +1,561 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+	// "github.com/apigee/registry/connection"
+)
+
+const specName = "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"
+const styleguideId = "openapi-test"
+
+// This test will catch any changes made to the original status values.
+func TestInitializeConformanceReport(t *testing.T) {
+	specName := specName
+	styleguideId := styleguideId
+	want := &rpc.ConformanceReport{
+		Name:           fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideId),
+		StyleguideName: styleguideId,
+		GuidelineReportGroups: []*rpc.GuidelineReportGroup{
+			{
+				Status:           rpc.Guideline_STATUS_UNSPECIFIED,
+				GuidelineReports: make([]*rpc.GuidelineReport, 0),
+			},
+			{
+				Status:           rpc.Guideline_PROPOSED,
+				GuidelineReports: make([]*rpc.GuidelineReport, 0),
+			},
+			{
+				Status:           rpc.Guideline_ACTIVE,
+				GuidelineReports: make([]*rpc.GuidelineReport, 0),
+			},
+			{
+				Status:           rpc.Guideline_DEPRECATED,
+				GuidelineReports: make([]*rpc.GuidelineReport, 0),
+			},
+			{
+				Status:           rpc.Guideline_DISABLED,
+				GuidelineReports: make([]*rpc.GuidelineReport, 0),
+			},
+		},
+	}
+
+	got := initializeConformanceReport(specName, styleguideId)
+	opts := cmp.Options{
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+	}
+	if !cmp.Equal(want, got, opts) {
+		t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(want, got, opts))
+	}
+}
+
+// This test will catch any changes made to the original severity values.
+func TestInitializeGuidelineReport(t *testing.T) {
+	guidelineId := styleguideId
+	want := &rpc.GuidelineReport{
+		GuidelineId: guidelineId,
+		RuleReportGroups: []*rpc.RuleReportGroup{
+			{
+				Severity:    rpc.Rule_SEVERITY_UNSPECIFIED,
+				RuleReports: make([]*rpc.RuleReport, 0),
+			},
+			{
+				Severity:    rpc.Rule_ERROR,
+				RuleReports: make([]*rpc.RuleReport, 0),
+			},
+			{
+				Severity:    rpc.Rule_WARNING,
+				RuleReports: make([]*rpc.RuleReport, 0),
+			},
+			{
+				Severity:    rpc.Rule_INFO,
+				RuleReports: make([]*rpc.RuleReport, 0),
+			},
+			{
+				Severity:    rpc.Rule_HINT,
+				RuleReports: make([]*rpc.RuleReport, 0),
+			},
+		},
+	}
+
+	got := initializeGuidelineReport(guidelineId)
+	opts := cmp.Options{
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+	}
+	if !cmp.Equal(want, got, opts) {
+		t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(want, got, opts))
+	}
+}
+
+func TestComputeConformanceReport(t *testing.T) {
+	tests := []struct {
+		desc           string
+		linterResponse *rpc.LinterResponse
+		linterMetadata *linterMetadata
+		wantReport     *rpc.ConformanceReport
+	}{
+		// Test basic flow.
+		{
+			desc: "Normal case",
+			linterResponse: &rpc.LinterResponse{
+				Lint: &rpc.Lint{
+					Name: "sample-result",
+					Files: []*rpc.LintFile{
+						{
+							FilePath: "test-result-file",
+							Problems: []*rpc.LintProblem{
+								{
+									Message:    "no-$ref-siblings violated",
+									RuleId:     "no-$ref-siblings",
+									Suggestion: "fix no-$ref-siblings",
+									Location: &rpc.LintLocation{
+										StartPosition: &rpc.LintPosition{LineNumber: 11, ColumnNumber: 25},
+										EndPosition:   &rpc.LintPosition{LineNumber: 11, ColumnNumber: 32},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			linterMetadata: &linterMetadata{
+				name:  "sample-linter",
+				rules: []string{"no-$ref-siblings"},
+				rulesMetadata: map[string]*ruleMetadata{
+					"no-$ref-siblings": {
+						guidelineRule: &rpc.Rule{
+							Id:       "norefsiblings",
+							Severity: rpc.Rule_ERROR,
+						},
+						guideline: &rpc.Guideline{
+							Id:     "refproperties",
+							Status: rpc.Guideline_ACTIVE,
+						},
+					},
+				},
+			},
+			wantReport: func() *rpc.ConformanceReport {
+				conformance := InitReport(t)
+				conformance.Name = fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideId)
+				conformance.StyleguideName = styleguideId
+
+				ruleReportGroups := InitRuleReportGroups(t)
+
+				// Populate the expected severity entry
+				ruleReportGroups[rpc.Rule_ERROR].RuleReports = []*rpc.RuleReport{
+					{
+						RuleId:     "norefsiblings",
+						SpecName:   specName,
+						FileName:   "test-result-file",
+						Suggestion: "fix no-$ref-siblings",
+						Location: &rpc.LintLocation{
+							StartPosition: &rpc.LintPosition{LineNumber: 11, ColumnNumber: 25},
+							EndPosition:   &rpc.LintPosition{LineNumber: 11, ColumnNumber: 32},
+						},
+					},
+				}
+
+				//Populate the expected guideline reports
+				guidelineReports := []*rpc.GuidelineReport{
+					{
+						GuidelineId:      "refproperties",
+						RuleReportGroups: ruleReportGroups,
+					},
+				}
+
+				//Populate the expected status entry
+				conformance.GuidelineReportGroups[rpc.Guideline_ACTIVE].GuidelineReports = guidelineReports
+
+				return conformance
+			}(),
+		},
+		// Test: LinterResponse includes multiple rule violations. Validate that only the once configured in the styleguide show up in the final conformance report.
+		{
+			desc: "Multiple violations",
+			linterResponse: &rpc.LinterResponse{
+				Lint: &rpc.Lint{
+					Name: "sample-result",
+					Files: []*rpc.LintFile{
+						{
+							FilePath: "test-result-file",
+							Problems: []*rpc.LintProblem{
+								{
+									Message:    "tag-description violated",
+									RuleId:     "tag-description",
+									Suggestion: "fix tag-description",
+								},
+								{
+									Message:    "operation-description violated",
+									RuleId:     "operation-description",
+									Suggestion: "fix operation-description",
+								},
+							},
+						},
+					},
+				},
+			},
+			linterMetadata: &linterMetadata{
+				name:  "sample-linter",
+				rules: []string{"operation-description"},
+				rulesMetadata: map[string]*ruleMetadata{
+					"operation-description": {
+						guidelineRule: &rpc.Rule{
+							Id:       "operationdescription",
+							Severity: rpc.Rule_ERROR,
+						},
+						guideline: &rpc.Guideline{
+							Id:     "descriptionproperties",
+							Status: rpc.Guideline_ACTIVE,
+						},
+					},
+				},
+			},
+			wantReport: func() *rpc.ConformanceReport {
+				conformance := InitReport(t)
+				conformance.Name = fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideId)
+				conformance.StyleguideName = styleguideId
+
+				ruleReportGroups := InitRuleReportGroups(t)
+
+				// Populate the expected severity entry
+				ruleReportGroups[rpc.Rule_ERROR].RuleReports = []*rpc.RuleReport{
+					{
+						RuleId:     "operationdescription",
+						SpecName:   specName,
+						FileName:   "test-result-file",
+						Suggestion: "fix operation-description",
+					},
+				}
+
+				//Populate the expected guideline reports
+				guidelineReports := []*rpc.GuidelineReport{
+					{
+						GuidelineId:      "descriptionproperties",
+						RuleReportGroups: ruleReportGroups,
+					},
+				}
+
+				//Populate the expected status entry
+				conformance.GuidelineReportGroups[rpc.Guideline_ACTIVE].GuidelineReports = guidelineReports
+
+				return conformance
+			}(),
+		},
+		// Test: Multiple rules are defined in multiple guidelines, check conformance report gets generated accurately.
+		{
+			desc: "Multiple guidelines",
+			linterResponse: &rpc.LinterResponse{
+				Lint: &rpc.Lint{
+					Name: "sample-result",
+					Files: []*rpc.LintFile{
+						{
+							FilePath: "test-result-file",
+							Problems: []*rpc.LintProblem{
+								{
+									Message:    "tag-description violated",
+									RuleId:     "tag-description",
+									Suggestion: "fix tag-description",
+								},
+								{
+									Message:    "operation-description violated",
+									RuleId:     "operation-description",
+									Suggestion: "fix operation-description",
+								},
+								{
+									Message:    "info-description violated",
+									RuleId:     "info-description",
+									Suggestion: "fix info-description",
+								},
+								{
+									Message:    "description-contains-no-tags violated",
+									RuleId:     "description-contains-no-tags",
+									Suggestion: "fix description-contains-no-tags",
+								},
+								{
+									Message:    "no-$ref-siblings violated",
+									RuleId:     "no-$ref-siblings",
+									Suggestion: "fix no-$ref-siblings",
+								},
+							},
+						},
+					},
+				},
+			},
+			linterMetadata: &linterMetadata{
+				name:  "sample-linter",
+				rules: []string{"operation-description", "tag-description", "info-description", "no-$ref-siblings"},
+				rulesMetadata: map[string]*ruleMetadata{
+					"operation-description": {
+						guidelineRule: &rpc.Rule{
+							Id:       "operationdescription",
+							Severity: rpc.Rule_ERROR,
+						},
+						guideline: &rpc.Guideline{
+							Id:     "descriptionproperties",
+							Status: rpc.Guideline_ACTIVE,
+						},
+					},
+					"tag-description": {
+						guidelineRule: &rpc.Rule{
+							Id:       "tagdescription",
+							Severity: rpc.Rule_WARNING,
+						},
+						guideline: &rpc.Guideline{
+							Id:     "descriptionproperties",
+							Status: rpc.Guideline_ACTIVE,
+						},
+					},
+					"info-description": {
+						guidelineRule: &rpc.Rule{
+							Id:       "infodescription",
+							Severity: rpc.Rule_WARNING,
+						},
+						guideline: &rpc.Guideline{
+							Id:     "descriptionproperties",
+							Status: rpc.Guideline_ACTIVE,
+						},
+					},
+					"no-$ref-siblings": {
+						guidelineRule: &rpc.Rule{
+							Id:       "norefsiblings",
+							Severity: rpc.Rule_ERROR,
+						},
+						guideline: &rpc.Guideline{
+							Id:     "refproperties",
+							Status: rpc.Guideline_PROPOSED,
+						},
+					},
+				},
+			},
+			wantReport: func() *rpc.ConformanceReport {
+				conformance := InitReport(t)
+				conformance.Name = fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideId)
+				conformance.StyleguideName = styleguideId
+
+				ruleReportGroups := InitRuleReportGroups(t)
+
+				// Populate the expected severity entries
+				ruleReportGroups[rpc.Rule_ERROR].RuleReports = []*rpc.RuleReport{
+					{
+						RuleId:     "operationdescription",
+						SpecName:   specName,
+						FileName:   "test-result-file",
+						Suggestion: "fix operation-description",
+					},
+				}
+
+				ruleReportGroups[rpc.Rule_WARNING].RuleReports = []*rpc.RuleReport{
+					{
+						RuleId:     "tagdescription",
+						SpecName:   specName,
+						FileName:   "test-result-file",
+						Suggestion: "fix tag-description",
+					},
+					{
+						RuleId:     "infodescription",
+						SpecName:   specName,
+						FileName:   "test-result-file",
+						Suggestion: "fix info-description",
+					},
+				}
+
+				//Populate the expected guideline reports
+				guidelineReports := []*rpc.GuidelineReport{
+					{
+						GuidelineId:      "descriptionproperties",
+						RuleReportGroups: ruleReportGroups,
+					},
+				}
+				//Populate the expected status entry
+				conformance.GuidelineReportGroups[rpc.Guideline_ACTIVE].GuidelineReports = guidelineReports
+
+				ruleReportGroups = InitRuleReportGroups(t)
+
+				// Populate the expected severity entry
+				ruleReportGroups[rpc.Rule_ERROR].RuleReports = []*rpc.RuleReport{
+					{
+						RuleId:     "norefsiblings",
+						SpecName:   specName,
+						FileName:   "test-result-file",
+						Suggestion: "fix no-$ref-siblings",
+					},
+				}
+
+				//Populate the expected guideline reports
+				guidelineReports = []*rpc.GuidelineReport{
+					{
+						GuidelineId:      "refproperties",
+						RuleReportGroups: ruleReportGroups,
+					},
+				}
+
+				//Populate the expected status entry
+				conformance.GuidelineReportGroups[rpc.Guideline_PROPOSED].GuidelineReports = guidelineReports
+
+				return conformance
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			task := &ComputeConformanceTask{
+				Spec:         &rpc.ApiSpec{Name: specName},
+				StyleguideId: styleguideId,
+			}
+
+			gotReport := initializeConformanceReport(task.Spec.GetName(), task.StyleguideId)
+			guidelineReportsMap := make(map[string]int)
+			task.computeConformanceReport(ctx, gotReport, guidelineReportsMap, test.linterResponse, test.linterMetadata)
+
+			opts := cmp.Options{
+				protocmp.IgnoreFields(&rpc.RuleReport{}),
+				protocmp.Transform(),
+				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+			}
+			if !cmp.Equal(test.wantReport, gotReport, opts) {
+				t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(test.wantReport, gotReport, opts))
+			}
+		})
+	}
+}
+
+// Test the scenario where there are pre-existing entries in the conformance report from other linters.
+func TestPreExistingConformanceReport(t *testing.T) {
+	linterResponse := &rpc.LinterResponse{
+		Lint: &rpc.Lint{
+			Name: "sample-result",
+			Files: []*rpc.LintFile{
+				{
+					FilePath: "test-result-file",
+					Problems: []*rpc.LintProblem{
+						{
+							Message:    "operation-description violated",
+							RuleId:     "operation-description",
+							Suggestion: "fix operation-description",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	linterMetadata := &linterMetadata{
+		name:  "sample-linter",
+		rules: []string{"operation-description"},
+		rulesMetadata: map[string]*ruleMetadata{
+			"operation-description": {
+				guidelineRule: &rpc.Rule{
+					Id:       "operationdescription",
+					Severity: rpc.Rule_ERROR,
+				},
+				guideline: &rpc.Guideline{
+					Id:     "descriptionproperties",
+					Status: rpc.Guideline_ACTIVE,
+				},
+			},
+		},
+	}
+
+	preexistingReport := func() *rpc.ConformanceReport {
+		conformance := InitReport(t)
+		conformance.Name = fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideId)
+		conformance.StyleguideName = styleguideId
+
+		// Populate the preexisting data
+		ruleReportGroups := InitRuleReportGroups(t)
+
+		// Populate the expected severity entry
+		ruleReportGroups[rpc.Rule_ERROR].RuleReports = []*rpc.RuleReport{
+			{
+				RuleId:     "tagdescription",
+				SpecName:   specName,
+				FileName:   "test-result-file",
+				Suggestion: "fix tag-description",
+			},
+		}
+
+		//Populate the expected guideline reports
+		guidelineReports := []*rpc.GuidelineReport{
+			{
+				GuidelineId:      "descriptionproperties",
+				RuleReportGroups: ruleReportGroups,
+			},
+		}
+
+		//Populate the expected status entry
+		conformance.GuidelineReportGroups[rpc.Guideline_ACTIVE].GuidelineReports = guidelineReports
+
+		return conformance
+	}()
+
+	guidelineReportsMap := map[string]int{
+		"descriptionproperties": 0,
+	}
+
+	wantReport := func() *rpc.ConformanceReport {
+		conformance := InitReport(t)
+		conformance.Name = fmt.Sprintf("%s/artifacts/conformance-%s", specName, styleguideId)
+		conformance.StyleguideName = styleguideId
+
+		ruleReportGroups := InitRuleReportGroups(t)
+
+		// Populate the expected severity entry
+		ruleReportGroups[rpc.Rule_ERROR].RuleReports = []*rpc.RuleReport{
+			{
+				RuleId:     "tagdescription",
+				SpecName:   specName,
+				FileName:   "test-result-file",
+				Suggestion: "fix tag-description",
+			},
+			{
+				RuleId:     "operationdescription",
+				SpecName:   specName,
+				FileName:   "test-result-file",
+				Suggestion: "fix operation-description",
+			},
+		}
+
+		//Populate the expected guideline reports
+		guidelineReports := []*rpc.GuidelineReport{
+			{
+				GuidelineId:      "descriptionproperties",
+				RuleReportGroups: ruleReportGroups,
+			},
+		}
+
+		//Populate the expected status entry
+		conformance.GuidelineReportGroups[rpc.Guideline_ACTIVE].GuidelineReports = guidelineReports
+
+		return conformance
+	}()
+
+	ctx := context.Background()
+
+	task := &ComputeConformanceTask{
+		Spec:         &rpc.ApiSpec{Name: specName},
+		StyleguideId: styleguideId,
+	}
+
+	task.computeConformanceReport(ctx, preexistingReport, guidelineReportsMap, linterResponse, linterMetadata)
+
+	opts := cmp.Options{
+		protocmp.IgnoreFields(&rpc.RuleReport{}),
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+	}
+	if !cmp.Equal(wantReport, preexistingReport, opts) {
+		t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(wantReport, preexistingReport, opts))
+	}
+
+}

--- a/cmd/registry/conformance/linter.go
+++ b/cmd/registry/conformance/linter.go
@@ -15,16 +15,9 @@
 package conformance
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"time"
 
-	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
-	"google.golang.org/protobuf/proto"
 )
 
 type ruleMetadata struct {
@@ -53,6 +46,9 @@ func GenerateLinterMetadata(styleguide *rpc.StyleGuide) (map[string]*linterMetad
 		for _, rule := range guideline.GetRules() {
 			// Get the name of the linter associated with the rule.
 			linterName := rule.GetLinter()
+			if len(linterName) == 0 {
+				continue
+			}
 
 			metadata, ok := linterNameToMetadata[linterName]
 			if !ok {
@@ -64,14 +60,19 @@ func GenerateLinterMetadata(styleguide *rpc.StyleGuide) (map[string]*linterMetad
 				linterNameToMetadata[linterName] = metadata
 			}
 
-			//Populate required metadata
-			metadata.rules = append(metadata.rules, rule.GetLinterRulename())
-
-			if _, ok := metadata.rulesMetadata[rule.GetLinterRulename()]; !ok {
-				metadata.rulesMetadata[rule.GetLinterRulename()] = &ruleMetadata{}
+			linterRuleName := rule.GetLinterRulename()
+			if len(linterRuleName) == 0 {
+				continue
 			}
-			metadata.rulesMetadata[rule.GetLinterRulename()].guideline = guideline
-			metadata.rulesMetadata[rule.GetLinterRulename()].guidelineRule = rule
+
+			//Populate required metadata
+			metadata.rules = append(metadata.rules, linterRuleName)
+
+			if _, ok := metadata.rulesMetadata[linterRuleName]; !ok {
+				metadata.rulesMetadata[linterRuleName] = &ruleMetadata{}
+			}
+			metadata.rulesMetadata[linterRuleName].guideline = guideline
+			metadata.rulesMetadata[linterRuleName].guidelineRule = rule
 		}
 	}
 
@@ -79,48 +80,4 @@ func GenerateLinterMetadata(styleguide *rpc.StyleGuide) (map[string]*linterMetad
 		return nil, fmt.Errorf("Empty linter metadata")
 	}
 	return linterNameToMetadata, nil
-}
-
-func invokeLinter(
-	ctx context.Context,
-	specDirectory string,
-	metadata *linterMetadata) (*rpc.LinterResponse, error) {
-
-	// Formulate the request.
-	requestBytes, err := proto.Marshal(&rpc.LinterRequest{
-		SpecDirectory: specDirectory,
-		RuleIds:       metadata.rules,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("Failed marshaling linterRequest, Error: %s ", err)
-	}
-
-	executableName := getLinterBinaryName(metadata.name)
-	cmd := exec.Command(executableName)
-	cmd.Stdin = bytes.NewReader(requestBytes)
-	cmd.Stderr = os.Stderr
-
-	pluginStartTime := time.Now()
-	// Run the linter.
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("Running the plugin %s return error: %s", executableName, err)
-	}
-
-	pluginElapsedTime := time.Since(pluginStartTime)
-	log.Debugf(ctx, "Plugin %s ran in time %s", executableName, pluginElapsedTime)
-
-	// Unmarshal the output bytes into a response object. If there's a failure, log and continue.
-	linterResponse := &rpc.LinterResponse{}
-	err = proto.Unmarshal(output, linterResponse)
-	if err != nil {
-		return nil, fmt.Errorf("Failed unmarshaling LinterResponse (plugins must write log messages to stderr, not stdout): %s", err)
-	}
-
-	// Check if there were any errors in the plugin.
-	if len(linterResponse.GetErrors()) > 0 {
-		return nil, fmt.Errorf("Plugin %s encountered errors: %v", executableName, linterResponse.GetErrors())
-	}
-
-	return linterResponse, nil
 }

--- a/cmd/registry/conformance/linter_test.go
+++ b/cmd/registry/conformance/linter_test.go
@@ -1,0 +1,282 @@
+package conformance
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+var rules = []*rpc.Rule{
+	{
+		Id:             "norefsiblings",
+		Linter:         "sample",
+		LinterRulename: "no-$ref-siblings",
+		Severity:       rpc.Rule_ERROR,
+	},
+	{
+		Id:             "norefcycles",
+		Linter:         "spectral",
+		LinterRulename: "no-ref-cycles",
+		Severity:       rpc.Rule_ERROR,
+	},
+	{
+		Id:             "operationdescription",
+		Linter:         "spectral",
+		LinterRulename: "operation-description",
+		Severity:       rpc.Rule_ERROR,
+	},
+}
+
+func TestGenerateLinterMetadata(t *testing.T) {
+	tests := []struct {
+		desc         string
+		styleguide   *rpc.StyleGuide
+		wantMetadata map[string]*linterMetadata
+		wantErr      bool
+	}{
+		{
+			desc: "Normal case",
+			styleguide: &rpc.StyleGuide{
+				Id:        "openapitest",
+				MimeTypes: []string{"application/x.openapi+gzip;version=3.0.0"},
+				Guidelines: []*rpc.Guideline{
+					{
+						Id:     "refproperties",
+						Rules:  []*rpc.Rule{rules[0]},
+						Status: rpc.Guideline_ACTIVE,
+					},
+				},
+			},
+			wantMetadata: map[string]*linterMetadata{
+				"sample": {
+					name:  "sample",
+					rules: []string{rules[0].GetLinterRulename()},
+					rulesMetadata: map[string]*ruleMetadata{
+						rules[0].GetLinterRulename(): {
+							guidelineRule: rules[0],
+							guideline: &rpc.Guideline{
+								Id:     "refproperties",
+								Rules:  []*rpc.Rule{rules[0]},
+								Status: rpc.Guideline_ACTIVE,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Multiple linters",
+			styleguide: &rpc.StyleGuide{
+				Id:        "openapitest",
+				MimeTypes: []string{"application/x.openapi+gzip;version=3.0.0"},
+				Guidelines: []*rpc.Guideline{
+					{
+						Id:     "descriptionproperties",
+						Rules:  []*rpc.Rule{rules[0], rules[1]},
+						Status: rpc.Guideline_ACTIVE,
+					},
+				},
+			},
+			wantMetadata: map[string]*linterMetadata{
+				"sample": {
+					name:  "sample",
+					rules: []string{rules[0].GetLinterRulename()},
+					rulesMetadata: map[string]*ruleMetadata{
+						rules[0].GetLinterRulename(): {
+							guidelineRule: rules[0],
+							guideline: &rpc.Guideline{
+								Id:     "descriptionproperties",
+								Rules:  []*rpc.Rule{rules[0], rules[1]},
+								Status: rpc.Guideline_ACTIVE,
+							},
+						},
+					},
+				},
+				"spectral": {
+					name:  "spectral",
+					rules: []string{rules[1].GetLinterRulename()},
+					rulesMetadata: map[string]*ruleMetadata{
+						rules[1].GetLinterRulename(): {
+							guidelineRule: rules[1],
+							guideline: &rpc.Guideline{
+								Id:     "descriptionproperties",
+								Rules:  []*rpc.Rule{rules[0], rules[1]},
+								Status: rpc.Guideline_ACTIVE,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Multiple linters guidelines",
+			styleguide: &rpc.StyleGuide{
+				Id:        "openapitest",
+				MimeTypes: []string{"application/x.openapi+gzip;version=3.0.0"},
+				Guidelines: []*rpc.Guideline{
+					{
+						Id:     "refproperties",
+						Rules:  []*rpc.Rule{rules[0], rules[1]},
+						Status: rpc.Guideline_ACTIVE,
+					},
+					{
+						Id:     "descriptionproperties",
+						Rules:  []*rpc.Rule{rules[2]},
+						Status: rpc.Guideline_PROPOSED,
+					},
+				},
+			},
+			wantMetadata: map[string]*linterMetadata{
+				"sample": {
+					name:  "sample",
+					rules: []string{rules[0].GetLinterRulename()},
+					rulesMetadata: map[string]*ruleMetadata{
+						rules[0].GetLinterRulename(): {
+							guidelineRule: rules[0],
+							guideline: &rpc.Guideline{
+								Id:     "refproperties",
+								Rules:  []*rpc.Rule{rules[0], rules[1]},
+								Status: rpc.Guideline_ACTIVE,
+							},
+						},
+					},
+				},
+				"spectral": {
+					name:  "spectral",
+					rules: []string{rules[1].GetLinterRulename(), rules[2].GetLinterRulename()},
+					rulesMetadata: map[string]*ruleMetadata{
+						rules[1].GetLinterRulename(): {
+							guidelineRule: rules[1],
+							guideline: &rpc.Guideline{
+								Id:     "refproperties",
+								Rules:  []*rpc.Rule{rules[0], rules[1]},
+								Status: rpc.Guideline_ACTIVE,
+							},
+						},
+						rules[2].GetLinterRulename(): {
+							guidelineRule: rules[2],
+							guideline: &rpc.Guideline{
+								Id:     "descriptionproperties",
+								Rules:  []*rpc.Rule{rules[2]},
+								Status: rpc.Guideline_PROPOSED,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "Empty metadata",
+			styleguide: &rpc.StyleGuide{
+				Id:        "openapitest",
+				MimeTypes: []string{"application/x.openapi+gzip;version=3.0.0"},
+				Guidelines: []*rpc.Guideline{
+					{
+						Id:     "refproperties",
+						Rules:  []*rpc.Rule{},
+						Status: rpc.Guideline_ACTIVE,
+					},
+				},
+			},
+			wantMetadata: nil,
+			wantErr:      true,
+		},
+		{
+			desc: "Missing linterName",
+			styleguide: &rpc.StyleGuide{
+				Id:        "openapitest",
+				MimeTypes: []string{"application/x.openapi+gzip;version=3.0.0"},
+				Guidelines: []*rpc.Guideline{
+					{
+						Id: "refproperties",
+						Rules: []*rpc.Rule{
+							{
+								Id:             "norefsiblings",
+								LinterRulename: "no-$ref-siblings",
+								Severity:       rpc.Rule_ERROR,
+							},
+						},
+						Status: rpc.Guideline_ACTIVE,
+					},
+				},
+			},
+			wantMetadata: nil,
+			wantErr:      true,
+		},
+		{
+			desc: "Missing linterRuleName",
+			styleguide: &rpc.StyleGuide{
+				Id:        "openapitest",
+				MimeTypes: []string{"application/x.openapi+gzip;version=3.0.0"},
+				Guidelines: []*rpc.Guideline{
+					{
+						Id: "refproperties",
+						Rules: []*rpc.Rule{
+							{
+								Id:       "norefsiblings",
+								Linter:   "spectral",
+								Severity: rpc.Rule_ERROR,
+							},
+							rules[1],
+						},
+						Status: rpc.Guideline_ACTIVE,
+					},
+				},
+			},
+			wantMetadata: map[string]*linterMetadata{
+				"spectral": {
+					name:  "spectral",
+					rules: []string{rules[1].GetLinterRulename()},
+					rulesMetadata: map[string]*ruleMetadata{
+						rules[1].GetLinterRulename(): {
+							guidelineRule: rules[1],
+							guideline: &rpc.Guideline{
+								Id: "refproperties",
+								Rules: []*rpc.Rule{
+									{
+										Id:       "norefsiblings",
+										Linter:   "spectral",
+										Severity: rpc.Rule_ERROR,
+									},
+									rules[1],
+								},
+								Status: rpc.Guideline_ACTIVE,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+
+			gotMetadata, err := GenerateLinterMetadata(test.styleguide)
+
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("Expected GenerateLinterMetadata() to return an error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error from GenerateLinterMetadata(): %s", err)
+				}
+			}
+
+			opts := cmp.Options{
+				protocmp.Transform(),
+				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+				cmp.AllowUnexported(linterMetadata{}),
+				cmp.AllowUnexported(ruleMetadata{}),
+				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
+			}
+			if !cmp.Equal(test.wantMetadata, gotMetadata, opts) {
+				t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(test.wantMetadata, gotMetadata, opts))
+			}
+		})
+	}
+}

--- a/cmd/registry/conformance/test-helpers.go
+++ b/cmd/registry/conformance/test-helpers.go
@@ -1,0 +1,61 @@
+package conformance
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+)
+
+func InitReport(t *testing.T) *rpc.ConformanceReport {
+	t.Helper()
+	return &rpc.ConformanceReport{
+		GuidelineReportGroups: []*rpc.GuidelineReportGroup{
+			{
+				Status:           rpc.Guideline_STATUS_UNSPECIFIED,
+				GuidelineReports: []*rpc.GuidelineReport{},
+			},
+			{
+				Status:           rpc.Guideline_PROPOSED,
+				GuidelineReports: []*rpc.GuidelineReport{},
+			},
+			{
+				Status:           rpc.Guideline_ACTIVE,
+				GuidelineReports: []*rpc.GuidelineReport{},
+			},
+			{
+				Status:           rpc.Guideline_DEPRECATED,
+				GuidelineReports: []*rpc.GuidelineReport{},
+			},
+			{
+				Status:           rpc.Guideline_DISABLED,
+				GuidelineReports: []*rpc.GuidelineReport{},
+			},
+		},
+	}
+}
+
+func InitRuleReportGroups(t *testing.T) []*rpc.RuleReportGroup {
+	t.Helper()
+	return []*rpc.RuleReportGroup{
+		{
+			Severity:    rpc.Rule_SEVERITY_UNSPECIFIED,
+			RuleReports: []*rpc.RuleReport{},
+		},
+		{
+			Severity:    rpc.Rule_ERROR,
+			RuleReports: []*rpc.RuleReport{},
+		},
+		{
+			Severity:    rpc.Rule_WARNING,
+			RuleReports: []*rpc.RuleReport{},
+		},
+		{
+			Severity:    rpc.Rule_INFO,
+			RuleReports: []*rpc.RuleReport{},
+		},
+		{
+			Severity:    rpc.Rule_HINT,
+			RuleReports: []*rpc.RuleReport{},
+		},
+	}
+}

--- a/cmd/registry/controller/local-tasks_test.go
+++ b/cmd/registry/controller/local-tasks_test.go
@@ -15,22 +15,372 @@
 package controller
 
 import (
+	"os"
 	"context"
 	"testing"
+	"fmt"
+	"github.com/apigee/registry/cmd/registry/core"
+	"github.com/apigee/registry/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"github.com/apigee/registry/connection"
+	"github.com/apigee/registry/server/registry/names"
+	"github.com/apigee/registry/rpc"
 )
 
-// Test the error scenario
-func TestErrorCases(t *testing.T) {
+const testProject = "local-tasks-test"
+const specName = "projects/local-tasks-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"
 
-	task := &ExecCommandTask{
-		Action: &Action{
-			Command: "resolve projects/demo/artifacts/test-manifest",
+// This is a fake process which executes the commands passed in test cases
+func TestProcessHelper(t *testing.T) {
+	
+	core.FakeTestProcess(t, func (cmd string, args []string) {
+		switch cmd {
+		case "registry":
+			subCmd := fmt.Sprintf("%s %s", args[0], args[1])
+			if subCmd == "compute lint" {
+				fmt.Fprint(os.Stderr, "compute doesn't have any child command lint")
+				os.Exit(2)
+			} else if subCmd == "compute conformance" {
+				fmt.Printf("Computing conformance report %s/artifacts/conformance-openapi", specName)
+				os.Exit(0)
+			} else if subCmd == "compute complexity" {
+				fmt.Printf("Computing complexity %s/artifacts/complexity", specName)
+				os.Exit(0)
+			} else if subCmd == "compute summary" {
+				fmt.Printf("Computing summary projects/%s/locations/global/artifacts/summary", testProject)
+				os.Exit(0)
+			}
+			fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
+			os.Exit(2)
+		case "swagger-codegen":
+			fmt.Printf("Generating code...")
+			os.Exit(0)
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
+			os.Exit(2)
+		}
+	})
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		desc string
+		task *ExecCommandTask
+		wantErr bool 
+	}{
+		{
+			desc: "Success",
+			task: &ExecCommandTask{
+				Action: &Action{Command: fmt.Sprintf("registry compute complexity %s", specName)},
+				CreateCommand: core.GetFakeCommandGenerator("TestProcessHelper"),
+			},
 		},
-		TaskID: "task0",
+		{
+			desc: "Failure",
+			task: &ExecCommandTask{
+				Action: &Action{Command: fmt.Sprintf("registry compute lint %s", specName)},
+				CreateCommand: core.GetFakeCommandGenerator("TestProcessHelper"),
+			},
+			wantErr: true,
+		},
 	}
-	ctx := context.Background()
-	err := task.Run(ctx)
-	if err == nil {
-		t.Errorf("Expected GetCommand() to return error.")
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			err := test.task.Run(ctx)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("Run() was successful, wanted error")
+				} 
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error from Run(): %s", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteCommand(t *testing.T) {
+
+	tests := []struct {
+		desc           string
+		task *ExecCommandTask
+		wantErr bool
+	}{
+		{
+			desc: "Success",
+			task: &ExecCommandTask{
+				Action: &Action{
+					Command: fmt.Sprintf("registry compute complexity %s", specName),
+				},
+			},
+		},
+		{
+			desc: "Error",
+			task: &ExecCommandTask{
+				Action: &Action{
+					Command: fmt.Sprintf("registry compute lint %s", specName),
+				},
+				// CreateCommand: core.GetFakeCommandGenerator("TestProcessHelper"),
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Resolve Command",
+			task: &ExecCommandTask{
+				Action: &Action{
+					Command: "registry resolve projects/demo/artifacts/test-manifest",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			logger := log.FromContext(ctx)
+
+			//Attach the fake command generator to the task
+			test.task.CreateCommand = core.GetFakeCommandGenerator("TestProcessHelper")
+			err := test.task.ExcecuteCommand(ctx, logger)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("ExecuteCommand() was succcessful, wanted error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error from ExecuteCommand(): %s", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteCommandWithReceipt(t *testing.T) {
+
+	tests := []struct {
+		desc           string
+		task *ExecCommandTask
+		wantErr bool
+		wantReceipt bool
+	}{
+		// Test: Both command execution and receipt creation is successful, overall success.
+		{
+			desc: "Receipt Success",
+			task: &ExecCommandTask{
+				Action: &Action{
+					Command: fmt.Sprintf("registry compute summary projects/%s", testProject),
+					GeneratedResource: fmt.Sprintf("projects/%s/locations/global/artifacts/summary", testProject),
+					RequiresReceipt: true,
+				},
+			},
+			wantReceipt: true,
+		},
+		// Test: Command execution is successful, receipt creation fails, overall error.
+		{
+			desc: "Receipt Failure",
+			task: &ExecCommandTask{
+				Action: &Action{
+					Command: fmt.Sprintf("registry compute conformance %s", specName),
+					GeneratedResource: fmt.Sprintf("%s/artifacts/conformance-openapi",  specName),
+					RequiresReceipt: true,
+				},
+			},
+			wantErr: true,
+			wantReceipt: false,
+		},
+		// Test: Command execution fails, hence receipt should not be created, overall error.
+		{
+			desc: "Command Failure",
+			task:  &ExecCommandTask{
+				Action: &Action{
+					Command: fmt.Sprintf("registry compute score projects/%s",  testProject),
+					GeneratedResource:  fmt.Sprintf("projects/%s/locations/global/artifacts/score", testProject),
+					RequiresReceipt: true,
+				},
+			},
+			wantErr: true,
+			wantReceipt: false,
+		},
+		{
+			desc: "3p Command",
+			task:  &ExecCommandTask{
+				Action: &Action{
+					Command: fmt.Sprintf("swagger-codegen generate -i projects/%s/locatios/global/apis/-/versions/-/specs/- -l csharp",  testProject),
+					GeneratedResource:  fmt.Sprintf("projects/%s/locations/global/artifacts/swagger-codegen", testProject),
+					RequiresReceipt: true,
+				},
+			},
+			wantErr: false,
+			wantReceipt: true,	
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			client, err := connection.NewClient(ctx)
+			if err != nil {
+				t.Fatalf("Setup: Failed to create client: %s", err)
+			}
+
+			adminClient, err := connection.NewAdminClient(ctx)
+			if err != nil {
+				t.Fatalf("Setup: Failed to create client: %s", err)
+			}
+
+			// Setup a project for successful creation of project level summary artifacts
+			err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+				Name:  "projects/" + testProject,
+				Force: true,
+			})
+			if err != nil && status.Code(err) != codes.NotFound {
+				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+
+			_, err = adminClient.CreateProject(ctx, &rpc.CreateProjectRequest{
+				ProjectId: testProject,
+				Project: &rpc.Project{
+					DisplayName: "Demo",
+					Description: "A demo catalog",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create project %s: %s", testProject, err.Error())
+			}
+
+			//Attach the fake command generator to the task
+			test.task.CreateCommand = core.GetFakeCommandGenerator("TestProcessHelper")
+			
+			logger := log.FromContext(ctx)
+			err = test.task.ExcecuteCommand(ctx, logger)
+
+			// Check if error is returned
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("ExecuteCommand() was successful, wanted error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error from ExecuteCommand(): %s", err)
+				}
+			}
+
+			// Check if the artifact is created
+			pattern := test.task.Action.GeneratedResource
+			artifactName, err := names.ParseArtifact(pattern)
+			if err != nil {
+				t.Fatalf("Invalid artifact pattern: %s", pattern)
+			}
+			_, err = core.GetArtifact(ctx, client, artifactName, true, nil)
+
+			if test.wantReceipt {
+				if err != nil {
+					t.Errorf("Expected ExecuteCommand() to create receipt artifact, artifact not found")
+				}
+			} else {
+				if err == nil {
+					t.Errorf("ExecuteCommand() should not create receipt artifact, artifact found")
+				}
+			}
+
+			// Delete the demo project
+			err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+				Name:  "projects/" + testProject,
+				Force: true,
+			})
+			if err != nil && status.Code(err) != codes.NotFound {
+				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+
+		})
+	}
+
+}
+
+func TestTouchArtifact(t *testing.T){
+	tests := []struct {
+		desc    string
+		action string
+		artifactName string
+		wantErr bool
+	}{
+		{
+			desc: "Normal case",
+			action: "registry test action",
+			artifactName: fmt.Sprintf("projects/%s/locations/global/artifacts/summary", testProject),
+			wantErr:  false,
+		},
+		{
+			desc: "SetArtifact Error",
+			action: fmt.Sprintf("registry compute complexity %s", specName),
+			artifactName: fmt.Sprintf("%s/artifacts/complexity", specName),
+			wantErr: true,
+		},
+		{
+			desc: "ProtoMarshal Error",
+			action: "\xa0\xa1", //invalid UTF-8 string for proto.Marshal to fail
+			artifactName: fmt.Sprintf("projects/%s/locations/global/artifacts/summary", testProject),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			adminClient, err := connection.NewAdminClient(ctx)
+			if err != nil {
+				t.Fatalf("Setup: Failed to create client: %s", err)
+			}
+
+			// Setup a project for successful creation of project level summary artifacts
+			err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+				Name:  "projects/" + testProject,
+				Force: true,
+			})
+			if err != nil && status.Code(err) != codes.NotFound {
+				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+
+			_, err = adminClient.CreateProject(ctx, &rpc.CreateProjectRequest{
+				ProjectId: testProject,
+				Project: &rpc.Project{
+					DisplayName: "Demo",
+					Description: "A demo catalog",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create project %s: %s", testProject, err.Error())
+			}
+
+			task := &ExecCommandTask{}
+
+			err = task.touchArtifact(ctx, test.artifactName, test.action)
+			if test.wantErr{
+				if err == nil {
+					t.Errorf("touchArtifact() succeeded, expected error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("touchArtifact() generated unexpected error: %s", err)
+				}
+			}
+
+			// Delete the demo project
+			err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+				Name:  "projects/" + testProject,
+				Force: true,
+			})
+			if err != nil && status.Code(err) != codes.NotFound {
+				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+		})
 	}
 }

--- a/cmd/registry/core/commands.go
+++ b/cmd/registry/core/commands.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"os"
+	"os/exec"
+	"fmt"
+	"testing"
+)
+
+type CommandGenerator func (string, ...string) *exec.Cmd
+
+func GetCommandGenerator() CommandGenerator {
+	return exec.Command
+}
+
+func GetFakeCommandGenerator(fakeProcessName string) CommandGenerator {
+	fakeCommandGenerator := func(name string, args ...string) *exec.Cmd {
+		fakeCommand := []string{fmt.Sprintf("-test.run=%s", fakeProcessName), "--", name}
+		fakeCommand = append(fakeCommand, args...)
+		cmd := exec.Command(os.Args[0], fakeCommand...)
+		cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+		return cmd
+	}
+
+	return fakeCommandGenerator
+}
+
+func FakeTestProcess(t *testing.T, processArgs func(string, []string)) {
+	t.Helper()
+
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	cmd, args := args[0], args[1:]
+	processArgs(cmd, args)
+}


### PR DESCRIPTION
Refactored `exec.Command()` usage.
Added tests for `local-tasks.go` in package controller.

More to follow in this PR:
Tests for `invokeLinter` in package `conformance`.

The testing pattern here is inspired from the test implementation in [exec_test.go](https://go.dev/src/os/exec/exec_test.go)