### PR TITLE
deprecation warning for client env var use

### DIFF
--- a/cmd/registry/cmd/annotate/annotate.go
+++ b/cmd/registry/cmd/annotate/annotate.go
@@ -47,7 +47,7 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -54,7 +54,7 @@ func complexityCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/compute/conformance.go
+++ b/cmd/registry/cmd/compute/conformance.go
@@ -53,7 +53,7 @@ func conformanceCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/compute/lint.go
+++ b/cmd/registry/cmd/compute/lint.go
@@ -50,7 +50,7 @@ func lintCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get fry-run from flags")
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/compute/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats.go
@@ -58,12 +58,12 @@ func lintStatsCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 
-			adminClient, err := connection.NewAdminClient(ctx)
+			adminClient, err := connection.NewAdminClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/compute/references.go
+++ b/cmd/registry/cmd/compute/references.go
@@ -49,7 +49,7 @@ func referencesCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -55,7 +55,7 @@ func vocabularyCommand() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/count/revisions.go
+++ b/cmd/registry/cmd/count/revisions.go
@@ -42,7 +42,7 @@ func revisionsCommand() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/count/versions.go
+++ b/cmd/registry/cmd/count/versions.go
@@ -42,7 +42,7 @@ func versionsCommand() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -41,7 +41,7 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/diff/diff.go
+++ b/cmd/registry/cmd/diff/diff.go
@@ -47,7 +47,7 @@ func Command() *cobra.Command {
 				args[i] = c.FQName(args[i])
 			}
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/export/sheet.go
+++ b/cmd/registry/cmd/export/sheet.go
@@ -53,7 +53,7 @@ func sheetCommand() *cobra.Command {
 			}
 
 			var path string
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/export/yaml.go
+++ b/cmd/registry/cmd/export/yaml.go
@@ -40,7 +40,7 @@ func yamlCommand() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -36,11 +36,11 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
-			adminClient, err := connection.NewAdminClient(ctx)
+			adminClient, err := connection.NewAdminClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/label/label.go
+++ b/cmd/registry/cmd/label/label.go
@@ -47,7 +47,7 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/list/list.go
+++ b/cmd/registry/cmd/list/list.go
@@ -40,11 +40,11 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			client, err := connection.NewRegistryClient(ctx)
+			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
-			adminClient, err := connection.NewAdminClient(ctx)
+			adminClient, err := connection.NewAdminClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/cmd/registry/cmd/resolve/resolve.go
+++ b/cmd/registry/cmd/resolve/resolve.go
@@ -73,7 +73,7 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Invalid manifest resource name")
 			}
 
-			registryClient, err := connection.NewRegistryClient(ctx)
+			registryClient, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,16 +31,22 @@ import (
 
 const ActivePointerFilename = "active_config"
 
-var NoActiveConfigurationError = fmt.Errorf("No active configuration.")
+var (
+	NoActiveConfigurationError = fmt.Errorf("No active configuration.")
 
-// Flags defines Flags that may be bound to a Configuration. Use like:
-// `cmd.PersistentFlags().AddFlagSet(connection.Flags)`
-var Flags *pflag.FlagSet = CreateFlagSet()
+	// Flags defines Flags that may be bound to a Configuration. Use like:
+	// `cmd.PersistentFlags().AddFlagSet(connection.Flags)`
+	Flags *pflag.FlagSet = CreateFlagSet()
 
-// Directory is $HOME/config/registry
-var Directory string
-var CannotDeleteActiveError = fmt.Errorf("Cannot delete active configuration")
-var ReservedConfigNameError = fmt.Errorf("%q is reserved", ActivePointerFilename)
+	// Directory is $HOME/config/registry
+	Directory               string
+	CannotDeleteActiveError = fmt.Errorf("Cannot delete active configuration")
+	ReservedConfigNameError = fmt.Errorf("%q is reserved", ActivePointerFilename)
+
+	envBindings    = []string{"registry.address", "registry.insecure", "registry.token"}
+	envPrefix      = "APG"
+	envKeyReplacer = strings.NewReplacer(".", "_")
+)
 
 func init() {
 	home, err := os.UserHomeDir()
@@ -190,6 +196,16 @@ func ReadValid(name string) (c Configuration, err error) {
 		return
 	}
 
+	for _, env := range envBindings {
+		if v.IsSet(env) {
+			evar := strings.ToUpper(envKeyReplacer.Replace(envPrefix + "." + env))
+			eval, _ := os.LookupEnv(evar)
+			if eval == v.GetString(env) {
+				fmt.Printf("WARN: deprecated env: %s=%q\n", evar, eval)
+			}
+		}
+	}
+
 	return
 }
 
@@ -259,10 +275,9 @@ func ActiveName() (string, error) {
 // Binds environment vars to populate config
 func bindEnvs(v *viper.Viper) error {
 	v.AutomaticEnv()
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	v.SetEnvPrefix("APG")
-	bindings := []string{"registry.address", "registry.insecure", "registry.token"}
-	for _, env := range bindings {
+	v.SetEnvKeyReplacer(envKeyReplacer)
+	v.SetEnvPrefix(envPrefix)
+	for _, env := range envBindings {
 		if err := v.BindEnv(env); err != nil {
 			return err
 		}


### PR DESCRIPTION
Example:

```
$ registry get something
WARN: deprecated env: APG_REGISTRY_ADDRESS="localhost:8080"
WARN: deprecated env: APG_REGISTRY_INSECURE="1"
 DEBUG[0000] Unsupported entity [projects/theganyo-1/locations/global/something] uid=6965bb68
```

Note: Also fixes commands where we were unnecessarily loading config twice causing duplicate warnings.

Fixes #702