### PR TITLE
Report controller task errors as warnings and not Fatal

### DIFF
--- a/cmd/registry/cmd/resolve/resolve.go
+++ b/cmd/registry/cmd/resolve/resolve.go
@@ -97,7 +97,7 @@ func Command(ctx context.Context) *cobra.Command {
 			}
 
 			log.Debug(ctx, "Starting execution...")
-			taskQueue, wait := core.WorkerPool(ctx, 64)
+			taskQueue, wait := core.WorkerPoolWithWarnings(ctx, 64)
 			defer wait()
 			// Submit tasks to taskQueue
 			for _, a := range actions {


### PR DESCRIPTION
This is required to reduce the noise in the controller's execution logs.

Currently, if a controller generates 10 actions and even one of those actions fails, we report that error as failure and the `resolve` command returns with exit code 1. This is not a failure of the controller but a task failure. We don't want this to be reported as a controller failure.

Solution: 
Controller will report errors in the following ways:
1. Log `Fatal` errors if the controller is:
    - not able to connect to the registry.
    - not able to fetch the manifest.
    - not able to read the state of the registry.
    and return with non-zero exit code.
2. Report `Warn` if there is error in any of the tasks which executed the actions. The underlying tool which executes the task is already logging error messages for failure. Controller doesn't need to log it again, instead report a warning and return with exit code 0.