### PR TITLE
Add tests and decompression support for GetArtifactContents 

### DIFF
--- a/server/registry/actions_artifacts_test.go
+++ b/server/registry/actions_artifacts_test.go
@@ -480,6 +480,57 @@ func TestGetArtifactResponseCodes(t *testing.T) {
 	}
 }
 
+func TestGetArtifactContents(t *testing.T) {
+	tests := []struct {
+		desc string
+		seed *rpc.Artifact
+		req  *rpc.GetArtifactContentsRequest
+		want codes.Code
+	}{
+		{
+			desc: "resource not found",
+			seed: &rpc.Artifact{Name: "projects/my-project/locations/global/artifacts/my-artifact"},
+			req: &rpc.GetArtifactContentsRequest{
+				Name: "projects/my-project/locations/global/artifacts/doesnt-exist",
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "case insensitive identifiers",
+			seed: &rpc.Artifact{Name: "projects/my-project/locations/global/artifacts/my-artifact"},
+			req: &rpc.GetArtifactContentsRequest{
+				Name: "projects/My-Project/locations/global/artifacts/My-Artifact",
+			},
+			want: codes.OK,
+		},
+		{
+			desc: "inappropriate contents suffix in resource name",
+			seed: &rpc.Artifact{
+				Name:     "projects/my-project/locations/global/artifacts/my-artifact",
+				Contents: []byte{},
+			},
+			req: &rpc.GetArtifactContentsRequest{
+				Name: "projects/my-project/locations/global/artifacts/my-artifact/contents",
+			},
+			want: codes.InvalidArgument,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			server := defaultTestServer(t)
+			if err := seeder.SeedArtifacts(ctx, server, test.seed); err != nil {
+				t.Fatalf("Setup/Seeding: Failed to seed registry: %s", err)
+			}
+
+			if _, err := server.GetArtifactContents(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("GetArtifactContents(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
 func TestListArtifacts(t *testing.T) {
 	tests := []struct {
 		desc      string

--- a/server/registry/actions_artifacts_test.go
+++ b/server/registry/actions_artifacts_test.go
@@ -514,6 +514,18 @@ func TestGetArtifactContents(t *testing.T) {
 			},
 			want: codes.InvalidArgument,
 		},
+		{
+			desc: "gzip mimetype with empty contents",
+			seed: &rpc.Artifact{
+				Name:     "projects/my-project/locations/global/artifacts/my-artifact",
+				MimeType: "application/x.openapi+gzip;version=3.0.0",
+				Contents: []byte{},
+			},
+			req: &rpc.GetArtifactContentsRequest{
+				Name: "projects/my-project/locations/global/artifacts/my-artifact",
+			},
+			want: codes.FailedPrecondition,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I noticed we didn't have tests for this RPC method, so I copied the cases from `TestGetApiSpecContents` and adjusted them for the artifact resource type. One of the cases failed, which led me to find that `GetArtifactContents` wasn't decompressing gzipped artifact contents as it [claims to support](https://github.com/apigee/registry/blob/61c5bc7df3a3ddbdb9587ae184b5d26a2931b39e/google/cloud/apigeeregistry/v1/registry_service.proto#L328). This PR adds that functionality and some tests for the method.