### PR TITLE
Enable config file usage and flags

### DIFF
--- a/cmd/registry/cmd/root.go
+++ b/cmd/registry/cmd/root.go
@@ -27,11 +27,10 @@ import (
 	"github.com/apigee/registry/cmd/registry/cmd/label"
 	"github.com/apigee/registry/cmd/registry/cmd/list"
 	"github.com/apigee/registry/cmd/registry/cmd/resolve"
+	"github.com/apigee/registry/cmd/registry/cmd/rpc"
 	"github.com/apigee/registry/cmd/registry/cmd/upload"
 	"github.com/apigee/registry/cmd/registry/cmd/vocabulary"
-
-	"github.com/apigee/registry/cmd/registry/cmd/rpc"
-
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/spf13/cobra"
 )
 
@@ -45,6 +44,7 @@ func Command() *cobra.Command {
 		Version: Version,
 		Short:   "A simple and eclectic utility for working with the API Registry",
 	}
+	cmd.PersistentFlags().AddFlagSet(connection.Flags)
 
 	cmd.AddCommand(annotate.Command())
 	cmd.AddCommand(apply.Command())

--- a/cmd/registry/cmd/rpc/generated/admin_service.go
+++ b/cmd/registry/cmd/rpc/generated/admin_service.go
@@ -3,19 +3,12 @@
 package generated
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"golang.org/x/oauth2"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 
 	gapic "github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/pkg/connection"
 )
 
-var AdminConfig *viper.Viper
 var AdminClient *gapic.AdminClient
 var AdminSubCommands []string = []string{
 	"get-status",
@@ -31,10 +24,6 @@ var AdminSubCommands []string = []string{
 func init() {
 	rootCmd.AddCommand(AdminServiceCmd)
 
-	AdminConfig = viper.New()
-	AdminConfig.SetEnvPrefix("APG_REGISTRY")
-	AdminConfig.AutomaticEnv()
-
 }
 
 var AdminServiceCmd = &cobra.Command{
@@ -43,37 +32,6 @@ var AdminServiceCmd = &cobra.Command{
 	Long:      "The Admin service supports setup and operation of an API registry.  It is typically not included in hosted versions of the API.",
 	ValidArgs: AdminSubCommands,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		var opts []option.ClientOption
-
-		address := AdminConfig.GetString("address")
-		if address != "" {
-			opts = append(opts, option.WithEndpoint(address))
-		}
-
-		if AdminConfig.GetBool("insecure") {
-			if address == "" {
-				return fmt.Errorf("Missing address to use with insecure connection")
-			}
-
-			conn, err := grpc.Dial(address, grpc.WithInsecure())
-			if err != nil {
-				return err
-			}
-			opts = append(opts, option.WithGRPCConn(conn))
-		}
-
-		if token := AdminConfig.GetString("token"); token != "" {
-			opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(
-				&oauth2.Token{
-					AccessToken: token,
-					TokenType:   "Bearer",
-				})))
-		}
-
-		if key := AdminConfig.GetString("api_key"); key != "" {
-			opts = append(opts, option.WithAPIKey(key))
-		}
-
 		AdminClient, err = connection.NewAdminClient(ctx)
 		return
 	},

--- a/cmd/registry/cmd/rpc/generated/admin_service.go
+++ b/cmd/registry/cmd/rpc/generated/admin_service.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 
 	gapic "github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/pkg/connection"
 )
 
 var AdminConfig *viper.Viper
@@ -73,7 +74,7 @@ var AdminServiceCmd = &cobra.Command{
 			opts = append(opts, option.WithAPIKey(key))
 		}
 
-		AdminClient, err = gapic.NewAdminClient(ctx, opts...)
+		AdminClient, err = connection.NewAdminClient(ctx)
 		return
 	},
 }

--- a/cmd/registry/cmd/rpc/generated/provisioning_service.go
+++ b/cmd/registry/cmd/rpc/generated/provisioning_service.go
@@ -3,19 +3,12 @@
 package generated
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"golang.org/x/oauth2"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 
 	gapic "github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/pkg/connection"
 )
 
-var ProvisioningConfig *viper.Viper
 var ProvisioningClient *gapic.ProvisioningClient
 var ProvisioningSubCommands []string = []string{
 	"create-instance",
@@ -26,10 +19,6 @@ var ProvisioningSubCommands []string = []string{
 func init() {
 	rootCmd.AddCommand(ProvisioningServiceCmd)
 
-	ProvisioningConfig = viper.New()
-	ProvisioningConfig.SetEnvPrefix("APG_REGISTRY")
-	ProvisioningConfig.AutomaticEnv()
-
 }
 
 var ProvisioningServiceCmd = &cobra.Command{
@@ -38,37 +27,6 @@ var ProvisioningServiceCmd = &cobra.Command{
 	Long:      "The service that is used for managing the data plane provisioning of the  Registry.",
 	ValidArgs: ProvisioningSubCommands,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		var opts []option.ClientOption
-
-		address := ProvisioningConfig.GetString("address")
-		if address != "" {
-			opts = append(opts, option.WithEndpoint(address))
-		}
-
-		if ProvisioningConfig.GetBool("insecure") {
-			if address == "" {
-				return fmt.Errorf("Missing address to use with insecure connection")
-			}
-
-			conn, err := grpc.Dial(address, grpc.WithInsecure())
-			if err != nil {
-				return err
-			}
-			opts = append(opts, option.WithGRPCConn(conn))
-		}
-
-		if token := ProvisioningConfig.GetString("token"); token != "" {
-			opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(
-				&oauth2.Token{
-					AccessToken: token,
-					TokenType:   "Bearer",
-				})))
-		}
-
-		if key := ProvisioningConfig.GetString("api_key"); key != "" {
-			opts = append(opts, option.WithAPIKey(key))
-		}
-
 		ProvisioningClient, err = connection.NewProvisioningClient(ctx)
 		return
 	},

--- a/cmd/registry/cmd/rpc/generated/provisioning_service.go
+++ b/cmd/registry/cmd/rpc/generated/provisioning_service.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 
 	gapic "github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/pkg/connection"
 )
 
 var ProvisioningConfig *viper.Viper
@@ -68,7 +69,7 @@ var ProvisioningServiceCmd = &cobra.Command{
 			opts = append(opts, option.WithAPIKey(key))
 		}
 
-		ProvisioningClient, err = gapic.NewProvisioningClient(ctx, opts...)
+		ProvisioningClient, err = connection.NewProvisioningClient(ctx)
 		return
 	},
 }

--- a/cmd/registry/cmd/rpc/generated/registry_service.go
+++ b/cmd/registry/cmd/rpc/generated/registry_service.go
@@ -3,19 +3,12 @@
 package generated
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"golang.org/x/oauth2"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 
 	gapic "github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/pkg/connection"
 )
 
-var RegistryConfig *viper.Viper
 var RegistryClient *gapic.RegistryClient
 var RegistrySubCommands []string = []string{
 	"list-apis",
@@ -58,10 +51,6 @@ var RegistrySubCommands []string = []string{
 func init() {
 	rootCmd.AddCommand(RegistryServiceCmd)
 
-	RegistryConfig = viper.New()
-	RegistryConfig.SetEnvPrefix("APG_REGISTRY")
-	RegistryConfig.AutomaticEnv()
-
 }
 
 var RegistryServiceCmd = &cobra.Command{
@@ -70,37 +59,6 @@ var RegistryServiceCmd = &cobra.Command{
 	Long:      "The Registry service allows teams to manage descriptions of APIs.",
 	ValidArgs: RegistrySubCommands,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		var opts []option.ClientOption
-
-		address := RegistryConfig.GetString("address")
-		if address != "" {
-			opts = append(opts, option.WithEndpoint(address))
-		}
-
-		if RegistryConfig.GetBool("insecure") {
-			if address == "" {
-				return fmt.Errorf("Missing address to use with insecure connection")
-			}
-
-			conn, err := grpc.Dial(address, grpc.WithInsecure())
-			if err != nil {
-				return err
-			}
-			opts = append(opts, option.WithGRPCConn(conn))
-		}
-
-		if token := RegistryConfig.GetString("token"); token != "" {
-			opts = append(opts, option.WithTokenSource(oauth2.StaticTokenSource(
-				&oauth2.Token{
-					AccessToken: token,
-					TokenType:   "Bearer",
-				})))
-		}
-
-		if key := RegistryConfig.GetString("api_key"); key != "" {
-			opts = append(opts, option.WithAPIKey(key))
-		}
-
 		RegistryClient, err = connection.NewClient(ctx)
 		return
 	},

--- a/cmd/registry/cmd/rpc/generated/registry_service.go
+++ b/cmd/registry/cmd/rpc/generated/registry_service.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 
 	gapic "github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/pkg/connection"
 )
 
 var RegistryConfig *viper.Viper
@@ -100,7 +101,7 @@ var RegistryServiceCmd = &cobra.Command{
 			opts = append(opts, option.WithAPIKey(key))
 		}
 
-		RegistryClient, err = gapic.NewRegistryClient(ctx, opts...)
+		RegistryClient, err = connection.NewClient(ctx)
 		return
 	},
 }

--- a/pkg/connection/README.md
+++ b/pkg/connection/README.md
@@ -1,4 +1,25 @@
 # connection
 
 This directory contains a Go package that can be used to get a Registry API
-client that authenticates using a standard set of environment variables.
+client that authenticates using passed Settings.
+
+Settings can be automatically loaded from files in ~/.config/registry. This
+includes the file `active_config` - which contains only the bare name (no path)
+of a config file in the same directory. The config file it points to should
+contain yaml configuration similar to this:
+
+``` yaml
+registry:
+    address: localhost:8080
+    insecure: true
+```
+
+See `settings.go` for more details.
+
+The following environment variables can also be used instead of a config file
+(or as overrides) for internal purposes, but should be avoided for production
+purposes as they may be removed at any time:
+
+- APG_REGISTRY_ADDRESS
+- APG_REGISTRY_INSECURE
+- APG_REGISTRY_TOKEN

--- a/pkg/connection/client.go
+++ b/pkg/connection/client.go
@@ -52,7 +52,7 @@ type RegistryClient = *gapic.RegistryClient
 
 // NewClient creates a new GAPIC client using environment variable settings.
 func NewClient(ctx context.Context) (RegistryClient, error) {
-	settings, err := activeSettings()
+	settings, err := ActiveSettings()
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ type AdminClient = *gapic.AdminClient
 
 // NewAdminClient creates a new GAPIC client using environment variable settings.
 func NewAdminClient(ctx context.Context) (AdminClient, error) {
-	settings, err := activeSettings()
+	settings, err := ActiveSettings()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connection/client.go
+++ b/pkg/connection/client.go
@@ -87,3 +87,23 @@ func NewAdminClientWithSettings(ctx context.Context, settings Settings) (AdminCl
 	}
 	return gapic.NewAdminClient(ctx, opts...)
 }
+
+type ProvisioningClient = *gapic.ProvisioningClient
+
+// NewAdminClient creates a new GAPIC client using environment variable settings.
+func NewProvisioningClient(ctx context.Context) (ProvisioningClient, error) {
+	settings, err := ActiveSettings()
+	if err != nil {
+		return nil, err
+	}
+	return NewProvisioningClientWithSettings(ctx, settings)
+}
+
+// NewAdminClientWithSettings creates a GAPIC client with specified settings.
+func NewProvisioningClientWithSettings(ctx context.Context, settings Settings) (ProvisioningClient, error) {
+	opts, err := clientOptions(settings)
+	if err != nil {
+		return nil, err
+	}
+	return gapic.NewProvisioningClient(ctx, opts...)
+}

--- a/pkg/connection/client.go
+++ b/pkg/connection/client.go
@@ -17,8 +17,6 @@ package connection
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/apigee/registry/gapic"
 	"golang.org/x/oauth2"
@@ -26,25 +24,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Settings configure the client.
-type Settings struct {
-	Address  string // service address
-	Insecure bool   // if true, connect over HTTP
-	Token    string // bearer token
-}
-
-func newSettings() (*Settings, error) {
-	settings := &Settings{}
-	settings.Address = os.Getenv("APG_REGISTRY_ADDRESS")
-	if settings.Address == "" {
-		return nil, fmt.Errorf("rpc error: APG_REGISTRY_ADDRESS must be set")
-	}
-	settings.Insecure, _ = strconv.ParseBool(os.Getenv("APG_REGISTRY_INSECURE"))
-	settings.Token = os.Getenv("APG_REGISTRY_TOKEN")
-	return settings, nil
-}
-
-func clientOptions(settings *Settings) ([]option.ClientOption, error) {
+func clientOptions(settings Settings) ([]option.ClientOption, error) {
 	var opts []option.ClientOption
 	if settings.Address == "" {
 		return nil, fmt.Errorf("rpc error: address must be set")
@@ -72,7 +52,7 @@ type RegistryClient = *gapic.RegistryClient
 
 // NewClient creates a new GAPIC client using environment variable settings.
 func NewClient(ctx context.Context) (RegistryClient, error) {
-	settings, err := newSettings()
+	settings, err := activeSettings()
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +60,7 @@ func NewClient(ctx context.Context) (RegistryClient, error) {
 }
 
 // NewClientWithSettings creates a GAPIC client with specified settings.
-func NewClientWithSettings(ctx context.Context, settings *Settings) (RegistryClient, error) {
+func NewClientWithSettings(ctx context.Context, settings Settings) (RegistryClient, error) {
 	opts, err := clientOptions(settings)
 	if err != nil {
 		return nil, err
@@ -92,7 +72,7 @@ type AdminClient = *gapic.AdminClient
 
 // NewAdminClient creates a new GAPIC client using environment variable settings.
 func NewAdminClient(ctx context.Context) (AdminClient, error) {
-	settings, err := newSettings()
+	settings, err := activeSettings()
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +80,7 @@ func NewAdminClient(ctx context.Context) (AdminClient, error) {
 }
 
 // NewAdminClientWithSettings creates a GAPIC client with specified settings.
-func NewAdminClientWithSettings(ctx context.Context, settings *Settings) (AdminClient, error) {
+func NewAdminClientWithSettings(ctx context.Context, settings Settings) (AdminClient, error) {
 	opts, err := clientOptions(settings)
 	if err != nil {
 		return nil, err

--- a/pkg/connection/grpctest/server.go
+++ b/pkg/connection/grpctest/server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/server/registry"
 	"google.golang.org/grpc"
 )
@@ -40,9 +41,9 @@ import (
 //   ... run test here ...
 // }
 func NewIfNoAddress(rc registry.Config) (*Server, error) {
-	addr := os.Getenv("APG_REGISTRY_ADDRESS")
-	if addr != "" {
-		log.Printf("Client will use remote registry at: %s", addr)
+	settings, _ := connection.ReadSettings("")
+	if settings.Address != "" && settings.Validate() == nil {
+		log.Printf("Client will use remote registry at: %s", settings.Address)
 		return nil, nil
 	}
 	log.Println("Client will use an embedded registry with a SQLite3 database")

--- a/pkg/connection/settings.go
+++ b/pkg/connection/settings.go
@@ -1,0 +1,188 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connection
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// Flags defines Flags that may be bound to the Settings. Use like:
+// `cmd.PersistentFlags().AddFlagSet(connection.Flags)`
+var Flags *pflag.FlagSet
+
+var configPath string
+var activeConfigPointerFilename = "active_config"
+
+func init() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	configPath = filepath.Join(home, ".config/registry")
+
+	Flags = pflag.NewFlagSet("registry", pflag.ExitOnError)
+	Flags.StringP("config", "c", "", "Name of a settings profile or path to config file")
+	Flags.String("registry.address", "", "the server and port of the registry api (eg. localhost:8080)")
+	Flags.Bool("registry.insecure", false, "set to true if client must connect via http (not https)")
+	Flags.String("registry.token", "", "the token to use for authorization to registry")
+}
+
+// Settings configure the client.
+type Settings struct {
+	Address  string `mapstructure:"address"`  // service address
+	Insecure bool   `mapstructure:"insecure"` // if true, connect over HTTP
+	Token    string `mapstructure:"token"`    // bearer token
+}
+
+func (s Settings) Validate() error {
+	if s.Address == "" {
+		return ValidationError{
+			"registry.address", "required",
+		}
+	}
+	return nil
+}
+
+func (s Settings) Write(name string) error {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	v.Set("registry.Address", s.Address)
+	v.Set("registry.Insecure", s.Insecure)
+	path := filepath.Join(configPath, name)
+	return v.WriteConfigAs(path)
+}
+
+// ActiveSettings determines the active configuration name,
+// reads the configuration, validates it, and returns
+// a valid Settings and possibly an error.
+// If `config` flag exists, overrides active_config file.
+func ActiveSettings() (Settings, error) {
+	var err error
+	name, _ := Flags.GetString("config")
+	if name == "" {
+		name, err = readActiveConfig()
+		if err != nil {
+			return Settings{}, err
+		}
+	}
+
+	return ReadValidSettings(name)
+}
+
+// SetActiveConfigFile sets the active configuration file.
+// name is normally a file name with no path.
+// will not error if config file doesn't exist
+func SetActiveConfigFile(name string) error {
+	f := filepath.Join(configPath, activeConfigPointerFilename)
+	return ioutil.WriteFile(f, []byte(name), os.FileMode(0644)) // rw,r,r
+}
+
+// ReadValidSettings reads the specified configuration
+// and validates it. An error is returned if the Settings could not
+// be read or are not valid. Binds to standard Flags().
+func ReadValidSettings(name string) (settings Settings, err error) {
+	settings, err = ReadSettings(name)
+	if err != nil {
+		return
+	}
+	err = settings.Validate()
+	return settings, err
+}
+
+// ReadSettings loads Settings from yaml file matching `name`. If name
+// contains a path, the file will be read from that path, otherwise
+// the path is assumed as: ~/.config/registry.
+// Setting values are prioritized in order from: flags, env vars, file.
+// If name is empty, no file will be loaded and only flags and env vars
+// will be used.
+// Client can call Flags() to get the standard list.
+// env vars: APG_REGISTRY_ADDRESS, APG_REGISTRY_INSECURE, APG_REGISTRY_TOKEN
+// flag names: registry.address, registry.insecure, registry.token
+func ReadSettings(name string) (settings Settings, err error) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	v.BindPFlags(Flags)
+	if err = bindEnvs(v); err != nil {
+		return
+	}
+
+	dir, file := filepath.Split(name)
+	v.SetConfigName(file)
+	if dir != "" {
+		v.AddConfigPath(dir)
+	} else {
+		v.AddConfigPath(configPath)
+	}
+
+	if err = v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok && name == "" {
+			err = nil
+		} else {
+			return
+		}
+	}
+
+	// add wrapper "registry.xxx " for unmarshal
+	reg := struct {
+		Settings Settings `mapstructure:"registry"`
+	}{}
+	if err = v.Unmarshal(&reg); err != nil {
+		return
+	}
+	settings = reg.Settings
+	return
+}
+
+// returns the config file to use from ~/.config/active_config.
+// Returns "" if active_config is not found.
+func readActiveConfig() (string, error) {
+	f := filepath.Join(configPath, activeConfigPointerFilename)
+	bytes, err := ioutil.ReadFile(f)
+	if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	return strings.TrimSpace(string(bytes)), err
+}
+
+// binds environment vars to populate config
+func bindEnvs(v *viper.Viper) error {
+	v.AutomaticEnv()
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvPrefix("APG")
+	bindings := []string{"registry.address", "registry.insecure", "registry.token"}
+	for _, env := range bindings {
+		if err := v.BindEnv(env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ValidationError struct {
+	Field      string
+	Validation string
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Validation)
+}

--- a/pkg/connection/settings.go
+++ b/pkg/connection/settings.go
@@ -43,7 +43,7 @@ func init() {
 	Flags = pflag.NewFlagSet("registry", pflag.ExitOnError)
 	Flags.StringP("config", "c", "", "Name of a settings profile or path to config file")
 	Flags.String("registry.address", "", "the server and port of the registry api (eg. localhost:8080)")
-	Flags.Bool("registry.insecure", false, "set to true if client must connect via http (not https)")
+	Flags.Bool("registry.insecure", false, "if specified, client connects via http (not https)")
 	Flags.String("registry.token", "", "the token to use for authorization to registry")
 }
 

--- a/pkg/connection/settings.go
+++ b/pkg/connection/settings.go
@@ -121,7 +121,9 @@ func ReadValidSettings(name string) (settings Settings, err error) {
 func ReadSettings(name string) (settings Settings, err error) {
 	v := viper.New()
 	v.SetConfigType("yaml")
-	v.BindPFlags(Flags)
+	if err = v.BindPFlags(Flags); err != nil {
+		return
+	}
 	if err = bindEnvs(v); err != nil {
 		return
 	}

--- a/pkg/connection/settings_test.go
+++ b/pkg/connection/settings_test.go
@@ -36,6 +36,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestSettingsActive(t *testing.T) {
+	// ensure outside env var doesn't affect this test
+	addrEnv := os.Getenv("APG_REGISTRY_ADDRESS")
+	if err := os.Unsetenv("APG_REGISTRY_ADDRESS"); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Setenv("APG_REGISTRY_ADDRESS", addrEnv)
+
 	// missing active file
 	settings, err := ActiveSettings()
 	if err == nil {

--- a/pkg/connection/settings_test.go
+++ b/pkg/connection/settings_test.go
@@ -1,0 +1,183 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connection
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/pflag"
+)
+
+func TestMain(m *testing.M) {
+	tmpDir, err := ioutil.TempDir("", "registry")
+	if err != nil {
+		panic("can't create temp dir")
+	}
+	configPath = tmpDir
+	code := m.Run()
+	os.Exit(code)
+}
+
+func TestSettingsActive(t *testing.T) {
+	// missing active file
+	settings, err := ActiveSettings()
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	// missing config file
+	err = SetActiveConfigFile("missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings, err = ActiveSettings()
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	// invalid config file
+	err = SetActiveConfigFile("invalid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Settings{}.Write("invalid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings, err = ActiveSettings()
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	// good config file
+	err = SetActiveConfigFile("good")
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings = Settings{
+		Address:  "localhost:8080",
+		Insecure: true,
+		Token:    "unstored",
+	}
+	err = settings.Write("good")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ActiveSettings()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	settings.Token = "" // should not have been stored
+	if diff := cmp.Diff(settings, got); diff != "" {
+		t.Errorf("activeSettings returned unexpected diff: (-want +got):\n%s", diff)
+	}
+}
+
+func TestSettingsEnvVars(t *testing.T) {
+	// no config files
+	want := Settings{
+		Address:  "localhost:8080",
+		Insecure: true,
+		Token:    "mytoken",
+	}
+	os.Setenv("APG_REGISTRY_ADDRESS", want.Address)
+	defer os.Unsetenv("APG_REGISTRY_ADDRESS")
+	os.Setenv("APG_REGISTRY_INSECURE", strconv.FormatBool(want.Insecure))
+	defer os.Unsetenv("APG_REGISTRY_INSECURE")
+	os.Setenv("APG_REGISTRY_TOKEN", want.Token)
+	defer os.Unsetenv("APG_REGISTRY_TOKEN")
+
+	got, err := ActiveSettings()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("activeSettings returned unexpected diff: (-want +got):\n%s", diff)
+	}
+
+	// good config file
+	err = SetActiveConfigFile("good")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = Settings{
+		Address: "overridden",
+		Token:   "overridden",
+	}.Write("good")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("activeSettings returned unexpected diff: (-want +got):\n%s", diff)
+	}
+}
+
+func TestSettingsDirectRead(t *testing.T) {
+	settings := Settings{
+		Address:  "localhost:8080",
+		Insecure: true,
+	}
+	err := settings.Write("good")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configFile := filepath.Join(configPath, "good")
+
+	args := os.Args
+	defer func() { os.Args = args }()
+	os.Args = []string{
+		"test",
+		"--config", configFile,
+	}
+	pflag.CommandLine.AddFlagSet(Flags)
+	pflag.Parse()
+	got, err := ActiveSettings()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if diff := cmp.Diff(settings, got); diff != "" {
+		t.Errorf("activeSettings returned unexpected diff: (-want +got):\n%s", diff)
+	}
+}
+
+func TestSettingsFlags(t *testing.T) {
+	want := Settings{
+		Address:  "localhost:8080",
+		Insecure: true,
+		Token:    "mytoken",
+	}
+	args := os.Args
+	defer func() { os.Args = args }()
+	os.Args = []string{
+		"test",
+		"--registry.address", want.Address,
+		"--registry.insecure", strconv.FormatBool(want.Insecure),
+		"--registry.token", want.Token,
+	}
+	pflag.CommandLine.AddFlagSet(Flags)
+	pflag.Parse()
+	got, err := ActiveSettings()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("activeSettings returned unexpected diff: (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/wipeout/wipeout_test.go
+++ b/pkg/wipeout/wipeout_test.go
@@ -20,12 +20,21 @@ import (
 	"testing"
 
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
 	"github.com/apigee/registry/server/registry/names"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
 
 func TestWipeout(t *testing.T) {
 	projectID := "wipeout-test"

--- a/tools/GENERATE-CLI.sh
+++ b/tools/GENERATE-CLI.sh
@@ -42,30 +42,29 @@ find $GENERATED -name "*.go" -type f -exec sed -i.bak "s/package main/package ge
 
 REGISTRY_SERVICE=${GENERATED}/registry_service.go
 sed -i.bak "/RegistryServiceCmd\.PersistentFlags/d" "${REGISTRY_SERVICE}"
-sed -i.bak "/RegistryConfig\.Bind/d" "${REGISTRY_SERVICE}"
-sed -i.bak "s/gapic\.NewRegistryClient.*)/connection\.NewClient\(ctx\)/" "${REGISTRY_SERVICE}"
+sed -i.bak "/RegistryConfig/d" "${REGISTRY_SERVICE}"
+sed -i.bak "/fmt/d" "${REGISTRY_SERVICE}"
+sed -i.bak "/viper/,/grpc/d" "${REGISTRY_SERVICE}"
+sed -i.bak "/option\.ClientOption/,/NewRegistryClient/d" "${REGISTRY_SERVICE}"
+sed -i.bak "s/return/RegistryClient, err = connection.NewClient\(ctx\)\n\treturn/" "${REGISTRY_SERVICE}"
 sed -i.bak "s/apigee\/registry\/gapic.*/apigee\/registry\/gapic\"\n\"github\.com\/apigee\/registry\/pkg\/connection\"/" "${REGISTRY_SERVICE}"
 
 ADMIN_SERVICE=${GENERATED}/admin_service.go
 sed -i.bak "/AdminServiceCmd\.PersistentFlags/d" "${ADMIN_SERVICE}"
-sed -i.bak "/AdminConfig\.Bind/d" "${ADMIN_SERVICE}"
-sed -i.bak "s/APG_ADMIN/APG_REGISTRY/" "${ADMIN_SERVICE}"
-if grep --quiet APG_ADMIN "${ADMIN_SERVICE}"; then
-  echo "Patching ${ADMIN_SERVICE} failed."
-  exit 1
-fi
-sed -i.bak "s/gapic\.NewAdminClient.*)/connection\.NewAdminClient\(ctx\)/" "${ADMIN_SERVICE}"
+sed -i.bak "/AdminConfig/d" "${ADMIN_SERVICE}"
+sed -i.bak "/fmt/d" "${ADMIN_SERVICE}"
+sed -i.bak "/viper/,/grpc/d" "${ADMIN_SERVICE}"
+sed -i.bak "/option\.ClientOption/,/NewAdminClient/d" "${ADMIN_SERVICE}"
+sed -i.bak "s/return/AdminClient, err = connection.NewAdminClient\(ctx\)\n\treturn/" "${ADMIN_SERVICE}"
 sed -i.bak "s/apigee\/registry\/gapic.*/apigee\/registry\/gapic\"\n\"github\.com\/apigee\/registry\/pkg\/connection\"/" "${ADMIN_SERVICE}"
 
 PROVISIONING_SERVICE=${GENERATED}/provisioning_service.go
 sed -i.bak "/ProvisioningServiceCmd\.PersistentFlags/d" "${PROVISIONING_SERVICE}"
-sed -i.bak "/ProvisioningConfig\.Bind/d" "${PROVISIONING_SERVICE}"
-sed -i.bak "s/APG_PROVISIONING/APG_REGISTRY/" "${PROVISIONING_SERVICE}"
-if grep --quiet APG_PROVISIONING "${PROVISIONING_SERVICE}"; then
-  echo "Patching ${PROVISIONING_SERVICE} failed."
-  exit 1
-fi
-sed -i.bak "s/gapic\.NewProvisioningClient.*)/connection\.NewProvisioningClient\(ctx\)/" "${PROVISIONING_SERVICE}"
+sed -i.bak "/ProvisioningConfig/d" "${PROVISIONING_SERVICE}"
+sed -i.bak "/fmt/d" "${PROVISIONING_SERVICE}"
+sed -i.bak "/viper/,/grpc/d" "${PROVISIONING_SERVICE}"
+sed -i.bak "/option\.ClientOption/,/NewProvisioningClient/d" "${PROVISIONING_SERVICE}"
+sed -i.bak "s/return/ProvisioningClient, err = connection.NewProvisioningClient\(ctx\)\n\treturn/" "${PROVISIONING_SERVICE}"
 sed -i.bak "s/apigee\/registry\/gapic.*/apigee\/registry\/gapic\"\n\"github\.com\/apigee\/registry\/pkg\/connection\"/" "${PROVISIONING_SERVICE}"
 
 # Format the files with significant patches.


### PR DESCRIPTION
Enables config file usage and flags as follows:

Flags enabled for registry CLI:

```
  -c, --config string             Name of a settings profile or path to config file
      --registry.address string   the server and port of the registry api (eg. localhost:8080)
      --registry.insecure         set to true if client must connect via http (not https)
      --registry.token string     the token to use for authorization to registry
```

Notes:

* This is 100% backward compatible
* `go test` will use env vars, not flags
* Settings are honored in prioritized order from: 1. flags, 2. env vars, 3. config file
* Config files are assumed to be stored in $HOME/.config/registry
* However, `--config` flag can specify an explicit path to a settings file directly

Config file management will be handled in #649 

Fixes #647
