### PR TITLE
Add curl, jq to registry-tools

### DIFF
--- a/containers/registry-tools/Dockerfile
+++ b/containers/registry-tools/Dockerfile
@@ -48,7 +48,7 @@ RUN apk update && apk upgrade
 RUN apk add --no-cache ca-certificates
 
 # Copy some commonly-needed tools into the image.
-RUN apk add --no-cache bash git
+RUN apk add --no-cache bash git curl jq
 
 # Copy binaries to the production image from the builder stage.
 COPY --from=builder /app/registry /bin/registry


### PR DESCRIPTION
When writing simple controllers which may be querying information from an external URL it would be easier to just use `curl` instead of having to build a new container on top of registry-tools.

Most of the information returned by registry-tools commands is in JSON format. 'jq' provides an easy way to query the information and use it to build shell scripts