### PR TITLE
Fix a few small problems in the top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ automatically published as a JSON REST API using a proxy. Proxies also enable
 [gRPC web](https://github.com/grpc/grpc-web), which allows gRPC calls to be
 directly made from browser-based applications. A configuration for the
 [Envoy](https://www.envoyproxy.io/) proxy is included
-([deployments/envoy/envoy.yaml](deployments/envoy/envoy.yaml)) along with
-scripts to build and deploy the Registry API server and a proxy in a single
-container on Google Cloud Run.
+([deployments/envoy/envoy.yaml](deployments/envoy/envoy.yaml)).
 
 The Registry API protos also include configuration to support
 [generated API clients (GAPICS)](https://googleapis.github.io/gapic-generators/),
@@ -71,14 +69,15 @@ The entry point for the Registry API server itself is
 The following tools are needed to build this software:
 
 - Go 1.18 (recommended) or later.
-- protoc, the Protocol Buffer Compiler, version 3.19.3.
+- protoc, the Protocol Buffer Compiler (see
+  [tools/PROTOC-VERSION.sh](/tools/PROTOC-VERSION.sh) for the currently-used
+  version).
 - make, git, and other elements of common unix build environments.
 
-This repository contains a Makefile that downloads all other dependencies and
-builds this software (`make all`). With dependencies downloaded, subsequent
-builds can be made with `go install ./...` or `make lite`. The Makefile also
-includes targets that build and deploy the API on
-[Google Cloud Run](https://cloud.google.com/run) (see below).
+This repository contains a [Makefile](/Makefile) that downloads all other
+dependencies and builds this software (`make all`). With dependencies
+downloaded, subsequent builds can be made with `go install ./...` or
+`make lite`.
 
 ## Quickstart
 

--- a/tests/demo/walkthrough.sh
+++ b/tests/demo/walkthrough.sh
@@ -38,7 +38,7 @@ apg registry create-api \
     --parent projects/demo/locations/global \
     --api_id petstore \
     --api.availability GENERAL \
-    --api.recommended_version "1.0.0" \
+    --api.recommended_version "projects/demo/locations/global/apis/petstore/versions/1.0.0" \
     --json
 
 echo
@@ -212,6 +212,6 @@ apg registry create-artifact \
     --json
 
 echo
-echo Export a YAML summary of the demo project.
-registry export yaml projects/demo > demo.yaml
-cat demo.yaml
+echo Export a YAML description of the demo project.
+registry export yaml projects/demo
+cat demo/apis/petstore.yaml


### PR DESCRIPTION
This removes a README reference to Cloud Run configuration in the Makefile (deprecated, to be moved to registry-experimental), updates the README to refer to tools/PROTOC_VERSION.sh for the currently-used protoc version, and fixes a bug in the tests/demo/walkthrough.sh script (see also #556).