### PR TITLE
Tweak setup-project.sh to minimize confusion.

### DIFF
--- a/demos/setup-project.sh
+++ b/demos/setup-project.sh
@@ -22,8 +22,9 @@ PROJECT=sample
 # Self-hosted (open source) installations require project creation.
 
 # Delete and re-create the project to get a fresh start.
-registry rpc admin delete-project --name projects/$PROJECT --force
+registry rpc admin delete-project --name projects/$PROJECT --force >& /dev/null
 registry rpc admin create-project --project_id $PROJECT \
 	--project.display_name $PROJECT \
-	--project.description "A registry project"
+	--project.description "A registry project" \
+	--json
 


### PR DESCRIPTION
This recently-added demo script uses `registry rpc admin` subcommands to delete a project (if it exists) and create a new one.

Errors in the delete command will occur if the project doesn't already exist, so to reduce confusion we suppress those by redirecting stdout/stderr to /dev/null. Errors other than NOT_FOUND will likely be reported by the subsequent create command, which gets a `--json` flag to make its output more readable.