### PR TITLE
Upgrade golangci-lint to v1.45 to support Go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.44
+        version: v1.45
         args: --timeout 5m0s
 
     - name: Install


### PR DESCRIPTION
Fixes #511.