### PR TITLE
Fix lingering references to the apg tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # Mark files as generated.
 # GitHub diffs will display changes to these files differently.
 # https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
-cmd/apg/*.go linguist-generated=true
+cmd/registry/cmd/rpc/generated/*.go linguist-generated=true
 gapic/*.go linguist-generated=true
 rpc/*.pb.go linguist-generated=true
 deployments/envoy/*.pb linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -50,15 +50,9 @@ is generated as part of the build process using
 sample Go GAPIC-based client is in
 [examples/gapic-client](examples/gapic-client).
 
-Two command-line interfaces are included:
-
-- [cmd/apg](cmd/apg), automatically generated from the API description using
-  the
-  [protoc-gen-go_cli](https://github.com/googleapis/gapic-generator-go/tree/master/cmd/protoc-gen-go_cli)
-  tool in
-  [gapic-generator-go](https://github.com/googleapis/gapic-generator-go).
-- [cmd/registry](cmd/registry), a hand-written command-line tool that uses the
-  Go GAPIC library to support additional API management tasks.
+A command-line interface is in [cmd/registry](cmd/registry) and provides a
+mixture of hand-written high-level features and automatically generated
+subcommands that call individual RPC methods of the Registry API.
 
 The entry point for the Registry API server itself is
 [cmd/registry-server](cmd/registry-server). For more on running the server, see
@@ -91,10 +85,9 @@ server with the following:
 
 `. auth/LOCAL.sh`
 
-Now you can check your server and configuration with the
-automatically-generated `apg` client:
+Now you can check your server and configuration with the `registry` tool:
 
-`apg admin get-status`
+`registry rpc admin get-status`
 
 Next run a suite of tests with `make test` and see a corresponding walkthrough
 of API features in [tests/demo/walkthrough.sh](tests/demo/walkthrough.sh). For

--- a/auth/README.md
+++ b/auth/README.md
@@ -2,8 +2,8 @@
 
 This directory contains scripts that can be used to set environment variables
 containing credentials and server information. These environment variables are
-used by `apg`, `registry`, and other tools to configure their connections to
-the `registry-server`.
+used by `registry` and other tools to configure their connections to the
+`registry-server`.
 
 - [LOCAL.sh](LOCAL.sh) configures clients to work with a locally-running
   `registry-server`.

--- a/cmd/registry/README.md
+++ b/cmd/registry/README.md
@@ -1,8 +1,8 @@
 # registry
 
-`registry` is a handwritten command line interface for the Registry API that
-provides high-level features that are not in the automatically-generated `apg`
-tool.
+`registry` is a line interface for the Registry API that provides a mixture of
+high-level features and automatically-generated subcommands that call methods
+of the Registry API.
 
 ## Usage
 

--- a/tools/registry-decode-spec/main.go
+++ b/tools/registry-decode-spec/main.go
@@ -27,7 +27,7 @@ import (
 
 // This is equivalent to running
 //  base64 --decode | gunzip
-// to decode specs returned by the apg tool, with an additional effort to
+// to decode specs returned by the `registry rpc` subcommands, with an additional effort to
 // handle the hex-encoded inputs produced by registry-encode-spec.
 func main() {
 	// decode the spec


### PR DESCRIPTION
Some of these changes were in #571, now on hold.