### PR TITLE
Convert pg unique_violation responses into status.AlreadyExists

### DIFF
--- a/server/registry/internal/storage/errors.go
+++ b/server/registry/internal/storage/errors.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/lib/pq"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// grpcErrorForDbError converts recognized database error codes to grpc error codes.
+func grpcErrorForDbError(err error) error {
+	switch v := err.(type) {
+	case *pq.Error: // Postgres codes are from https://www.postgresql.org/docs/current/errcodes-appendix.html
+		if v.Code == "23505" { // unique_violation
+			return status.Error(codes.AlreadyExists, err.Error())
+		}
+	}
+	// All unrecognized codes fall through to become "Internal" errors.
+	return status.Error(codes.Internal, err.Error())
+}

--- a/server/registry/internal/storage/save.go
+++ b/server/registry/internal/storage/save.go
@@ -18,8 +18,6 @@ import (
 	"context"
 
 	"github.com/apigee/registry/server/registry/internal/storage/models"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 )
 
@@ -92,7 +90,7 @@ func (c *Client) save(ctx context.Context, v interface{}) error {
 		return nil
 	})
 	if err != nil {
-		return status.Error(codes.Internal, err.Error())
+		return grpcErrorForDbError(err)
 	}
 
 	return nil


### PR DESCRIPTION
This provides better handling of errors due to race conditions between parallel goroutines that create resources like APIs after first verifying that they don't exist ([example](https://github.com/apigee/registry/blob/dddab476d64c29a30ab7a45b2919b9d5b38a3061/server/registry/actions_apis.go#L52)).

When two such goroutines are creating the sample API, both can get past the `db.GetApi` check and the second will fail on `db.SaveApi`. When that happens, an error code is returned by the database that gets returned as `status.Internal`. It's better for clients to return this as `status.AlreadyExists`, which allows clients to decide if that's actually a problem or not (it's not a problem for bulk uploading code like [this](https://github.com/apigee/registry/blob/dddab476d64c29a30ab7a45b2919b9d5b38a3061/cmd/registry/cmd/upload/bulk/discovery.go#L131)).

In the future, we could simplify and improve the server code by refactoring it to remove the race condition by just removing the `db.GetApi` check and properly handling the response code from all databases, but this would require also trapping errors from SQLite which I think is out of scope for this PR.