### PR TITLE
Upload dependencies of protos in uploaded APIs.

### DIFF
--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -344,29 +344,27 @@ func (task *uploadProtoTask) zipContents() ([]byte, error) {
 
 // Collect the names of all metadata files in a source directory, stripping the prefix.
 func localMetadata(source, prefix string) ([]string, error) {
-	filenames := make([]string, 0)
-	err := filepath.WalkDir(source, func(p string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		} else if entry.IsDir() {
-			return nil // Do nothing for the directory, but still walk its contents.
-		} else if strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".yaml") {
-			filenames = append(filenames, strings.TrimPrefix(p, prefix))
-		}
-		return nil
+	return localFiles(source, prefix, func(name string) bool {
+		return strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".yaml")
 	})
-	return filenames, err
 }
 
 // Collect the names of all proto files in a source directory, stripping the prefix.
 func localProtos(source, prefix string) ([]string, error) {
+	return localFiles(source, prefix, func(name string) bool {
+		return strings.HasSuffix(name, ".proto")
+	})
+}
+
+// Collect the names of all matching files in a source directory, stripping the prefix.
+func localFiles(source, prefix string, match func(string) bool) ([]string, error) {
 	filenames := make([]string, 0)
 	err := filepath.WalkDir(source, func(p string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		} else if entry.IsDir() {
 			return nil // Do nothing for the directory, but still walk its contents.
-		} else if strings.HasSuffix(p, ".proto") {
+		} else if match(p) {
 			filenames = append(filenames, strings.TrimPrefix(p, prefix))
 		}
 		return nil

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -331,10 +331,8 @@ func (task *uploadProtoTask) zipContents() ([]byte, error) {
 		return nil, err
 	}
 
-	allfiles := append(metadata, protos...)
-
 	// Zip the listed files.
-	contents, err := core.ZipArchiveOfFiles(allfiles, prefix, true)
+	contents, err := core.ZipArchiveOfFiles(append(metadata, protos...), prefix, true)
 	if err != nil {
 		return nil, err
 	}
@@ -386,8 +384,7 @@ func referencedProtos(protos []string, root string) ([]string, error) {
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("failed to compile protos with protoc: %s", err)
 	}
-	filenames, err := protosFromFileDescriptorSet(tempDir + "/proto.pb")
-	return filenames, err
+	return protosFromFileDescriptorSet(tempDir + "/proto.pb")
 }
 
 // Get all the protos listed as dependencies in a file descriptor set.

--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -313,16 +313,11 @@ func (task *uploadProtoTask) zipContents() ([]byte, error) {
 	}
 
 	// Compile the listed protos to get their dependencies.
-	count := len(protos)
-	for count > 0 {
+	if len(protos) > 0 {
 		protos, err = referencedProtos(protos, task.directory)
 		if err != nil {
 			return nil, err
 		}
-		if len(protos) == count {
-			break
-		}
-		count = len(protos)
 	}
 
 	// Get the metadata files in the main directory.

--- a/cmd/registry/core/zip.go
+++ b/cmd/registry/core/zip.go
@@ -122,6 +122,20 @@ func ZipArchiveOfPath(path, prefix string, recursive bool) (buf bytes.Buffer, er
 	return buf, err
 }
 
+// ZipArchiveOfFiles stores a list of files in a zip archive.
+// The specified prefix is stripped from file names in the archive.
+func ZipArchiveOfFiles(files []string, prefix string, recursive bool) (buf bytes.Buffer, err error) {
+	zipWriter := zip.NewWriter(&buf)
+	defer zipWriter.Close()
+
+	for _, filename := range files {
+		if err = addFileToZip(zipWriter, prefix+filename, prefix); err != nil {
+			return buf, err
+		}
+	}
+	return buf, err
+}
+
 func addFileToZip(zipWriter *zip.Writer, filename, prefix string) error {
 	fileToZip, err := os.Open(filename)
 	if err != nil {

--- a/cmd/registry/plugins/registry-lint-api-linter/main_test.go
+++ b/cmd/registry/plugins/registry-lint-api-linter/main_test.go
@@ -50,7 +50,7 @@ func TestApiLinterPluginLintSpec(t *testing.T) {
 	}{
 		{
 			&apiLinterRunner{},
-			func(specPath string) ([]*rpc.LintProblem, error) {
+			func(specPath, specDir string) ([]*rpc.LintProblem, error) {
 				return []*rpc.LintProblem{
 						{
 							Message: "test",
@@ -103,7 +103,7 @@ func TestApiLinterPluginLintSpec(t *testing.T) {
 		},
 		{
 			&apiLinterRunner{},
-			func(specPath string) ([]*rpc.LintProblem, error) {
+			func(specPath, specDir string) ([]*rpc.LintProblem, error) {
 				return []*rpc.LintProblem{}, errors.New("test")
 			},
 			&rpc.LinterRequest{


### PR DESCRIPTION
This makes proto-based API specs fully self-contained. Before uploading protos, the uploader uses `protoc` to compile them and collect a list of referenced files, repeating until all transitive inclusions are listed, and then all of these files are included in the zip archive, making the uploaded spec "fully resolved". The resulting zip archives can be unzipped in a fresh directory and compiled with `protoc` for use in any other desired applications.

A new `--protoc-root` option allows the bulk uploader to upload individual protobuf specs. When `--protoc-root` is used to specify the proto compilation root, the `PATH` argument can point to a subdirectory of that root that includes a directory containing a single API. For example, the registry API can be individually uploaded with the following invocation:
```
registry upload bulk protos ~/googleapis/google/cloud/apigeeregistry/v1 --protoc-root ~/googleapis --project-id googleapis
```
An accompanying change updates the api-linter plugin to work correctly with these uploaded specs. It excludes common protos from linting and removes the prior (ugly) workarounds for incomplete specs (downloading [api-common-protos](https://github.com/googleapis/api-common-protos) and [googleapis](https://github.com/googleapis/googleapis) to resolve missing dependencies).

Here's a simple demonstration that uploads Google API protos and runs [api-linter](https://linter.aip.dev/)-based conformance checks:
```
# Create a sample project.
registry rpc admin create-project --project_id googleapis

# Load the protos for Google APIs.
# This assumes github.com/googleapis/googleapis is cloned to your home directory.
# Proto specs are uploaded as zip files that contain all the protos needed to compile the API spec.
registry upload bulk protos ~/googleapis --project-id googleapis

# Load the AIP-based style guide (get it from https://github.com/apigee/registry-experimental/pull/97).
registry apply -f apihub-styleguide.yaml --parent projects/googleapis/locations/global

# Compute conformance for all APIs. This uses the AIP style guide for all proto-based APIs.
registry compute conformance projects/googleapis/locations/global/apis/-/versions/-/specs/-

# Get one of the conformance reports.
registry get projects/googleapis/locations/global/apis/apigeeregistry/versions/v1/specs/google-cloud-apigeeregistry-v1.zip/artifacts/conformance-apihub-styleguide --print

# Count the conformance reports and specs. The numbers should match.
registry list projects/googleapis/locations/global/apis/-/versions/-/specs/-/artifacts/conformance-apihub-styleguide | wc -l
registry list projects/googleapis/locations/global/apis/-/versions/-/specs/- | wc -l
```

Known problems:
- No tests: #739