### PR TITLE
Update gorm query to fix ordering bug

### DIFF
--- a/server/registry/internal/storage/get.go
+++ b/server/registry/internal/storage/get.go
@@ -64,10 +64,10 @@ func (c *Client) GetSpec(ctx context.Context, name names.Spec) (*models.Spec, er
 		Where("api_id = ?", name.ApiID).
 		Where("version_id = ?", name.VersionID).
 		Where("spec_id = ?", name.SpecID).
-		Order("revision_create_time")
+		Order("revision_create_time desc")
 
 	v := new(models.Spec)
-	if err := op.Last(v).Error; err == gorm.ErrRecordNotFound {
+	if err := op.First(v).Error; err == gorm.ErrRecordNotFound {
 		return nil, status.Errorf(codes.NotFound, "%q not found in database", name)
 	} else if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -114,10 +114,10 @@ func (c *Client) GetDeployment(ctx context.Context, name names.Deployment) (*mod
 		Where("project_id = ?", name.ProjectID).
 		Where("api_id = ?", name.ApiID).
 		Where("deployment_id = ?", name.DeploymentID).
-		Order("revision_create_time")
+		Order("revision_create_time desc")
 
 	v := new(models.Deployment)
-	if err := op.Last(v).Error; err == gorm.ErrRecordNotFound {
+	if err := op.First(v).Error; err == gorm.ErrRecordNotFound {
 		return nil, status.Errorf(codes.NotFound, "%q not found in database", name)
 	} else if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
Unexpectedly, the Last method in GORM's query builder doesn't select the
last row in the query result. Instead, it adds an additional ordering
parameter to order by descending primary key and takes the first row in
the overall query result. With our queries, it has no effect on the
ordering and results in the first row, i.e. the row with the oldest
revision_create_time, being selected.

This fix just reverses the ordering in our query and selects the first
row, so we always pick the most recent revision_create_time.