### PR TITLE
Lock the table of affected entities during update operations.

### DIFF
--- a/server/registry/actions_artifacts.go
+++ b/server/registry/actions_artifacts.go
@@ -268,6 +268,7 @@ func (s *RegistryServer) ReplaceArtifact(ctx context.Context, req *rpc.ReplaceAr
 
 	var artifact *models.Artifact
 	err = db.Transaction(ctx, func(ctx context.Context, db *storage.Client) error {
+		db.LockArtifacts(ctx)
 		// Replacement should only succeed on artifacts that currently exist.
 		if _, err = db.GetArtifact(ctx, name); err != nil {
 			return err

--- a/server/registry/internal/storage/lock.go
+++ b/server/registry/internal/storage/lock.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	_ "github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/postgres"
+)
+
+func (c *Client) lockTable(ctx context.Context, name string) *Client {
+	if c.db.WithContext(ctx).Name() != "postgres" {
+		return c
+	}
+	return &Client{db: c.db.Exec(fmt.Sprintf("LOCK TABLE %s IN ACCESS EXCLUSIVE MODE", name))}
+}
+
+func (c *Client) LockProjects(ctx context.Context) *Client {
+	return c.lockTable(ctx, "projects")
+}
+
+func (c *Client) LockApis(ctx context.Context) *Client {
+	return c.lockTable(ctx, "apis")
+}
+
+func (c *Client) LockVersions(ctx context.Context) *Client {
+	return c.lockTable(ctx, "versions")
+}
+
+func (c *Client) LockDeployments(ctx context.Context) *Client {
+	return c.lockTable(ctx, "deployments")
+}
+
+func (c *Client) LockSpecs(ctx context.Context) *Client {
+	return c.lockTable(ctx, "specs")
+}
+
+func (c *Client) LockArtifacts(ctx context.Context) *Client {
+	return c.lockTable(ctx, "artifacts")
+}


### PR DESCRIPTION
This is an alternate (and somewhat brute-force) approach to addressing race conditions mentioned in #448 and partially addressed in #715. It locks entire tables during update operations -- the full-table lock is needed because the update action first checks to see if a row exists, and if no row is present, there's no row to lock to prevent other processes or threads from trying to create it. The table locks are not supported by SQLite (it errors, so the locks are excluded for SQLite), and they are redundant because SQLite already locks tables during transactions.

Locks are automatically released when transactions end.

https://stackoverflow.com/a/72680220
https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-TABLES
