### PR TITLE
Propagate contexts using Cobra in registry tool

### DIFF
--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var (
 		filter    string
 		overwrite bool
@@ -40,6 +40,7 @@ func Command(ctx context.Context) *cobra.Command {
 		Short: "Annotate resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/annotate/annotate_test.go
+++ b/cmd/registry/cmd/annotate/annotate_test.go
@@ -127,7 +127,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for APIs.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{apiName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -145,7 +145,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for versions.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{versionName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -163,7 +163,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for specs.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{specName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -181,7 +181,7 @@ func TestAnnotate(t *testing.T) {
 	}
 	// test annotations for Deployments.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{deploymentName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)

--- a/cmd/registry/cmd/apply/apply.go
+++ b/cmd/registry/cmd/apply/apply.go
@@ -15,7 +15,6 @@
 package apply
 
 import (
-	"context"
 	"errors"
 	"io/fs"
 
@@ -25,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var fileName string
 	var parent string
 	var recursive bool
@@ -34,6 +33,7 @@ func Command(ctx context.Context) *cobra.Command {
 		Short: "Apply patches that add content to the API Registry",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/apply/apply_test.go
+++ b/cmd/registry/cmd/apply/apply_test.go
@@ -66,7 +66,7 @@ func TestApply(t *testing.T) {
 	// FAIL: TestApplyAPIs/Create, not FAIL: TestApply/Create_and_Export_API, or worse FAIL: TestApply.
 	{
 		const filename = "testdata/registry.yaml"
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs([]string{"-f", filename, "--parent", parent})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", cmd.Args, err)
@@ -100,7 +100,7 @@ func TestApply(t *testing.T) {
 	artifacts := []string{"lifecycle", "manifest", "taxonomies"}
 	for _, a := range artifacts {
 		filename := fmt.Sprintf("testdata/%s.yaml", a)
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs([]string{"-f", filename, "--parent", parent})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", cmd.Args, err)

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -32,12 +32,13 @@ import (
 	oas3 "github.com/google/gnostic/openapiv3"
 )
 
-func complexityCommand(ctx context.Context) *cobra.Command {
+func complexityCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "complexity",
 		Short: "Compute complexity metrics of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -15,23 +15,21 @@
 package compute
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compute",
 		Short: "Compute properties of resources in the API Registry",
 	}
 
-	cmd.AddCommand(conformanceCommand(ctx))
-	cmd.AddCommand(complexityCommand(ctx))
-	cmd.AddCommand(lintCommand(ctx))
-	cmd.AddCommand(lintStatsCommand(ctx))
-	cmd.AddCommand(referencesCommand(ctx))
-	cmd.AddCommand(vocabularyCommand(ctx))
+	cmd.AddCommand(conformanceCommand())
+	cmd.AddCommand(complexityCommand())
+	cmd.AddCommand(lintCommand())
+	cmd.AddCommand(lintStatsCommand())
+	cmd.AddCommand(referencesCommand())
+	cmd.AddCommand(vocabularyCommand())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	return cmd

--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -29,7 +29,7 @@ import (
 
 const styleguideFilter = "mime_type.contains('google.cloud.apigeeregistry.applications.v1alpha1.StyleGuide')"
 
-func conformanceCommand(ctx context.Context) *cobra.Command {
+func conformanceCommand() *cobra.Command {
 	var filter string
 
 	cmd := &cobra.Command{
@@ -37,6 +37,7 @@ func conformanceCommand(ctx context.Context) *cobra.Command {
 		Short: "Compute lint results for API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/compute/conformance_test.go
+++ b/cmd/registry/cmd/compute/conformance_test.go
@@ -421,13 +421,13 @@ func TestConformance(t *testing.T) {
 
 			// Upload the styleguide to registry
 			args := []string{"styleguide", test.conformancePath, "--project-id=" + testProject}
-			uploadCmd := upload.Command(ctx)
+			uploadCmd := upload.Command()
 			uploadCmd.SetArgs(args)
 			if err = uploadCmd.Execute(); err != nil {
 				t.Fatalf("Failed to upload the styleguide: %s", err)
 			}
 
-			conformanceCmd := conformanceCommand(ctx)
+			conformanceCmd := conformanceCommand()
 
 			args = []string{spec.Name}
 			conformanceCmd.SetArgs(args)

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -27,13 +27,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func lintCommand(ctx context.Context) *cobra.Command {
+func lintCommand() *cobra.Command {
 	var linter string
 	cmd := &cobra.Command{
 		Use:   "lint",
 		Short: "Compute lint results for API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -35,13 +35,14 @@ func lintStatsRelation(linter string) string {
 	return "lintstats-" + linter
 }
 
-func lintStatsCommand(ctx context.Context) *cobra.Command {
+func lintStatsCommand() *cobra.Command {
 	var linter string
 	cmd := &cobra.Command{
 		Use:   "lintstats",
 		Short: "Compute summaries of linter runs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -27,12 +27,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func referencesCommand(ctx context.Context) *cobra.Command {
+func referencesCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "references",
 		Short: "Compute references of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -33,12 +33,13 @@ import (
 	oas3 "github.com/google/gnostic/openapiv3"
 )
 
-func vocabularyCommand(ctx context.Context) *cobra.Command {
+func vocabularyCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "vocabulary",
 		Short: "Compute vocabularies of API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/count/count.go
+++ b/cmd/registry/cmd/count/count.go
@@ -15,19 +15,17 @@
 package count
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "count",
 		Short: "Count quantities in the API Registry",
 	}
 
-	cmd.AddCommand(revisionsCommand(ctx))
-	cmd.AddCommand(versionsCommand(ctx))
+	cmd.AddCommand(revisionsCommand())
+	cmd.AddCommand(versionsCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/count/revisions.go
+++ b/cmd/registry/cmd/count/revisions.go
@@ -28,13 +28,14 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-func revisionsCommand(ctx context.Context) *cobra.Command {
+func revisionsCommand() *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "revisions",
 		Short: "Count the number of revisions of specified resources",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -28,13 +28,14 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-func versionsCommand(ctx context.Context) *cobra.Command {
+func versionsCommand() *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "versions",
 		Short: "Count the number of versions of specified APIs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -27,13 +27,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete resources from the API Registry",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/diff/diff.go
+++ b/cmd/registry/cmd/diff/diff.go
@@ -32,12 +32,13 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Compare resources in the registry",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/export/csv.go
+++ b/cmd/registry/cmd/export/csv.go
@@ -15,7 +15,6 @@
 package export
 
 import (
-	"context"
 	"encoding/csv"
 	"fmt"
 
@@ -34,7 +33,7 @@ type exportCSVRow struct {
 	ContentsPath string
 }
 
-func csvCommand(ctx context.Context) *cobra.Command {
+func csvCommand() *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "csv [--filter expression] parent ...",
@@ -49,6 +48,7 @@ func csvCommand(ctx context.Context) *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/export/csv_test.go
+++ b/cmd/registry/cmd/export/csv_test.go
@@ -92,7 +92,7 @@ func TestExportCSV(t *testing.T) {
 	}
 
 	// Execute
-	cmd := Command(ctx)
+	cmd := Command()
 	out := bytes.NewBuffer(make([]byte, 0))
 	args := []string{"csv", version.GetName()}
 	cmd.SetOutput(out)

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -15,20 +15,18 @@
 package export
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export resources from the API Registry",
 	}
 
-	cmd.AddCommand(csvCommand(ctx))
-	cmd.AddCommand(sheetCommand(ctx))
-	cmd.AddCommand(yamlCommand(ctx))
+	cmd.AddCommand(csvCommand())
+	cmd.AddCommand(sheetCommand())
+	cmd.AddCommand(yamlCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/export/sheet.go
+++ b/cmd/registry/cmd/export/sheet.go
@@ -32,7 +32,7 @@ import (
 	metrics "github.com/google/gnostic/metrics"
 )
 
-func sheetCommand(ctx context.Context) *cobra.Command {
+func sheetCommand() *cobra.Command {
 	var (
 		filter   string
 		artifact string
@@ -43,6 +43,7 @@ func sheetCommand(ctx context.Context) *cobra.Command {
 		Short: "Export a specified artifact to a Google sheet",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			var path string
 			client, err := connection.NewClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/export/yaml.go
+++ b/cmd/registry/cmd/export/yaml.go
@@ -24,15 +24,15 @@ import (
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
-func yamlCommand(ctx context.Context) *cobra.Command {
+func yamlCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "yaml",
 		Short: "Export a subtree of the registry to a YAML file",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -15,8 +15,6 @@
 package get
 
 import (
-	"context"
-
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
@@ -24,13 +22,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var getContents bool
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get resources from the API Registry",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -27,13 +27,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "index",
 		Short: "Operate on API indexes in the API Registry",
 	}
 
-	cmd.AddCommand(unionCommand(ctx))
+	cmd.AddCommand(unionCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/index/union.go
+++ b/cmd/registry/cmd/index/union.go
@@ -15,15 +15,13 @@
 package index
 
 import (
-	"context"
-
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
 	"github.com/spf13/cobra"
 )
 
-func unionCommand(ctx context.Context) *cobra.Command {
+func unionCommand() *cobra.Command {
 	var (
 		filter string
 		output string
@@ -34,6 +32,7 @@ func unionCommand(ctx context.Context) *cobra.Command {
 		Short: "Compute the union of specified API indexes",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var (
 		filter    string
 		overwrite bool
@@ -40,6 +40,7 @@ func Command(ctx context.Context) *cobra.Command {
 		Short: "Label resources in the API Registry",
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/label/label_test.go
+++ b/cmd/registry/cmd/label/label_test.go
@@ -127,7 +127,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for APIs.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{apiName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -145,7 +145,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for versions.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{versionName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -163,7 +163,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for specs.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{specName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)
@@ -181,7 +181,7 @@ func TestLabel(t *testing.T) {
 	}
 	// test labels for Deployments.
 	for _, tc := range testCases {
-		cmd := Command(ctx)
+		cmd := Command()
 		cmd.SetArgs(append([]string{deploymentName}, tc.args...))
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() with args %+v returned error: %s", tc.args, err)

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -26,13 +26,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List resources in the API Registry",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/resolve/resolve.go
+++ b/cmd/registry/cmd/resolve/resolve.go
@@ -53,13 +53,14 @@ func fetchManifest(
 	return manifest, nil
 }
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "resolve MANIFEST_RESOURCE",
 		Short: "resolve the dependencies and update the registry state (experimental)",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			name, err := names.ParseArtifact(args[0])
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Invalid manifest resource name")

--- a/cmd/registry/cmd/resolve/resolve_test.go
+++ b/cmd/registry/cmd/resolve/resolve_test.go
@@ -231,13 +231,13 @@ func TestResolve(t *testing.T) {
 
 			// Upload the manifest to registry
 			args := []string{"manifest", test.manifestPath, "--project-id=" + testProject}
-			uploadCmd := upload.Command(ctx)
+			uploadCmd := upload.Command()
 			uploadCmd.SetArgs(args)
 			if err = uploadCmd.Execute(); err != nil {
 				t.Fatalf("Failed to upload the manifest: %s", err)
 			}
 
-			resolveCmd := Command(ctx)
+			resolveCmd := Command()
 
 			args = []string{"projects/" + testProject + "/locations/global/artifacts/test-manifest"}
 			if test.dryRun {

--- a/cmd/registry/cmd/root.go
+++ b/cmd/registry/cmd/root.go
@@ -15,9 +15,6 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/apigee/registry/cmd/registry/cmd/annotate"
 	"github.com/apigee/registry/cmd/registry/cmd/apply"
 	"github.com/apigee/registry/cmd/registry/cmd/compute"
@@ -32,37 +29,29 @@ import (
 	"github.com/apigee/registry/cmd/registry/cmd/resolve"
 	"github.com/apigee/registry/cmd/registry/cmd/upload"
 	"github.com/apigee/registry/cmd/registry/cmd/vocabulary"
-	"github.com/apigee/registry/log"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "registry",
 		Short: "A simple and eclectic utility for working with the API Registry",
 	}
 
-	// Bind a logger instance to the local context with metadata for outbound requests.
-	logger := log.NewLogger(log.DebugLevel)
-	ctx = log.NewOutboundContext(log.NewContext(ctx, logger), log.Metadata{
-		UID: fmt.Sprintf("%.8s", uuid.New()),
-	})
-
-	cmd.AddCommand(annotate.Command(ctx))
-	cmd.AddCommand(apply.Command(ctx))
-	cmd.AddCommand(compute.Command(ctx))
-	cmd.AddCommand(count.Command(ctx))
-	cmd.AddCommand(resolve.Command(ctx))
-	cmd.AddCommand(delete.Command(ctx))
-	cmd.AddCommand(diff.Command(ctx))
-	cmd.AddCommand(export.Command(ctx))
-	cmd.AddCommand(get.Command(ctx))
-	cmd.AddCommand(index.Command(ctx))
-	cmd.AddCommand(label.Command(ctx))
-	cmd.AddCommand(list.Command(ctx))
-	cmd.AddCommand(upload.Command(ctx))
-	cmd.AddCommand(vocabulary.Command(ctx))
+	cmd.AddCommand(annotate.Command())
+	cmd.AddCommand(apply.Command())
+	cmd.AddCommand(compute.Command())
+	cmd.AddCommand(count.Command())
+	cmd.AddCommand(resolve.Command())
+	cmd.AddCommand(delete.Command())
+	cmd.AddCommand(diff.Command())
+	cmd.AddCommand(export.Command())
+	cmd.AddCommand(get.Command())
+	cmd.AddCommand(index.Command())
+	cmd.AddCommand(label.Command())
+	cmd.AddCommand(list.Command())
+	cmd.AddCommand(upload.Command())
+	cmd.AddCommand(vocabulary.Command())
 
 	return cmd
 }

--- a/cmd/registry/cmd/root_test.go
+++ b/cmd/registry/cmd/root_test.go
@@ -25,7 +25,7 @@ import (
 // Test that currently supported commands in the registry tool execute successfully in ExecCommandTask
 func TestCommandCoverage(t *testing.T) {
 	ctx := context.Background()
-	rootCmd := Command(ctx)
+	rootCmd := Command()
 
 	// Submit tasks to taskQueue
 	for i, cmd := range rootCmd.Commands() {

--- a/cmd/registry/cmd/upload/artifact.go
+++ b/cmd/registry/cmd/upload/artifact.go
@@ -31,13 +31,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func artifactCommand(ctx context.Context) *cobra.Command {
+func artifactCommand() *cobra.Command {
 	var parent string
 	cmd := &cobra.Command{
 		Use:   "artifact FILE_PATH --parent=value",
 		Short: "Upload an artifact",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			artifactFilePath := args[0]
 			if artifactFilePath == "" {
 				log.Fatal(ctx, "Please provide a FILE_PATH for an artifact")

--- a/cmd/registry/cmd/upload/artifact_test.go
+++ b/cmd/registry/cmd/upload/artifact_test.go
@@ -90,7 +90,7 @@ func TestManifestArtifactUpload(t *testing.T) {
 				t.Fatalf("Failed to create project %s: %s", test.project, err.Error())
 			}
 
-			cmd := Command(ctx)
+			cmd := Command()
 			args := []string{"artifact", test.filePath, "--parent", fmt.Sprintf("projects/%s/locations/global", test.project)}
 			cmd.SetArgs(args)
 			if err = cmd.Execute(); err != nil {

--- a/cmd/registry/cmd/upload/bulk/bulk.go
+++ b/cmd/registry/cmd/upload/bulk/bulk.go
@@ -15,20 +15,18 @@
 package bulk
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bulk",
 		Short: "Bulk-upload API specs of selected styles",
 	}
 
-	cmd.AddCommand(discoveryCommand(ctx))
-	cmd.AddCommand(openAPICommand(ctx))
-	cmd.AddCommand(protosCommand(ctx))
+	cmd.AddCommand(discoveryCommand())
+	cmd.AddCommand(openAPICommand())
+	cmd.AddCommand(protosCommand())
 
 	cmd.PersistentFlags().String("project-id", "", "Project ID to use for each upload")
 	_ = cmd.MarkFlagRequired("project-id")

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -31,11 +31,12 @@ import (
 	discovery "github.com/google/gnostic/discovery"
 )
 
-func discoveryCommand(ctx context.Context) *cobra.Command {
+func discoveryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "discovery",
 		Short: "Bulk-upload API Discovery documents from the Google API Discovery service",
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			projectID, err := cmd.Flags().GetString("project-id")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get project-id from flags")

--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -34,13 +34,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func openAPICommand(ctx context.Context) *cobra.Command {
+func openAPICommand() *cobra.Command {
 	var baseURI string
 	cmd := &cobra.Command{
 		Use:   "openapi",
 		Short: "Bulk-upload OpenAPI descriptions from a directory of specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			projectID, err := cmd.Flags().GetString("project-id")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get project-id from flags")

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -48,13 +48,14 @@ type ServiceConfig struct {
 	} `yaml:"documentation"`
 }
 
-func protosCommand(ctx context.Context) *cobra.Command {
+func protosCommand() *cobra.Command {
 	var baseURI string
 	cmd := &cobra.Command{
 		Use:   "protos",
 		Short: "Bulk-upload Protocol Buffer descriptions from a directory of specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			projectID, err := cmd.Flags().GetString("project-id")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get project-id from flags")

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func csvCommand(ctx context.Context) *cobra.Command {
+func csvCommand() *cobra.Command {
 	var (
 		projectID string
 		delimiter string
@@ -44,6 +44,7 @@ func csvCommand(ctx context.Context) *cobra.Command {
 		Short: "Upload API specs from a CSV file",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			if len(delimiter) != 1 {
 				log.Fatalf(ctx, "Invalid delimiter %q: must be exactly one character", delimiter)
 			}

--- a/cmd/registry/cmd/upload/csv_test.go
+++ b/cmd/registry/cmd/upload/csv_test.go
@@ -137,7 +137,7 @@ func TestUploadCSV(t *testing.T) {
 
 			args := append([]string{"csv"}, test.args...)
 
-			cmd := Command(ctx)
+			cmd := Command()
 			cmd.SetArgs(args)
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("Execute() with args %v returned error: %s", args, err)

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -15,7 +15,6 @@
 package upload
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 
@@ -48,13 +47,14 @@ func readManifestProto(filename string) (*rpc.Manifest, error) {
 	return m, nil
 }
 
-func manifestCommand(ctx context.Context) *cobra.Command {
+func manifestCommand() *cobra.Command {
 	var projectID string
 	cmd := &cobra.Command{
 		Use:   "manifest FILE_PATH --project-id=value",
 		Short: "Upload a dependency manifest",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			manifestPath := args[0]
 			if manifestPath == "" {
 				log.Fatal(ctx, "Please provide manifest-path")

--- a/cmd/registry/cmd/upload/manifest_test.go
+++ b/cmd/registry/cmd/upload/manifest_test.go
@@ -90,7 +90,7 @@ func TestManifestUpload(t *testing.T) {
 				t.Fatalf("Failed to create project %s: %s", test.project, err.Error())
 			}
 
-			cmd := Command(ctx)
+			cmd := Command()
 			args := []string{"manifest", test.filePath, "--project-id", test.project}
 			cmd.SetArgs(args)
 			if err = cmd.Execute(); err != nil {

--- a/cmd/registry/cmd/upload/spec.go
+++ b/cmd/registry/cmd/upload/spec.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func specCommand(ctx context.Context) *cobra.Command {
+func specCommand() *cobra.Command {
 	var (
 		version string
 		style   string
@@ -43,6 +43,7 @@ func specCommand(ctx context.Context) *cobra.Command {
 		Short: "Upload an API spec",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -15,7 +15,6 @@
 package upload
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 
@@ -51,13 +50,14 @@ func readStyleGuideProto(filename string) (*rpc.StyleGuide, error) {
 	return m, nil
 }
 
-func styleGuideCommand(ctx context.Context) *cobra.Command {
+func styleGuideCommand() *cobra.Command {
 	var projectID string
 	cmd := &cobra.Command{
 		Use:   "styleguide FILE_PATH --project-id=value",
 		Short: "Upload an API style guide",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			styleGuidePath := args[0]
 			if styleGuidePath == "" {
 				log.Fatal(ctx, "Please provide style guide path")

--- a/cmd/registry/cmd/upload/styleguide_test.go
+++ b/cmd/registry/cmd/upload/styleguide_test.go
@@ -101,7 +101,7 @@ func TestStyleGuideUpload(t *testing.T) {
 				t.Fatalf("Failed to create project %s: %s", test.project, err.Error())
 			}
 
-			cmd := Command(ctx)
+			cmd := Command()
 			args := []string{"styleguide", test.filePath, "--project-id", test.project}
 			cmd.SetArgs(args)
 			if err = cmd.Execute(); err != nil {

--- a/cmd/registry/cmd/upload/upload.go
+++ b/cmd/registry/cmd/upload/upload.go
@@ -15,24 +15,22 @@
 package upload
 
 import (
-	"context"
-
 	"github.com/apigee/registry/cmd/registry/cmd/upload/bulk"
 	"github.com/spf13/cobra"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upload",
 		Short: "Upload information to the API Registry",
 	}
 
-	cmd.AddCommand(artifactCommand(ctx))
-	cmd.AddCommand(bulk.Command(ctx))
-	cmd.AddCommand(csvCommand(ctx))
-	cmd.AddCommand(manifestCommand(ctx))
-	cmd.AddCommand(specCommand(ctx))
-	cmd.AddCommand(styleGuideCommand(ctx))
+	cmd.AddCommand(artifactCommand())
+	cmd.AddCommand(bulk.Command())
+	cmd.AddCommand(csvCommand())
+	cmd.AddCommand(manifestCommand())
+	cmd.AddCommand(specCommand())
+	cmd.AddCommand(styleGuideCommand())
 
 	return cmd
 }

--- a/cmd/registry/cmd/vocabulary/difference.go
+++ b/cmd/registry/cmd/vocabulary/difference.go
@@ -15,8 +15,6 @@
 package vocabulary
 
 import (
-	"context"
-
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
@@ -24,12 +22,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func differenceCommand(ctx context.Context) *cobra.Command {
+func differenceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "difference",
 		Short: "Compute the difference of specified API vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/vocabulary/intersection.go
+++ b/cmd/registry/cmd/vocabulary/intersection.go
@@ -15,8 +15,6 @@
 package vocabulary
 
 import (
-	"context"
-
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
@@ -24,12 +22,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func intersectionCommand(ctx context.Context) *cobra.Command {
+func intersectionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "intersection",
 		Short: "Compute the intersection of specified API vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/vocabulary/union.go
+++ b/cmd/registry/cmd/vocabulary/union.go
@@ -15,8 +15,6 @@
 package vocabulary
 
 import (
-	"context"
-
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
 	"github.com/apigee/registry/log"
@@ -24,12 +22,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func unionCommand(ctx context.Context) *cobra.Command {
+func unionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "union",
 		Short: "Compute the union of specified API vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/vocabulary/unique.go
+++ b/cmd/registry/cmd/vocabulary/unique.go
@@ -15,7 +15,6 @@
 package vocabulary
 
 import (
-	"context"
 	"path/filepath"
 	"strings"
 
@@ -26,13 +25,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func uniqueCommand(ctx context.Context) *cobra.Command {
+func uniqueCommand() *cobra.Command {
 	var outputID string
 	cmd := &cobra.Command{
 		Use:   "unique",
 		Short: "Compute the unique subsets of each member of specified vocabularies",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/vocabulary/versions.go
+++ b/cmd/registry/cmd/vocabulary/versions.go
@@ -15,7 +15,6 @@
 package vocabulary
 
 import (
-	"context"
 	"strings"
 
 	"github.com/apigee/registry/cmd/registry/core"
@@ -25,12 +24,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func versionsCommand(ctx context.Context) *cobra.Command {
+func versionsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "versions",
 		Short: "Compute the differences in API vocabularies associated with successive API versions",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -29,17 +29,17 @@ import (
 	metrics "github.com/google/gnostic/metrics"
 )
 
-func Command(ctx context.Context) *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vocabulary",
 		Short: "Operate on API vocabularies in the API Registry",
 	}
 
-	cmd.AddCommand(differenceCommand(ctx))
-	cmd.AddCommand(intersectionCommand(ctx))
-	cmd.AddCommand(unionCommand(ctx))
-	cmd.AddCommand(uniqueCommand(ctx))
-	cmd.AddCommand(versionsCommand(ctx))
+	cmd.AddCommand(differenceCommand())
+	cmd.AddCommand(intersectionCommand())
+	cmd.AddCommand(unionCommand())
+	cmd.AddCommand(uniqueCommand())
+	cmd.AddCommand(versionsCommand())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	return cmd

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -20,12 +20,19 @@ import (
 	"os"
 
 	"github.com/apigee/registry/cmd/registry/cmd"
+	"github.com/apigee/registry/log"
+	"github.com/google/uuid"
 )
 
 func main() {
-	ctx := context.Background()
-	cmd := cmd.Command(ctx)
-	if err := cmd.Execute(); err != nil {
+	// Bind a logger instance to the local context with metadata for outbound requests.
+	logger := log.NewLogger(log.DebugLevel)
+	ctx := log.NewOutboundContext(log.NewContext(context.Background(), logger), log.Metadata{
+		UID: fmt.Sprintf("%.8s", uuid.New()),
+	})
+
+	cmd := cmd.Command()
+	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
We didn't need to use function closures to pass the main program's
context into each command. Cobra already has a mechanism for this,
allowing the caller to decide whether to provide a custom context using
ExecuteContext or default to a background context by using Execute.

Our tests don't need to specify a custom context, so they will continue
using Execute to provide a default context. The main program will use a
custom context to set up application-wide features like logging.