### PR TITLE
Add simple tests for the MigrateDatabase admin rpc.

### DIFF
--- a/server/registry/actions_migrate_database.go
+++ b/server/registry/actions_migrate_database.go
@@ -39,10 +39,16 @@ func (s *RegistryServer) MigrateDatabase(ctx context.Context, req *rpc.MigrateDa
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	metadata, _ := anypb.New(&rpc.MigrateDatabaseMetadata{})
-	response, _ := anypb.New(&rpc.MigrateDatabaseResponse{
+	metadata, err := anypb.New(&rpc.MigrateDatabaseMetadata{})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	response, err := anypb.New(&rpc.MigrateDatabaseResponse{
 		Message: "OK",
 	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	return &longrunning.Operation{
 		Name:     "migrate",
 		Metadata: metadata,

--- a/server/registry/actions_migrate_database_test.go
+++ b/server/registry/actions_migrate_database_test.go
@@ -1,0 +1,109 @@
+// Copyright 2020 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apigee/registry/rpc"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genproto/googleapis/longrunning"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestMigrateDatabase(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+
+	req := &rpc.MigrateDatabaseRequest{}
+	metadata, err := anypb.New(&rpc.MigrateDatabaseMetadata{})
+	if err != nil {
+		t.Fatalf("MigrateDatabase(%+v) test failed to build expected metadata: %s", req, err)
+	}
+	response, err := anypb.New(&rpc.MigrateDatabaseResponse{
+		Message: "OK",
+	})
+	if err != nil {
+		t.Fatalf("MigrateDatabase(%+v) test failed to build expected response: %s", req, err)
+	}
+	want := &longrunning.Operation{
+		Name:     "migrate",
+		Done:     true,
+		Metadata: metadata,
+		Result:   &longrunning.Operation_Response{Response: response},
+	}
+
+	got, err := server.MigrateDatabase(ctx, req)
+	if err != nil {
+		t.Fatalf("MigrateDatabase(%+v) returned error: %s", req, err)
+	}
+
+	opts := cmp.Options{
+		protocmp.Transform(),
+		// Ignore fields that are build-dependent or excluded from Go 	< 1.18.
+		protocmp.IgnoreFields(&rpc.Status{}, "build"),
+	}
+
+	if !cmp.Equal(want, got, opts) {
+		t.Errorf("MigrateDatabase(%+v) returned unexpected diff (-want +got):\n%s", req, cmp.Diff(want, got, opts))
+	}
+}
+
+func TestMigrateDatabaseKinds(t *testing.T) {
+	ctx := context.Background()
+	server := defaultTestServer(t)
+
+	tests := []struct {
+		desc string
+		req  *rpc.MigrateDatabaseRequest
+		want codes.Code
+	}{
+		{
+			req:  &rpc.MigrateDatabaseRequest{Kind: "auto"},
+			want: codes.OK,
+		},
+		{
+			req:  &rpc.MigrateDatabaseRequest{Kind: ""},
+			want: codes.OK,
+		},
+		{
+			req:  &rpc.MigrateDatabaseRequest{Kind: "unsupported"},
+			want: codes.InvalidArgument,
+		},
+		{
+			req:  &rpc.MigrateDatabaseRequest{Kind: "invalid"},
+			want: codes.InvalidArgument,
+		},
+	}
+
+	for _, test := range tests {
+		_, err := server.MigrateDatabase(ctx, test.req)
+		if test.want == codes.OK {
+			if err != nil {
+				t.Fatalf("MigrateDatabase(%+v) returned error: %s (expected %s)", test.req, err, test.want)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("MigrateDatabase(%+v) succeeded (expected %s)", test.req, test.want)
+			} else if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("MigrateDatabase(%+v) returned error: %s (expected %s)", test.req, err, test.want)
+			}
+		}
+	}
+}

--- a/server/registry/actions_migrate_database_test.go
+++ b/server/registry/actions_migrate_database_test.go
@@ -34,13 +34,13 @@ func TestMigrateDatabase(t *testing.T) {
 	req := &rpc.MigrateDatabaseRequest{}
 	metadata, err := anypb.New(&rpc.MigrateDatabaseMetadata{})
 	if err != nil {
-		t.Fatalf("MigrateDatabase(%+v) test failed to build expected metadata: %s", req, err)
+		t.Fatalf("MigrateDatabase(%+v) test failed to build expected response metadata: %s", req, err)
 	}
 	response, err := anypb.New(&rpc.MigrateDatabaseResponse{
 		Message: "OK",
 	})
 	if err != nil {
-		t.Fatalf("MigrateDatabase(%+v) test failed to build expected response: %s", req, err)
+		t.Fatalf("MigrateDatabase(%+v) test failed to build expected response message: %s", req, err)
 	}
 	want := &longrunning.Operation{
 		Name:     "migrate",

--- a/server/registry/actions_migrate_database_test.go
+++ b/server/registry/actions_migrate_database_test.go
@@ -96,17 +96,8 @@ func TestMigrateDatabaseKinds(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			_, err := server.MigrateDatabase(ctx, test.req)
-			if test.want == codes.OK {
-				if err != nil {
-					t.Fatalf("MigrateDatabase(%+v) returned error: %s (expected %s)", test.req, err, test.want)
-				}
-			} else {
-				if err == nil {
-					t.Fatalf("MigrateDatabase(%+v) succeeded (expected %s)", test.req, test.want)
-				} else if status.Code(err) != test.want {
-					t.Fatalf("MigrateDatabase(%+v) returned error: %s (expected %s)", test.req, err, test.want)
-				}
+			if _, err := server.MigrateDatabase(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("MigrateDatabase(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
 			}
 		})
 	}

--- a/server/registry/actions_migrate_database_test.go
+++ b/server/registry/actions_migrate_database_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC. All Rights Reserved.
+// Copyright 2022 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This increases test coverage of `actions_migrate_database.go` from zero to 73% (all but a few returns from error conditions).