### PR TITLE
ignore ext `APG_REGISTRY` vars in config tests

### DIFF
--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -281,6 +281,8 @@ func TestManipulations(t *testing.T) {
 
 func TestAllConfigs(t *testing.T) {
 	t.Cleanup(test.CleanConfigDir(t))
+	t.Setenv("APG_REGISTRY_ADDRESS", "")
+	t.Setenv("APG_REGISTRY_INSECURE", "")
 
 	config1 := config.Configuration{
 		Registry: config.Registry{

--- a/pkg/connection/client_test.go
+++ b/pkg/connection/client_test.go
@@ -23,6 +23,8 @@ import (
 
 func TestClientBadConfig(t *testing.T) {
 	t.Cleanup(test.CleanConfigDir(t))
+	t.Setenv("APG_REGISTRY_ADDRESS", "")
+	t.Setenv("APG_REGISTRY_INSECURE", "")
 
 	_, err := NewRegistryClient(context.Background())
 	if err == nil {


### PR DESCRIPTION
Fixes #684