### PR TITLE
Minor cleanup to CI tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,7 +83,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         go clean -testcache
-        go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./server/... ./...
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,7 +83,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         go clean -testcache
-        go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=all ./...
+        go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./server/... ./...
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,7 +83,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         go clean -testcache
-        go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./server/... ./...
+        go test -race -coverprofile=coverage.txt -covermode=atomic ./...
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
       run: go install ./...
 
     - name: Test everything with SQLite
-      run: make test
+      run: go test ./...
 
     - name: Configure PostgreSQL
       env:
@@ -77,6 +77,21 @@ jobs:
 
     - name: Test registry server with PostgreSQL
       run: go test ./server/registry -postgresql
+
+    - name: Compute code coverage
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        go clean -testcache
+        go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        shasum -a 256 -c codecov.SHA256SUM
+        chmod +x codecov
+        ./codecov -t ${CODECOV_TOKEN}
 
     - name: Start a standalone registry server for subsequent testing
       run: registry-server &
@@ -105,20 +120,3 @@ jobs:
       run: |
         registry rpc admin create-project --project_id=$PROJECTID --json
         go test ./tests/benchmark --bench=. --project_id=$PROJECTID --benchtime=${ITERATIONS}x --timeout=0
-
-    - name: Compute code coverage
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        APG_REGISTRY_ADDRESS: localhost:8080 
-        APG_REGISTRY_INSECURE: 1
-      run: |
-        go clean -testcache
-        go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
-        chmod +x codecov
-        ./codecov -t ${CODECOV_TOKEN}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,7 +83,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
         go clean -testcache
-        go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./server/... ./...
+        go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=all ./...
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM


### PR DESCRIPTION
- replace `make test` with `go test ./...`
- use built-in server for coverage testing