### PR TITLE
add project, location config and allow short names

### DIFF
--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -46,7 +45,7 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -41,6 +42,12 @@ func Command() *cobra.Command {
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -44,7 +43,7 @@ func complexityCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -36,9 +37,15 @@ func complexityCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "complexity",
 		Short: "Compute complexity metrics of API specs",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
@@ -58,7 +65,7 @@ func complexityCommand() *cobra.Command {
 
 			spec, err := names.ParseSpec(args[0])
 			if err != nil {
-				return // TODO: Log an error.
+				log.FromContext(ctx).WithError(err).Fatal("Failed parse")
 			}
 
 			// Iterate through a collection of specs and summarize each.

--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/conformance"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/cmd/registry/patch"
@@ -43,7 +42,7 @@ func conformanceCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {

--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/conformance"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/cmd/registry/patch"
@@ -35,9 +36,15 @@ func conformanceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conformance",
 		Short: "Compute lint results for API specs",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -40,7 +39,7 @@ func lintCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -32,9 +33,15 @@ func lintCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lint",
 		Short: "Compute lint results for API specs",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
@@ -54,7 +61,7 @@ func lintCommand() *cobra.Command {
 
 			spec, err := names.ParseSpec(args[0])
 			if err != nil {
-				return // TODO: Log an error.
+				log.FromContext(ctx).WithError(err).Fatal("Failed parse")
 			}
 
 			// Iterate through a collection of specs and evaluate each.

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -40,9 +41,15 @@ func lintStatsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lintstats",
 		Short: "Compute summaries of linter runs",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -48,7 +47,7 @@ func lintStatsCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -31,9 +32,15 @@ func referencesCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "references",
 		Short: "Compute references of API specs",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
@@ -53,7 +60,7 @@ func referencesCommand() *cobra.Command {
 
 			spec, err := names.ParseSpec(args[0])
 			if err != nil {
-				return // TODO: Log an error.
+				log.FromContext(ctx).WithError(err).Fatal("Failed parse")
 			}
 
 			// Iterate through a collection of specs and compute references for each

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -39,7 +38,7 @@ func referencesCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -45,7 +44,7 @@ func vocabularyCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			path := util.FQName(c, args[0])
+			path := c.FQName(args[0])
 
 			filter, err := cmd.Flags().GetString("filter")
 			if err != nil {

--- a/cmd/registry/cmd/count/revisions.go
+++ b/cmd/registry/cmd/count/revisions.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -41,7 +40,7 @@ func revisionsCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -33,9 +34,15 @@ func versionsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "versions",
 		Short: "Count the number of versions of specified APIs",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
@@ -46,7 +53,7 @@ func versionsCommand() *cobra.Command {
 
 			api, err := names.ParseApi(args[0])
 			if err != nil {
-				return // TODO: Log an error.
+				log.FromContext(ctx).WithError(err).Fatal("Failed parse")
 			}
 
 			// Iterate through a collection of APIs and count the number of versions of each.

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -41,7 +40,7 @@ func versionsCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -32,9 +33,15 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete resources from the API Registry",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -40,7 +39,7 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/diff/diff.go
+++ b/cmd/registry/cmd/diff/diff.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -45,7 +44,7 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
 			for i := range args {
-				args[i] = util.FQName(c, args[i])
+				args[i] = c.FQName(args[i])
 			}
 
 			client, err := connection.NewRegistryClient(ctx)

--- a/cmd/registry/cmd/diff/diff.go
+++ b/cmd/registry/cmd/diff/diff.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -39,6 +40,14 @@ func Command() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			for i := range args {
+				args[i] = util.FQName(c, args[i])
+			}
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/export/csv.go
+++ b/cmd/registry/cmd/export/csv.go
@@ -18,6 +18,7 @@ import (
 	"encoding/csv"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -39,7 +40,12 @@ func csvCommand() *cobra.Command {
 		Use:   "csv [--filter expression] parent ...",
 		Short: "Export API specs to a CSV file",
 		Args: func(cmd *cobra.Command, args []string) error {
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				return fmt.Errorf("Failed to get config: %s", err)
+			}
 			for _, parent := range args {
+				parent = util.FQName(c, parent)
 				if _, err := names.ParseVersion(parent); err != nil {
 					return fmt.Errorf("invalid parent argument %q", parent)
 				}

--- a/cmd/registry/cmd/export/csv.go
+++ b/cmd/registry/cmd/export/csv.go
@@ -18,7 +18,6 @@ import (
 	"encoding/csv"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -45,7 +44,7 @@ func csvCommand() *cobra.Command {
 				return fmt.Errorf("Failed to get config: %s", err)
 			}
 			for _, parent := range args {
-				parent = util.FQName(c, parent)
+				parent = c.FQName(parent)
 				if _, err := names.ParseVersion(parent); err != nil {
 					return fmt.Errorf("invalid parent argument %q", parent)
 				}

--- a/cmd/registry/cmd/export/sheet.go
+++ b/cmd/registry/cmd/export/sheet.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -44,6 +45,14 @@ func sheetCommand() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			for i := range args {
+				args[i] = util.FQName(c, args[i])
+			}
+
 			var path string
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/export/sheet.go
+++ b/cmd/registry/cmd/export/sheet.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -50,7 +49,7 @@ func sheetCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
 			for i := range args {
-				args[i] = util.FQName(c, args[i])
+				args[i] = c.FQName(args[i])
 			}
 
 			var path string

--- a/cmd/registry/cmd/export/yaml.go
+++ b/cmd/registry/cmd/export/yaml.go
@@ -17,7 +17,6 @@ package export
 import (
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/cmd/registry/patch"
 	"github.com/apigee/registry/log"
@@ -39,7 +38,7 @@ func yamlCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
@@ -54,7 +53,7 @@ func yamlCommand() *cobra.Command {
 				if err != nil {
 					log.FromContext(ctx).WithError(err).Fatal("Failed to export project YAML")
 				}
-			} else if api, err := names.ParseApi(util.FQName(c, args[0])); err == nil {
+			} else if api, err := names.ParseApi(c.FQName(args[0])); err == nil {
 				err = core.GetAPI(ctx, client, api, func(message *rpc.Api) error {
 					bytes, _, err := patch.ExportAPI(ctx, client, message)
 					if err != nil {
@@ -66,7 +65,7 @@ func yamlCommand() *cobra.Command {
 				if err != nil {
 					log.FromContext(ctx).WithError(err).Fatal("Failed to export API YAML")
 				}
-			} else if artifact, err := names.ParseArtifact(util.FQName(c, args[0])); err == nil {
+			} else if artifact, err := names.ParseArtifact(c.FQName(args[0])); err == nil {
 				err = core.GetArtifact(ctx, client, artifact, false, func(message *rpc.Artifact) error {
 					bytes, _, err := patch.ExportArtifact(ctx, client, message)
 					if err != nil {

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -15,7 +15,6 @@
 package get
 
 import (
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -35,7 +34,7 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -15,6 +15,7 @@
 package get
 
 import (
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -27,9 +28,15 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get resources from the API Registry",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
@@ -39,35 +46,30 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
-			var name string
-			if len(args) > 0 {
-				name = args[0]
-			}
-
 			var err2 error
-			if project, err := names.ParseProject(name); err == nil {
+			if project, err := names.ParseProject(args[0]); err == nil {
 				err2 = core.GetProject(ctx, adminClient, project, core.PrintProjectDetail)
-			} else if api, err := names.ParseApi(name); err == nil {
+			} else if api, err := names.ParseApi(args[0]); err == nil {
 				err2 = core.GetAPI(ctx, client, api, core.PrintAPIDetail)
-			} else if deployment, err := names.ParseDeployment(name); err == nil {
+			} else if deployment, err := names.ParseDeployment(args[0]); err == nil {
 				err2 = core.GetDeployment(ctx, client, deployment, core.PrintDeploymentDetail)
-			} else if deployment, err := names.ParseDeploymentRevision(name); err == nil {
+			} else if deployment, err := names.ParseDeploymentRevision(args[0]); err == nil {
 				err2 = core.GetDeploymentRevision(ctx, client, deployment, core.PrintDeploymentDetail)
-			} else if version, err := names.ParseVersion(name); err == nil {
+			} else if version, err := names.ParseVersion(args[0]); err == nil {
 				err2 = core.GetVersion(ctx, client, version, core.PrintVersionDetail)
-			} else if spec, err := names.ParseSpec(name); err == nil {
+			} else if spec, err := names.ParseSpec(args[0]); err == nil {
 				if getContents {
 					err2 = core.GetSpec(ctx, client, spec, getContents, core.PrintSpecContents)
 				} else {
 					err2 = core.GetSpec(ctx, client, spec, getContents, core.PrintSpecDetail)
 				}
-			} else if spec, err := names.ParseSpecRevision(name); err == nil {
+			} else if spec, err := names.ParseSpecRevision(args[0]); err == nil {
 				if getContents {
 					err2 = core.GetSpecRevision(ctx, client, spec, getContents, core.PrintSpecContents)
 				} else {
 					err2 = core.GetSpecRevision(ctx, client, spec, getContents, core.PrintSpecDetail)
 				}
-			} else if artifact, err := names.ParseArtifact(name); err == nil {
+			} else if artifact, err := names.ParseArtifact(args[0]); err == nil {
 				if getContents {
 					err2 = core.GetArtifact(ctx, client, artifact, getContents, core.PrintArtifactContents)
 				} else {

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -41,7 +42,13 @@ func Command() *cobra.Command {
 func collectInputIndexes(ctx context.Context, client connection.RegistryClient, args []string, filter string) ([]string, []*rpc.Index) {
 	inputNames := make([]string, 0)
 	inputs := make([]*rpc.Index, 0)
+	c, err := connection.ActiveConfig()
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+	}
+
 	for _, name := range args {
+		name = util.FQName(c, name)
 		artifact, err := names.ParseArtifact(name)
 		if err != nil {
 			continue

--- a/cmd/registry/cmd/index/index.go
+++ b/cmd/registry/cmd/index/index.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -48,7 +47,7 @@ func collectInputIndexes(ctx context.Context, client connection.RegistryClient, 
 	}
 
 	for _, name := range args {
-		name = util.FQName(c, name)
+		name = c.FQName(name)
 		artifact, err := names.ParseArtifact(name)
 		if err != nil {
 			continue

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -46,7 +45,7 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -41,6 +42,12 @@ func Command() *cobra.Command {
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -31,9 +32,15 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List resources in the API Registry",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
@@ -76,7 +83,7 @@ func matchAndHandleListCmd(
 	}
 
 	// Then try to match resource names.
-	if project, err := names.ParseProjectCollection(name); err == nil {
+	if project, err := names.ParseProject(name); err == nil {
 		return core.ListProjects(ctx, adminClient, project, filter, core.PrintProject)
 	} else if api, err := names.ParseApi(name); err == nil {
 		return core.ListAPIs(ctx, client, api, filter, core.PrintAPI)

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -39,7 +38,7 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {

--- a/cmd/registry/cmd/resolve/resolve.go
+++ b/cmd/registry/cmd/resolve/resolve.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/controller"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
@@ -66,7 +65,7 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = util.FQName(c, args[0])
+			args[0] = c.FQName(args[0])
 
 			name, err := names.ParseArtifact(args[0])
 			if err != nil {

--- a/cmd/registry/cmd/resolve/resolve.go
+++ b/cmd/registry/cmd/resolve/resolve.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/controller"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
@@ -58,9 +59,15 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resolve MANIFEST_RESOURCE",
 		Short: "resolve the dependencies and update the registry state (experimental)",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			c, err := connection.ActiveConfig()
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+			}
+			args[0] = util.FQName(c, args[0])
+
 			name, err := names.ParseArtifact(args[0])
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Invalid manifest resource name")

--- a/cmd/registry/cmd/util/util.go
+++ b/cmd/registry/cmd/util/util.go
@@ -16,11 +16,8 @@ package util
 
 import (
 	"fmt"
-	"path"
-	"strings"
 
 	"github.com/apigee/registry/pkg/config"
-	"github.com/apigee/registry/pkg/connection"
 )
 
 var NoActiveConfigurationError = fmt.Errorf(`No active configuration. Use 'registry config configurations' to manage.`)
@@ -32,18 +29,4 @@ func TargetConfiguration() (name string, c config.Configuration, err error) {
 	}
 
 	return
-}
-
-// FQName ensures the project and location, if available,
-// are properly included in the resource name.
-func FQName(c connection.Config, name string) string {
-	name = strings.TrimPrefix(name, "/")
-	if !strings.HasPrefix(name, "projects") && c.Project != "" {
-		if strings.HasPrefix(name, "locations") {
-			name = path.Join("projects", c.Project, name)
-		} else if c.Location != "" {
-			name = path.Join("projects", c.Project, "locations", c.Location, name)
-		}
-	}
-	return name
 }

--- a/cmd/registry/cmd/util/util.go
+++ b/cmd/registry/cmd/util/util.go
@@ -16,8 +16,11 @@ package util
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/apigee/registry/pkg/config"
+	"github.com/apigee/registry/pkg/connection"
 )
 
 var NoActiveConfigurationError = fmt.Errorf(`No active configuration. Use 'registry config configurations' to manage.`)
@@ -29,4 +32,18 @@ func TargetConfiguration() (name string, c config.Configuration, err error) {
 	}
 
 	return
+}
+
+// FQName ensures the project and location, if available,
+// are properly included in the resource name.
+func FQName(c connection.Config, name string) string {
+	name = strings.TrimPrefix(name, "/")
+	if !strings.HasPrefix(name, "projects") && c.Project != "" {
+		if strings.HasPrefix(name, "locations") {
+			name = path.Join("projects", c.Project, name)
+		} else if c.Location != "" {
+			name = path.Join("projects", c.Project, "locations", c.Location, name)
+		}
+	}
+	return name
 }

--- a/cmd/registry/cmd/util/util_test.go
+++ b/cmd/registry/cmd/util/util_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection"
+)
+
+func TestFQNamePartialConfig(t *testing.T) {
+	data := []struct {
+		input string
+		want  string
+	}{
+		{"projects/project1", "projects/project1"},
+		{"/projects/project1", "projects/project1"},
+		{"locations/foo", "locations/foo"},
+		{"/locations/foo", "locations/foo"},
+		{"apis/foo", "apis/foo"},
+		{"/apis/foo", "apis/foo"},
+	}
+
+	c := connection.Config{
+		Location: "location",
+	}
+	for _, d := range data {
+		t.Run(d.input, func(t *testing.T) {
+			got := FQName(c, d.input)
+			if d.want != got {
+				t.Errorf("want: %q, got: %q", d.want, got)
+			}
+		})
+	}
+}
+
+func TestFQNameFullConfig(t *testing.T) {
+	data := []struct {
+		input string
+		want  string
+	}{
+		{"projects/foo", "projects/foo"},
+		{"/projects/foo", "projects/foo"},
+		{"", "projects/project1/locations/location1"},
+		{"/", "projects/project1/locations/location1"},
+		{"locations/foo", "projects/project1/locations/foo"},
+		{"/locations/foo", "projects/project1/locations/foo"},
+		{"projects/foo/locations/bar", "projects/foo/locations/bar"},
+		{"/apis/foo", "projects/project1/locations/location1/apis/foo"},
+	}
+
+	c := connection.Config{
+		Project:  "project1",
+		Location: "location1",
+	}
+	for _, d := range data {
+		got := FQName(c, d.input)
+		if d.want != got {
+			t.Errorf("for: %q, want: %q, got: %q", d.input, d.want, got)
+		}
+	}
+}

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -46,9 +47,15 @@ func Command() *cobra.Command {
 }
 
 func collectInputVocabularies(ctx context.Context, client connection.RegistryClient, args []string, filter string) ([]string, []*metrics.Vocabulary) {
+	c, err := connection.ActiveConfig()
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
+	}
+
 	inputNames := make([]string, 0)
 	inputs := make([]*metrics.Vocabulary, 0)
 	for _, name := range args {
+		name = util.FQName(c, name)
 		artifact, err := names.ParseArtifact(name)
 		if err != nil {
 			continue

--- a/cmd/registry/cmd/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/vocabulary/vocabulary.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/apigee/registry/cmd/registry/cmd/util"
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
@@ -55,7 +54,7 @@ func collectInputVocabularies(ctx context.Context, client connection.RegistryCli
 	inputNames := make([]string, 0)
 	inputs := make([]*metrics.Vocabulary, 0)
 	for _, name := range args {
-		name = util.FQName(c, name)
+		name = c.FQName(name)
 		artifact, err := names.ParseArtifact(name)
 		if err != nil {
 			continue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,9 +50,11 @@ func init() {
 
 func CreateFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("registry", pflag.ExitOnError)
-	flags.StringP("config", "c", "", "Name of a configuration profile or path to config file")
+	flags.StringP("config", "c", "", "name of a configuration profile or path to config file")
 	flags.String("registry.address", "", "the server and port of the registry api (eg. localhost:8080)")
 	flags.Bool("registry.insecure", false, "if specified, client connects via http (not https)")
+	flags.String("registry.location", "", "the registry location")
+	flags.String("registry.project", "", "the registry project")
 	flags.String("registry.token", "", "the token to use for authorization to registry")
 	return flags
 }

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -35,7 +35,9 @@ type Configuration struct {
 type Registry struct {
 	Address  string `mapstructure:"address" yaml:"address"`   // service address
 	Insecure bool   `mapstructure:"insecure" yaml:"insecure"` // if true, connect over HTTP
-	Token    string `mapstructure:"token" yaml:"-"`           // generated from TokenSource
+	Location string `mapstructure:"location" yaml:"location"`
+	Project  string `mapstructure:"project" yaml:"project"`
+	Token    string `mapstructure:"token" yaml:"-"` // generated from TokenSource
 }
 
 // Write stores the Configuration in the passed file name.

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -143,6 +143,8 @@ func TestSettingsDirectRead(t *testing.T) {
 		Registry: config.Registry{
 			Address:  "localhost:8080",
 			Insecure: true,
+			Location: "location",
+			Project:  "project",
 		},
 	}
 	err := c.Write("good")
@@ -178,6 +180,8 @@ func TestSettingsFlags(t *testing.T) {
 		Registry: config.Registry{
 			Address:  "localhost:8080",
 			Insecure: true,
+			Location: "location",
+			Project:  "project",
 			Token:    "token",
 		},
 	}
@@ -185,6 +189,8 @@ func TestSettingsFlags(t *testing.T) {
 		"test",
 		"--registry.address", want.Registry.Address,
 		"--registry.insecure", strconv.FormatBool(want.Registry.Insecure),
+		"--registry.location", want.Registry.Location,
+		"--registry.project", want.Registry.Project,
 		"--registry.token", want.Registry.Token,
 	}
 	config.Flags = config.CreateFlagSet()
@@ -227,12 +233,16 @@ func TestManipulations(t *testing.T) {
 		Registry: config.Registry{
 			Address:  "address",
 			Insecure: true,
+			Location: "location",
+			Project:  "project",
 			Token:    "token",
 		},
 	}
 	want := map[string]interface{}{
 		"registry.address":  c.Registry.Address,
 		"registry.insecure": c.Registry.Insecure,
+		"registry.location": c.Registry.Location,
+		"registry.project":  c.Registry.Project,
 		"registry.token":    c.Registry.Token,
 		"token-source":      "",
 	}

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -15,6 +15,9 @@
 package connection
 
 import (
+	"path"
+	"strings"
+
 	"github.com/apigee/registry/pkg/config"
 )
 
@@ -54,4 +57,19 @@ func ReadConfig(name string) (Config, error) {
 	}
 
 	return config, err
+}
+
+// FQName ensures the project and location, if available,
+// are properly included to make ensure the resource name
+// is fully qualified.
+func (c Config) FQName(name string) string {
+	name = strings.TrimPrefix(name, "/")
+	if !strings.HasPrefix(name, "projects") && c.Project != "" {
+		if strings.HasPrefix(name, "locations") {
+			name = path.Join("projects", c.Project, name)
+		} else if c.Location != "" {
+			name = path.Join("projects", c.Project, "locations", c.Location, name)
+		}
+	}
+	return name
 }

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -22,6 +22,8 @@ import (
 type Config struct {
 	Address  string `mapstructure:"address"`  // service address
 	Insecure bool   `mapstructure:"insecure"` // if true, connect over HTTP
+	Location string `mapstructure:"location"` // optional
+	Project  string `mapstructure:"project"`  // optional
 	Token    string `mapstructure:"token"`    // bearer token
 }
 
@@ -43,11 +45,12 @@ func ReadConfig(name string) (Config, error) {
 		return Config{}, err
 	}
 
-	reg := c.Registry
 	config := Config{
-		Address:  reg.Address,
-		Insecure: reg.Insecure,
-		Token:    reg.Token,
+		Address:  c.Registry.Address,
+		Insecure: c.Registry.Insecure,
+		Location: c.Registry.Location,
+		Project:  c.Registry.Project,
+		Token:    c.Registry.Token,
 	}
 
 	return config, err

--- a/pkg/connection/config_test.go
+++ b/pkg/connection/config_test.go
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package connection
 
 import (
 	"testing"
-
-	"github.com/apigee/registry/pkg/connection"
 )
 
 func TestFQNamePartialConfig(t *testing.T) {
@@ -33,12 +31,12 @@ func TestFQNamePartialConfig(t *testing.T) {
 		{"/apis/foo", "apis/foo"},
 	}
 
-	c := connection.Config{
+	c := Config{
 		Location: "location",
 	}
 	for _, d := range data {
 		t.Run(d.input, func(t *testing.T) {
-			got := FQName(c, d.input)
+			got := c.FQName(d.input)
 			if d.want != got {
 				t.Errorf("want: %q, got: %q", d.want, got)
 			}
@@ -61,12 +59,12 @@ func TestFQNameFullConfig(t *testing.T) {
 		{"/apis/foo", "projects/project1/locations/location1/apis/foo"},
 	}
 
-	c := connection.Config{
+	c := Config{
 		Project:  "project1",
 		Location: "location1",
 	}
 	for _, d := range data {
-		got := FQName(c, d.input)
+		got := c.FQName(d.input)
 		if d.want != got {
 			t.Errorf("for: %q, want: %q, got: %q", d.input, d.want, got)
 		}


### PR DESCRIPTION
This isn't as elegant as I'd like, but I didn't see a good integration point that could fix it as a cross-cutting concern. Reworking the naming package to require configuration didn't seem reasonable. One potential alternative to this rather brute-force approach would be to rework the configured clients to include naming lookups... however, right now they are direct pointers to the generated clients... so we'd have to wrap them in our own client structs instead and change the references. I can investigate that (or other ideas) if the solution in this PR isn't desireable.

Fixes #677