### PR TITLE
Dry run support in compute command

### DIFF
--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -131,19 +131,14 @@ func (task *computeComplexityTask) Run(ctx context.Context) error {
 
 	if task.dryRun {
 		core.PrintMessage(complexity)
-	} else {
-		subject := task.specName
-		messageData, _ := proto.Marshal(complexity)
-		artifact := &rpc.Artifact{
-			Name:     subject + "/artifacts/" + relation,
-			MimeType: core.MimeTypeForMessageType("gnostic.metrics.Complexity"),
-			Contents: messageData,
-		}
-		err = core.SetArtifact(ctx, task.client, artifact)
-		if err != nil {
-			return err
-		}
+		return nil
 	}
-
-	return nil
+	subject := task.specName
+	messageData, _ := proto.Marshal(complexity)
+	artifact := &rpc.Artifact{
+		Name:     subject + "/artifacts/" + relation,
+		MimeType: core.MimeTypeForMessageType("gnostic.metrics.Complexity"),
+		Contents: messageData,
+	}
+	return core.SetArtifact(ctx, task.client, artifact)
 }

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -34,5 +34,6 @@ func Command() *cobra.Command {
 	cmd.AddCommand(vocabularyCommand())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and not uploaded to registry")
 	return cmd
 }

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -34,6 +34,6 @@ func Command() *cobra.Command {
 	cmd.AddCommand(vocabularyCommand())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and not uploaded to registry")
+	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
 	return cmd
 }

--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -30,14 +30,21 @@ import (
 const styleguideFilter = "mime_type.contains('google.cloud.apigeeregistry.applications.v1alpha1.StyleGuide')"
 
 func conformanceCommand() *cobra.Command {
-	var filter string
-
 	cmd := &cobra.Command{
 		Use:   "conformance",
 		Short: "Compute lint results for API specs",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			filter, err := cmd.Flags().GetString("filter")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
+			}
+
 			client, err := connection.NewClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
@@ -71,18 +78,17 @@ func conformanceCommand() *cobra.Command {
 
 			for _, guide := range guides {
 				log.Debugf(ctx, "Processing styleguide: %s", guide.GetId())
-				processStyleGuide(ctx, client, guide, specs)
+				processStyleGuide(ctx, client, guide, specs, dryRun)
 			}
 		},
 	}
 
-	cmd.Flags().StringVar(&filter, "filter", "", "Filter selected resources")
 	return cmd
 }
 
 // processStyleGuide computes and attaches conformance reports as
 // artifacts to a spec or a collection of specs.
-func processStyleGuide(ctx context.Context, client connection.Client, styleguide *rpc.StyleGuide, specs []*rpc.ApiSpec) {
+func processStyleGuide(ctx context.Context, client connection.Client, styleguide *rpc.StyleGuide, specs []*rpc.ApiSpec, dryRun bool) {
 	linterNameToMetadata, err := conformance.GenerateLinterMetadata(styleguide)
 	if err != nil {
 		log.Errorf(ctx, "Failed generating linter metadata, check styleguide definition, Error: %s", err)
@@ -98,19 +104,13 @@ func processStyleGuide(ctx context.Context, client connection.Client, styleguide
 				continue // Only compute matching style guides.
 			}
 
-			taskQueue <- &conformance.ComputeConformanceTask{
-				Client:          client,
-				Spec:            spec,
-				LintersMetadata: linterNameToMetadata,
-				StyleguideId:    styleguide.GetId(),
-			}
-
 			// Delegate the task of computing the conformance report for this spec to the worker pool.
 			taskQueue <- &conformance.ComputeConformanceTask{
 				Client:          client,
 				Spec:            spec,
 				LintersMetadata: linterNameToMetadata,
 				StyleguideId:    styleguide.GetId(),
+				DryRun:          dryRun,
 			}
 		}
 	}

--- a/cmd/registry/cmd/compute/conformance_test.go
+++ b/cmd/registry/cmd/compute/conformance_test.go
@@ -427,7 +427,10 @@ func TestConformance(t *testing.T) {
 				t.Fatalf("Failed to upload the styleguide: %s", err)
 			}
 
+			// setup the command
 			conformanceCmd := conformanceCommand()
+			conformanceCmd.Flags().String("filter", "", "Filter selected resources")
+			conformanceCmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and not uploaded to registry")
 
 			args = []string{spec.Name}
 			conformanceCmd.SetArgs(args)

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -39,6 +39,10 @@ func lintCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get fry-run from flags")
+			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -59,6 +63,7 @@ func lintCommand() *cobra.Command {
 					client:   client,
 					specName: spec.Name,
 					linter:   linter,
+					dryRun:   dryRun,
 				}
 				return nil
 			})
@@ -76,6 +81,7 @@ type computeLintTask struct {
 	client   connection.Client
 	specName string
 	linter   string
+	dryRun   bool
 }
 
 func (task *computeLintTask) String() string {
@@ -127,16 +133,22 @@ func (task *computeLintTask) Run(ctx context.Context) error {
 	} else {
 		return fmt.Errorf("we don't know how to lint %s", spec.Name)
 	}
-	subject := spec.GetName()
-	messageData, _ := proto.Marshal(lint)
-	artifact := &rpc.Artifact{
-		Name:     subject + "/artifacts/" + relation,
-		MimeType: core.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.Lint"),
-		Contents: messageData,
+
+	if task.dryRun {
+		core.PrintMessage(lint)
+	} else {
+		subject := spec.GetName()
+		messageData, _ := proto.Marshal(lint)
+		artifact := &rpc.Artifact{
+			Name:     subject + "/artifacts/" + relation,
+			MimeType: core.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.Lint"),
+			Contents: messageData,
+		}
+		err = core.SetArtifact(ctx, task.client, artifact)
+		if err != nil {
+			return err
+		}
 	}
-	err = core.SetArtifact(ctx, task.client, artifact)
-	if err != nil {
-		return err
-	}
+
 	return nil
 }

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -136,19 +136,15 @@ func (task *computeLintTask) Run(ctx context.Context) error {
 
 	if task.dryRun {
 		core.PrintMessage(lint)
-	} else {
-		subject := spec.GetName()
-		messageData, _ := proto.Marshal(lint)
-		artifact := &rpc.Artifact{
-			Name:     subject + "/artifacts/" + relation,
-			MimeType: core.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.Lint"),
-			Contents: messageData,
-		}
-		err = core.SetArtifact(ctx, task.client, artifact)
-		if err != nil {
-			return err
-		}
+		return nil
 	}
 
-	return nil
+	subject := spec.GetName()
+	messageData, _ := proto.Marshal(lint)
+	artifact := &rpc.Artifact{
+		Name:     subject + "/artifacts/" + relation,
+		MimeType: core.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.Lint"),
+		Contents: messageData,
+	}
+	return core.SetArtifact(ctx, task.client, artifact)
 }

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -104,15 +104,15 @@ func (task *computeReferencesTask) Run(ctx context.Context) error {
 
 	if task.dryRun {
 		core.PrintMessage(references)
-	} else {
-		messageData, _ := proto.Marshal(references)
-		artifact := &rpc.Artifact{
-			Name:     task.specName + "/artifacts/references",
-			MimeType: core.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.References"),
-			Contents: messageData,
-		}
-
-		return core.SetArtifact(ctx, task.client, artifact)
+		return nil
 	}
-	return nil
+
+	messageData, _ := proto.Marshal(references)
+	artifact := &rpc.Artifact{
+		Name:     task.specName + "/artifacts/references",
+		MimeType: core.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.References"),
+		Contents: messageData,
+	}
+
+	return core.SetArtifact(ctx, task.client, artifact)
 }

--- a/cmd/registry/cmd/compute/score.go
+++ b/cmd/registry/cmd/compute/score.go
@@ -33,9 +33,14 @@ func scoreCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
+			}
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
 			}
 
 			client, err := connection.NewClient(ctx)
@@ -63,6 +68,7 @@ func scoreCommand() *cobra.Command {
 						client:      client,
 						defArtifact: d,
 						resource:    r,
+						dryRun:      dryRun,
 					}
 				}
 			}
@@ -76,6 +82,7 @@ type computeScoreTask struct {
 	client      connection.Client
 	defArtifact *rpc.Artifact
 	resource    patterns.ResourceInstance
+	dryRun      bool
 }
 
 func (task *computeScoreTask) String() string {
@@ -83,5 +90,5 @@ func (task *computeScoreTask) String() string {
 }
 
 func (task *computeScoreTask) Run(ctx context.Context) error {
-	return scoring.CalculateScore(ctx, task.client, task.defArtifact, task.resource)
+	return scoring.CalculateScore(ctx, task.client, task.defArtifact, task.resource, task.dryRun)
 }

--- a/cmd/registry/cmd/compute/scorecard.go
+++ b/cmd/registry/cmd/compute/scorecard.go
@@ -37,6 +37,10 @@ func scoreCardCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
 			}
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
+			}
 
 			client, err := connection.NewClient(ctx)
 			if err != nil {
@@ -63,6 +67,7 @@ func scoreCardCommand() *cobra.Command {
 						client:      client,
 						defArtifact: d,
 						resource:    r,
+						dryRun:      dryRun,
 					}
 				}
 			}
@@ -76,6 +81,7 @@ type computeScoreCardTask struct {
 	client      connection.Client
 	defArtifact *rpc.Artifact
 	resource    patterns.ResourceInstance
+	dryRun      bool
 }
 
 func (task *computeScoreCardTask) String() string {
@@ -83,5 +89,5 @@ func (task *computeScoreCardTask) String() string {
 }
 
 func (task *computeScoreCardTask) Run(ctx context.Context) error {
-	return scoring.CalculateScoreCard(ctx, task.client, task.defArtifact, task.resource)
+	return scoring.CalculateScoreCard(ctx, task.client, task.defArtifact, task.resource, task.dryRun)
 }

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -131,18 +131,16 @@ func (task *computeVocabularyTask) Run(ctx context.Context) error {
 
 	if task.dryRun {
 		core.PrintMessage(vocab)
-	} else {
-		messageData, err := proto.Marshal(vocab)
-		if err != nil {
-			return err
-		}
-
-		return core.SetArtifact(ctx, task.client, &rpc.Artifact{
-			Name:     task.specName + "/artifacts/vocabulary",
-			MimeType: core.MimeTypeForMessageType("gnostic.metrics.Vocabulary"),
-			Contents: messageData,
-		})
+		return nil
 	}
 
-	return nil
+	messageData, err := proto.Marshal(vocab)
+	if err != nil {
+		return err
+	}
+	return core.SetArtifact(ctx, task.client, &rpc.Artifact{
+		Name:     task.specName + "/artifacts/vocabulary",
+		MimeType: core.MimeTypeForMessageType("gnostic.metrics.Vocabulary"),
+		Contents: messageData,
+	})
 }

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -79,6 +79,7 @@ type ComputeConformanceTask struct {
 	Spec            *rpc.ApiSpec
 	LintersMetadata map[string]*linterMetadata
 	StyleguideId    string
+	DryRun          bool
 }
 
 func (task *ComputeConformanceTask) String() string {
@@ -126,7 +127,13 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 		task.computeConformanceReport(ctx, conformanceReport, guidelineReportsMap, linterResponse, metadata)
 	}
 
-	return task.storeConformanceReport(ctx, conformanceReport)
+	if task.DryRun {
+		core.PrintMessage(conformanceReport)
+	} else {
+		return task.storeConformanceReport(ctx, conformanceReport)
+	}
+
+	return nil
 }
 
 func (task *ComputeConformanceTask) invokeLinter(

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -129,11 +129,9 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 
 	if task.DryRun {
 		core.PrintMessage(conformanceReport)
-	} else {
-		return task.storeConformanceReport(ctx, conformanceReport)
+		return nil
 	}
-
-	return nil
+	return task.storeConformanceReport(ctx, conformanceReport)
 }
 
 func (task *ComputeConformanceTask) invokeLinter(

--- a/cmd/registry/scoring/score.go
+++ b/cmd/registry/scoring/score.go
@@ -120,16 +120,12 @@ func CalculateScore(
 
 		if dryRun {
 			core.PrintMessage(score)
-		} else {
-			err = uploadScore(ctx, client, resource, score)
-			if err != nil {
-				return err
-			}
+			return nil
 		}
-	} else {
-		log.Debugf(ctx, "Score %s is already up-to-date.", artifactName)
+		return uploadScore(ctx, client, resource, score)
 	}
 
+	log.Debugf(ctx, "Score %s is already up-to-date.", artifactName)
 	return nil
 }
 

--- a/cmd/registry/scoring/score_test.go
+++ b/cmd/registry/scoring/score_test.go
@@ -498,7 +498,7 @@ func TestCalculateScore(t *testing.T) {
 				t.Errorf("failed to fetch the definition Artifact from setup: %s", err)
 			}
 
-			gotErr := CalculateScore(ctx, registryClient, defArtifact, resource)
+			gotErr := CalculateScore(ctx, registryClient, defArtifact, resource, false)
 			if gotErr != nil {
 				t.Errorf("CalculateScore(ctx, client, %v, %v) returned unexpected error: %s", defArtifact, resource, gotErr)
 			}

--- a/cmd/registry/scoring/scorecard.go
+++ b/cmd/registry/scoring/scorecard.go
@@ -74,7 +74,8 @@ func CalculateScoreCard(
 	ctx context.Context,
 	client connection.Client,
 	defArtifact *rpc.Artifact,
-	resource patterns.ResourceInstance) error {
+	resource patterns.ResourceInstance,
+	dryRun bool) error {
 	project := fmt.Sprintf("%s/locations/global", resource.ResourceName().Project())
 
 	// Extract definition
@@ -108,13 +109,17 @@ func CalculateScoreCard(
 	}
 
 	if result.needsUpdate {
-		// TODO: Add dry_run flag
-
-		// upload the scoreCard to registry
-		err = uploadScoreCard(ctx, client, resource, result.scoreCard)
-		if err != nil {
-			return err
+		if dryRun {
+			core.PrintMessage(result.scoreCard)
+		} else {
+			// upload the scoreCard to registry
+			err = uploadScoreCard(ctx, client, resource, result.scoreCard)
+			if err != nil {
+				return err
+			}
 		}
+	} else {
+		log.Debugf(ctx, "ScoreCard %s is already up-to-date.", artifactName)
 	}
 
 	return nil

--- a/cmd/registry/scoring/scorecard.go
+++ b/cmd/registry/scoring/scorecard.go
@@ -111,17 +111,13 @@ func CalculateScoreCard(
 	if result.needsUpdate {
 		if dryRun {
 			core.PrintMessage(result.scoreCard)
-		} else {
-			// upload the scoreCard to registry
-			err = uploadScoreCard(ctx, client, resource, result.scoreCard)
-			if err != nil {
-				return err
-			}
+			return nil
 		}
-	} else {
-		log.Debugf(ctx, "ScoreCard %s is already up-to-date.", artifactName)
+		// upload the scoreCard to registry
+		return uploadScoreCard(ctx, client, resource, result.scoreCard)
 	}
 
+	log.Debugf(ctx, "ScoreCard %s is already up-to-date.", artifactName)
 	return nil
 }
 

--- a/cmd/registry/scoring/scorecard_test.go
+++ b/cmd/registry/scoring/scorecard_test.go
@@ -533,7 +533,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				t.Errorf("failed to fetch the definition Artifact from setup: %s", err)
 			}
 
-			gotErr := CalculateScoreCard(ctx, registryClient, defArtifact, resource)
+			gotErr := CalculateScoreCard(ctx, registryClient, defArtifact, resource, false)
 			if gotErr != nil {
 				t.Errorf("CalculateScore(ctx, client, %v, %v) returned unexpected error: %s", defArtifact, resource, gotErr)
 			}


### PR DESCRIPTION
I started this PR with adding `dry-run` support for score commands. 

However, it would be better to add that support across compute commands since each compute sub-command is uploading some artifact to the registry, users should have the option of not uploading the artifact.