### PR TITLE
Replace ioutil functions with recommended alternatives

### DIFF
--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -98,7 +97,7 @@ func main() {
 	bootLogger := log.NewLogger()
 	if configPath != "" {
 		bootLogger.Infof("Loading configuration from %s", configPath)
-		raw, err := ioutil.ReadFile(configPath)
+		raw, err := os.ReadFile(configPath)
 		if err != nil {
 			bootLogger.WithError(err).Fatal("Failed to open config file")
 		}

--- a/cmd/registry/cmd/compute/conformance_test.go
+++ b/cmd/registry/cmd/compute/conformance_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -35,7 +35,7 @@ import (
 
 func readAndGZipFile(t *testing.T, filename string) (*bytes.Buffer, error) {
 	t.Helper()
-	fileBytes, _ := ioutil.ReadFile(filename)
+	fileBytes, _ := os.ReadFile(filename)
 	var buf bytes.Buffer
 	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	_, err := zw.Write(fileBytes)

--- a/cmd/registry/cmd/resolve/resolve_test.go
+++ b/cmd/registry/cmd/resolve/resolve_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +34,7 @@ import (
 
 func readAndGZipFile(t *testing.T, filename string) (*bytes.Buffer, error) {
 	t.Helper()
-	fileBytes, _ := ioutil.ReadFile(filename)
+	fileBytes, _ := os.ReadFile(filename)
 	var buf bytes.Buffer
 	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	_, err := zw.Write(fileBytes)

--- a/cmd/registry/cmd/upload/artifact.go
+++ b/cmd/registry/cmd/upload/artifact.go
@@ -17,7 +17,7 @@ package upload
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/apigee/registry/cmd/registry/controller"
 	"github.com/apigee/registry/cmd/registry/core"
@@ -64,7 +64,7 @@ func artifactCommand() *cobra.Command {
 }
 
 func buildArtifact(ctx context.Context, parent string, filename string) (*rpc.Artifact, error) {
-	yamlBytes, err := ioutil.ReadFile(filename)
+	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -177,7 +176,7 @@ func (task *uploadOpenAPITask) populateFields() error {
 	task.specID = sanitize(specPart)
 
 	var err error
-	task.contents, err = ioutil.ReadFile(task.path)
+	task.contents, err = os.ReadFile(task.path)
 	if err != nil {
 		return err
 	}

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -103,7 +102,7 @@ func scanDirectoryForProtos(client connection.Client, projectID, baseURI, root s
 			return nil
 		}
 
-		bytes, err := ioutil.ReadFile(filepath)
+		bytes, err := os.ReadFile(filepath)
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/apigee/registry/cmd/registry/core"
@@ -221,7 +220,7 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure API version exists: %s", err)
 	}
 
-	contents, err := ioutil.ReadFile(t.filepath)
+	contents, err := os.ReadFile(t.filepath)
 	if err != nil {
 		return err
 	}

--- a/cmd/registry/cmd/upload/csv_test.go
+++ b/cmd/registry/cmd/upload/csv_test.go
@@ -17,7 +17,7 @@ package upload
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,22 +36,22 @@ const (
 )
 
 func TestUploadCSV(t *testing.T) {
-	cloudtasksGA, err := ioutil.ReadFile(filepath.Join("testdata", "cloudtasks", "v2", "openapi.yaml"))
+	cloudtasksGA, err := os.ReadFile(filepath.Join("testdata", "cloudtasks", "v2", "openapi.yaml"))
 	if err != nil {
 		t.Fatalf("Setup: Failed to read spec contents: %s", err)
 	}
 
-	cloudtasksBeta, err := ioutil.ReadFile(filepath.Join("testdata", "cloudtasks", "v2beta2", "openapi.yaml"))
+	cloudtasksBeta, err := os.ReadFile(filepath.Join("testdata", "cloudtasks", "v2beta2", "openapi.yaml"))
 	if err != nil {
 		t.Fatalf("Setup: Failed to read spec contents: %s", err)
 	}
 
-	datastoreGA, err := ioutil.ReadFile(filepath.Join("testdata", "datastore", "v1", "openapi.yaml"))
+	datastoreGA, err := os.ReadFile(filepath.Join("testdata", "datastore", "v1", "openapi.yaml"))
 	if err != nil {
 		t.Fatalf("Setup: Failed to read spec contents: %s", err)
 	}
 
-	datastoreBeta, err := ioutil.ReadFile(filepath.Join("testdata", "datastore", "v1beta1", "openapi.yaml"))
+	datastoreBeta, err := os.ReadFile(filepath.Join("testdata", "datastore", "v1beta1", "openapi.yaml"))
 	if err != nil {
 		t.Fatalf("Setup: Failed to read spec contents: %s", err)
 	}

--- a/cmd/registry/cmd/upload/manifest.go
+++ b/cmd/registry/cmd/upload/manifest.go
@@ -16,7 +16,7 @@ package upload
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/apigee/registry/cmd/registry/controller"
 	"github.com/apigee/registry/cmd/registry/core"
@@ -30,7 +30,7 @@ import (
 )
 
 func readManifestProto(filename string) (*rpc.Manifest, error) {
-	yamlBytes, err := ioutil.ReadFile(filename)
+	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/cmd/upload/spec.go
+++ b/cmd/registry/cmd/upload/spec.go
@@ -17,7 +17,6 @@ package upload
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,7 +134,7 @@ func uploadSpecFile(ctx context.Context, filename string, client *gapic.Registry
 	request.Name = version + "/specs/" + specID
 	_, err := client.GetApiSpec(ctx, request)
 	if err != nil { // TODO only do this for NotFound errors
-		bytes, err := ioutil.ReadFile(filename)
+		bytes, err := os.ReadFile(filename)
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Debug("Failed to read file")
 		} else {

--- a/cmd/registry/cmd/upload/styleguide.go
+++ b/cmd/registry/cmd/upload/styleguide.go
@@ -16,7 +16,7 @@ package upload
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/connection"
@@ -29,7 +29,7 @@ import (
 )
 
 func readStyleGuideProto(filename string) (*rpc.StyleGuide, error) {
-	yamlBytes, err := ioutil.ReadFile(filename)
+	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -105,7 +105,7 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 		_, err = core.UnzipArchiveToPath(data, root)
 	} else {
 		// Write the file to the temporary directory.
-		err = ioutil.WriteFile(filepath.Join(root, name), data, 0644)
+		err = os.WriteFile(filepath.Join(root, name), data, 0644)
 	}
 	if err != nil {
 		return err

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,7 +93,7 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 		return err
 	}
 	// Put the spec in a temporary directory.
-	root, err := ioutil.TempDir("", "registry-spec-")
+	root, err := os.MkdirTemp("", "registry-spec-")
 	if err != nil {
 		return err
 	}

--- a/cmd/registry/core/gzip.go
+++ b/cmd/registry/core/gzip.go
@@ -17,7 +17,7 @@ package core
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 )
 
 // GZippedBytes compresses a slice of bytes.
@@ -41,5 +41,5 @@ func GUnzippedBytes(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(zr)
+	return io.ReadAll(zr)
 }

--- a/cmd/registry/core/lint-openapi-gnostic.go
+++ b/cmd/registry/core/lint-openapi-gnostic.go
@@ -15,7 +15,7 @@
 package core
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -34,7 +34,7 @@ func lintFileForOpenAPIWithGnostic(path string, root string) (*rpc.LintFile, err
 	if err != nil {
 		return nil, err
 	}
-	b, err := ioutil.ReadFile(filepath.Join(root, "/linter.pb"))
+	b, err := os.ReadFile(filepath.Join(root, "/linter.pb"))
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ type nodeFinder struct {
 }
 
 func newNodeFinder(filename string) (*nodeFinder, error) {
-	data, _ := ioutil.ReadFile(filename)
+	data, _ := os.ReadFile(filename)
 	var node yaml.Node
 	if err := yaml.Unmarshal(data, &node); err != nil {
 		return nil, err

--- a/cmd/registry/core/lint-openapi-spectral.go
+++ b/cmd/registry/core/lint-openapi-spectral.go
@@ -16,7 +16,7 @@ package core
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -47,7 +47,7 @@ func lintFileForOpenAPIWithSpectral(path string, root string) (*rpc.LintFile, er
 	cmd.Dir = root
 	// ignore errors from Spectral because Spectral returns an error result when APIs have errors.
 	_ = cmd.Run()
-	b, err := ioutil.ReadFile(filepath.Join(root, "/spectral-lint.json"))
+	b, err := os.ReadFile(filepath.Join(root, "/spectral-lint.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/core/lint-openapi.go
+++ b/cmd/registry/core/lint-openapi.go
@@ -34,7 +34,7 @@ func NewLintFromOpenAPI(name string, spec []byte, linter string) (*rpc.Lint, err
 	// whenever we finish, delete the tmp directory
 	defer os.RemoveAll(root)
 	// write the file to the temp directory
-	err = ioutil.WriteFile(filepath.Join(root, name), spec, 0644)
+	err = os.WriteFile(filepath.Join(root, name), spec, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/core/lint-openapi.go
+++ b/cmd/registry/core/lint-openapi.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -26,7 +25,7 @@ import (
 // NewLintFromOpenAPI runs the API linter and returns the results.
 func NewLintFromOpenAPI(name string, spec []byte, linter string) (*rpc.Lint, error) {
 	// create a tmp directory
-	root, err := ioutil.TempDir("", "registry-openapi-")
+	root, err := os.MkdirTemp("", "registry-openapi-")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/core/lint-proto.go
+++ b/cmd/registry/core/lint-proto.go
@@ -15,7 +15,6 @@
 package core
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +27,7 @@ import (
 // NewLintFromZippedProtos runs the API linter and returns the results.
 func NewLintFromZippedProtos(name string, b []byte) (*rpc.Lint, error) {
 	// create a tmp directory
-	root, err := ioutil.TempDir("", "registry-protos-")
+	root, err := os.MkdirTemp("", "registry-protos-")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/diff/differ_test.go
+++ b/cmd/registry/diff/differ_test.go
@@ -15,7 +15,7 @@
 package diff
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -103,11 +103,11 @@ func TestDiffProtoStruct(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			baseYaml, err := ioutil.ReadFile(test.baseSpec)
+			baseYaml, err := os.ReadFile(test.baseSpec)
 			if err != nil {
 				t.Fatalf("Failed to get base spec yaml: %s", err)
 			}
-			revisionYaml, err := ioutil.ReadFile(test.revisionSpec)
+			revisionYaml, err := os.ReadFile(test.revisionSpec)
 			if err != nil {
 				t.Fatalf("Failed to get revision spec yaml: %s", err)
 			}

--- a/cmd/registry/googleauth/client.go
+++ b/cmd/registry/googleauth/client.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -36,7 +35,7 @@ func GetAuthenticatedClient(ctx context.Context) (*http.Client, error) {
 		return nil, err
 	}
 	dir := usr.HomeDir
-	b, err := ioutil.ReadFile(filepath.Join(dir, ".credentials/registry.json"))
+	b, err := os.ReadFile(filepath.Join(dir, ".credentials/registry.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/patch/apply.go
+++ b/cmd/registry/patch/apply.go
@@ -17,7 +17,7 @@ package patch
 import (
 	"context"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -65,7 +65,7 @@ func (task *applyFileTask) String() string {
 
 func (task *applyFileTask) Run(ctx context.Context) error {
 	log.FromContext(ctx).Infof("Applying %s", task.path)
-	bytes, err := ioutil.ReadFile(task.path)
+	bytes, err := os.ReadFile(task.path)
 	if err != nil {
 		return err
 	}

--- a/cmd/registry/patch/spec.go
+++ b/cmd/registry/patch/spec.go
@@ -17,7 +17,7 @@ package patch
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -96,7 +96,7 @@ func applyApiSpecPatch(
 			if err != nil {
 				return err
 			}
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err
 			}

--- a/cmd/registry/patch/spec.go
+++ b/cmd/registry/patch/spec.go
@@ -131,7 +131,7 @@ func applyApiSpecPatch(
 				}
 				req.ApiSpec.Contents = contents.Bytes()
 			} else {
-				body, err := ioutil.ReadFile(path)
+				body, err := os.ReadFile(path)
 				if err != nil {
 					return err
 				}

--- a/cmd/registry/plugins/linter/lint_framework.go
+++ b/cmd/registry/plugins/linter/lint_framework.go
@@ -16,7 +16,7 @@ package linter
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/apigee/registry/rpc"
@@ -46,7 +46,7 @@ func respondAndExit(response *rpc.LinterResponse) {
 // GetRequest constructs a LinterRequest object from standard input.
 func getRequest() (*rpc.LinterRequest, error) {
 	// Read from stdin.
-	pluginData, err := ioutil.ReadAll(os.Stdin)
+	pluginData, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/plugins/registry-lint-api-linter/main_test.go
+++ b/cmd/registry/plugins/registry-lint-api-linter/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func setupFakeSpec() (path string, err error) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/registry/plugins/registry-lint-api-linter/main_test.go
+++ b/cmd/registry/plugins/registry-lint-api-linter/main_test.go
@@ -30,7 +30,7 @@ func setupFakeSpec() (path string, err error) {
 		return "", err
 	}
 
-	f, err := ioutil.TempFile(tempDir, "*.proto")
+	f, err := os.CreateTemp(tempDir, "*.proto")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -84,7 +83,7 @@ func (linter *sampleOpenApiLinterRunner) Run(req *rpc.LinterRequest) (*rpc.Linte
 }
 
 func lintFile(specPath string, ruleIds []string) ([]*rpc.LintProblem, error) {
-	specFile, err := ioutil.ReadFile(specPath)
+	specFile, err := os.ReadFile(specPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
@@ -34,7 +34,7 @@ func setupFakeSpec(contents string) (dirPath, specFilePath string, err error) {
 		return "", "", err
 	}
 
-	err = ioutil.WriteFile(f.Name(), []byte(contents), 0644)
+	err = os.WriteFile(f.Name(), []byte(contents), 0644)
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -24,7 +23,7 @@ import (
 )
 
 func setupFakeSpec(contents string) (dirPath, specFilePath string, err error) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
+++ b/cmd/registry/plugins/registry-lint-openapi-sample/main_test.go
@@ -29,7 +29,7 @@ func setupFakeSpec(contents string) (dirPath, specFilePath string, err error) {
 		return "", "", err
 	}
 
-	f, err := ioutil.TempFile(tempDir, "*.yaml")
+	f, err := os.CreateTemp(tempDir, "*.yaml")
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/registry/plugins/registry-lint-spectral/main.go
+++ b/cmd/registry/plugins/registry-lint-spectral/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func (linter *spectralLinterRunner) RunImpl(
 	lintFiles := make([]*rpc.LintFile, 0)
 
 	// Create a temporary directory to store the configuration.
-	root, err := ioutil.TempDir("", "spectral-config-")
+	root, err := os.MkdirTemp("", "spectral-config-")
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +179,7 @@ func getLintProblemsFromSpectralResults(
 
 func runSpectralLinter(specPath, configPath string) ([]*spectralLintResult, error) {
 	// Create a temporary destination directory to store the output.
-	root, err := ioutil.TempDir("", "spectral-output-")
+	root, err := os.MkdirTemp("", "spectral-output-")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/plugins/registry-lint-spectral/main.go
+++ b/cmd/registry/plugins/registry-lint-spectral/main.go
@@ -145,7 +145,7 @@ func (linter *spectralLinterRunner) createConfigurationFile(root string, ruleIds
 
 	// Write the configuration to the temporary directory.
 	configPath := filepath.Join(root, "spectral.json")
-	err = ioutil.WriteFile(configPath, file, 0644)
+	err = os.WriteFile(configPath, file, 0644)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/registry/plugins/registry-lint-spectral/main.go
+++ b/cmd/registry/plugins/registry-lint-spectral/main.go
@@ -201,7 +201,7 @@ func runSpectralLinter(specPath, configPath string) ([]*spectralLintResult, erro
 	_ = cmd.Run()
 
 	// Read and parse the spectral output.
-	b, err := ioutil.ReadFile(outputPath)
+	b, err := os.ReadFile(outputPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/registry/plugins/registry-lint-spectral/main_test.go
+++ b/cmd/registry/plugins/registry-lint-spectral/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func setupFakeSpec() (path string, err error) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/registry/plugins/registry-lint-spectral/main_test.go
+++ b/cmd/registry/plugins/registry-lint-spectral/main_test.go
@@ -30,7 +30,7 @@ func setupFakeSpec() (path string, err error) {
 		return "", err
 	}
 
-	f, err := ioutil.TempFile(tempDir, "*.yaml")
+	f, err := os.CreateTemp(tempDir, "*.yaml")
 	if err != nil {
 		return "", err
 	}

--- a/server/registry/internal/storage/models/gzip.go
+++ b/server/registry/internal/storage/models/gzip.go
@@ -17,7 +17,7 @@ package models
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 )
 
 // GUnzippedBytes uncompresses a slice of bytes.
@@ -27,5 +27,5 @@ func GUnzippedBytes(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(zr)
+	return io.ReadAll(zr)
 }

--- a/tests/crud/crud_test.go
+++ b/tests/crud/crud_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -53,7 +53,7 @@ func check(t *testing.T, message string, err error) {
 }
 
 func readAndGZipFile(filename string) (*bytes.Buffer, error) {
-	fileBytes, _ := ioutil.ReadFile(filename)
+	fileBytes, _ := os.ReadFile(filename)
 	var buf bytes.Buffer
 	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	_, err := zw.Write(fileBytes)
@@ -201,7 +201,7 @@ func TestCRUD(t *testing.T) {
 		revision = spec.GetRevisionId()
 	}
 	// Compute some common values for subsequent tests.
-	buf, err := ioutil.ReadFile(filepath.Join("testdata", "openapi.yaml"))
+	buf, err := os.ReadFile(filepath.Join("testdata", "openapi.yaml"))
 	check(t, "error reading spec", err)
 	expectedHash := hashForBytes(buf)
 	expectedContentType := "application/x.openapi;version=3.0.0"

--- a/tests/demo/demo_test.go
+++ b/tests/demo/demo_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +52,7 @@ func check(t *testing.T, message string, err error) {
 }
 
 func readAndGZipFile(filename string) (*bytes.Buffer, error) {
-	fileBytes, _ := ioutil.ReadFile(filename)
+	fileBytes, _ := os.ReadFile(filename)
 	var buf bytes.Buffer
 	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	_, err := zw.Write(fileBytes)
@@ -260,7 +260,7 @@ func TestDemo(t *testing.T) {
 		check(t, "error getting spec %s", err)
 		// compute the size and hash of the original file
 		fileName := fmt.Sprintf("openapi.yaml@r%d", len(revisionIDs)-i-1)
-		fileBytes, err := ioutil.ReadFile(filepath.Join("testdata", fileName))
+		fileBytes, err := os.ReadFile(filepath.Join("testdata", fileName))
 		check(t, "error reading spec", err)
 		if int(spec.GetSizeBytes()) != len(fileBytes) {
 			t.Errorf("size mismatch %d != %d (%s)", spec.GetSizeBytes(), len(fileBytes), fileName)


### PR DESCRIPTION
Following [this discussion](https://github.com/apigee/registry/pull/586#discussion_r884027359) and [this reference](https://go.dev/doc/go1.16#ioutil), this replaces all usage of functions from `ioutil` with recommended alternatives.