### PR TITLE
Registry tests: Reorganize CI testing to move standalone server tests later.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,10 +62,7 @@ jobs:
       run: go install ./...
 
     - name: Test everything with SQLite
-      run: registry-server & make test
-      env:
-        APG_REGISTRY_ADDRESS: localhost:8080 
-        APG_REGISTRY_INSECURE: 1
+      run: make test
 
     - name: Configure PostgreSQL
       env:
@@ -81,24 +78,27 @@ jobs:
     - name: Test registry server with PostgreSQL
       run: go test ./server/registry -postgresql
 
-    - name: Test a remote (standalone) registry server
+    - name: Start a standalone registry server for subsequent testing
+      run: registry-server &
+
+    - name: Test a standalone registry server using the remote proxy
       env:
         APG_REGISTRY_ADDRESS: localhost:8080
         APG_REGISTRY_INSECURE: 1
       run: go test ./server/registry -remote
 
-    - name: Test a remote (standalone) registry server in hosted mode
+    - name: Test a standalone registry server using the remote proxy in hosted mode
       env:
-        APG_REGISTRY_ADDRESS: localhost:8080 
+        APG_REGISTRY_ADDRESS: localhost:8080
         APG_REGISTRY_INSECURE: 1
         PROJECTID: hosted-ci-test
       run: |
         registry rpc admin create-project --project_id=$PROJECTID --json
         go test ./server/registry -hosted $PROJECTID
 
-    - name: Verify that benchmarks run
+    - name: Verify that benchmarks run on a standalone registry server
       env:
-        APG_REGISTRY_ADDRESS: localhost:8080 
+        APG_REGISTRY_ADDRESS: localhost:8080
         APG_REGISTRY_INSECURE: 1
         PROJECTID: bench
         ITERATIONS: 1


### PR DESCRIPTION
This defers startup of the standalone `registry-server` to ensure that all of the `make test` tests can run with the built-in test server which is run from  [`TestMain()` in `pkg/connection/grptest`](https://github.com/apigee/registry/blob/a14cd98c777af469363cae18b8efff2a43169a64/pkg/connection/grpctest/server.go#L62).


A few test phases also get some minor renaming for clarity.