### PR TITLE
Update wipeout test to use an auto-started server when necessary.

### DIFF
--- a/pkg/wipeout/wipeout_test.go
+++ b/pkg/wipeout/wipeout_test.go
@@ -20,12 +20,21 @@ import (
 	"testing"
 
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
 	"github.com/apigee/registry/server/registry/names"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
 
 func TestWipeout(t *testing.T) {
 	projectID := "wipeout-test"


### PR DESCRIPTION
This allows the wipeout test to run when there is no external server running or configured.