### PR TITLE
Update generated client code with the latest gapic-generator-go

### DIFF
--- a/cmd/registry/cmd/rpc/generated/list-api-deployments.go
+++ b/cmd/registry/cmd/rpc/generated/list-api-deployments.go
@@ -31,7 +31,7 @@ func init() {
 
 	ListApiDeploymentsCmd.Flags().StringVar(&ListApiDeploymentsInput.Filter, "filter", "", "An expression that can be used to filter the...")
 
-	ListApiDeploymentsCmd.Flags().StringVar(&ListApiDeploymentsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar'")
+	ListApiDeploymentsCmd.Flags().StringVar(&ListApiDeploymentsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar' ...")
 
 	ListApiDeploymentsCmd.Flags().StringVar(&ListApiDeploymentsFromFile, "from_file", "", "Absolute path to JSON file containing request payload")
 

--- a/cmd/registry/cmd/rpc/generated/list-api-specs.go
+++ b/cmd/registry/cmd/rpc/generated/list-api-specs.go
@@ -31,7 +31,7 @@ func init() {
 
 	ListApiSpecsCmd.Flags().StringVar(&ListApiSpecsInput.Filter, "filter", "", "An expression that can be used to filter the...")
 
-	ListApiSpecsCmd.Flags().StringVar(&ListApiSpecsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar'")
+	ListApiSpecsCmd.Flags().StringVar(&ListApiSpecsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar' ...")
 
 	ListApiSpecsCmd.Flags().StringVar(&ListApiSpecsFromFile, "from_file", "", "Absolute path to JSON file containing request payload")
 

--- a/cmd/registry/cmd/rpc/generated/list-api-versions.go
+++ b/cmd/registry/cmd/rpc/generated/list-api-versions.go
@@ -31,7 +31,7 @@ func init() {
 
 	ListApiVersionsCmd.Flags().StringVar(&ListApiVersionsInput.Filter, "filter", "", "An expression that can be used to filter the...")
 
-	ListApiVersionsCmd.Flags().StringVar(&ListApiVersionsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar'")
+	ListApiVersionsCmd.Flags().StringVar(&ListApiVersionsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar' ...")
 
 	ListApiVersionsCmd.Flags().StringVar(&ListApiVersionsFromFile, "from_file", "", "Absolute path to JSON file containing request payload")
 

--- a/cmd/registry/cmd/rpc/generated/list-apis.go
+++ b/cmd/registry/cmd/rpc/generated/list-apis.go
@@ -31,7 +31,7 @@ func init() {
 
 	ListApisCmd.Flags().StringVar(&ListApisInput.Filter, "filter", "", "An expression that can be used to filter the...")
 
-	ListApisCmd.Flags().StringVar(&ListApisInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar'")
+	ListApisCmd.Flags().StringVar(&ListApisInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar' ...")
 
 	ListApisCmd.Flags().StringVar(&ListApisFromFile, "from_file", "", "Absolute path to JSON file containing request payload")
 

--- a/cmd/registry/cmd/rpc/generated/list-artifacts.go
+++ b/cmd/registry/cmd/rpc/generated/list-artifacts.go
@@ -31,7 +31,7 @@ func init() {
 
 	ListArtifactsCmd.Flags().StringVar(&ListArtifactsInput.Filter, "filter", "", "An expression that can be used to filter the...")
 
-	ListArtifactsCmd.Flags().StringVar(&ListArtifactsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar'")
+	ListArtifactsCmd.Flags().StringVar(&ListArtifactsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar' ...")
 
 	ListArtifactsCmd.Flags().StringVar(&ListArtifactsFromFile, "from_file", "", "Absolute path to JSON file containing request payload")
 

--- a/cmd/registry/cmd/rpc/generated/list-projects.go
+++ b/cmd/registry/cmd/rpc/generated/list-projects.go
@@ -29,7 +29,7 @@ func init() {
 
 	ListProjectsCmd.Flags().StringVar(&ListProjectsInput.Filter, "filter", "", "An expression that can be used to filter the...")
 
-	ListProjectsCmd.Flags().StringVar(&ListProjectsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar'")
+	ListProjectsCmd.Flags().StringVar(&ListProjectsInput.OrderBy, "order_by", "", "A comma-separated list of fields, e.g. 'foo,bar' ...")
 
 	ListProjectsCmd.Flags().StringVar(&ListProjectsFromFile, "from_file", "", "Absolute path to JSON file containing request payload")
 

--- a/gapic/admin_client.go
+++ b/gapic/admin_client.go
@@ -128,7 +128,8 @@ func (c *AdminClient) setGoogleClientInfo(keyval ...string) {
 
 // Connection returns a connection to the API service.
 //
-// Deprecated.
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
 func (c *AdminClient) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
@@ -277,7 +278,8 @@ func NewAdminClient(ctx context.Context, opts ...option.ClientOption) (*AdminCli
 
 // Connection returns a connection to the API service.
 //
-// Deprecated.
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
 func (c *adminGRPCClient) Connection() *grpc.ClientConn {
 	return c.connPool.Conn()
 }

--- a/gapic/admin_client_example_test.go
+++ b/gapic/admin_client_example_test.go
@@ -27,6 +27,11 @@ import (
 
 func ExampleNewAdminClient() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -39,6 +44,11 @@ func ExampleNewAdminClient() {
 
 func ExampleAdminClient_GetStatus() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -59,6 +69,11 @@ func ExampleAdminClient_GetStatus() {
 
 func ExampleAdminClient_GetStorage() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -79,6 +94,11 @@ func ExampleAdminClient_GetStorage() {
 
 func ExampleAdminClient_MigrateDatabase() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -104,6 +124,11 @@ func ExampleAdminClient_MigrateDatabase() {
 
 func ExampleAdminClient_ListProjects() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -130,6 +155,11 @@ func ExampleAdminClient_ListProjects() {
 
 func ExampleAdminClient_GetProject() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -150,6 +180,11 @@ func ExampleAdminClient_GetProject() {
 
 func ExampleAdminClient_CreateProject() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -170,6 +205,11 @@ func ExampleAdminClient_CreateProject() {
 
 func ExampleAdminClient_UpdateProject() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -190,6 +230,11 @@ func ExampleAdminClient_UpdateProject() {
 
 func ExampleAdminClient_DeleteProject() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewAdminClient(ctx)
 	if err != nil {
 		// TODO: Handle error.

--- a/gapic/doc.go
+++ b/gapic/doc.go
@@ -19,6 +19,11 @@
 //
 // To get started with this package, create a client.
 //  ctx := context.Background()
+//  // This snippet has been automatically generated and should be regarded as a code template only.
+//  // It will require modifications to work:
+//  // - It may require correct/in-range values for request initialization.
+//  // - It may require specifying regional endpoints when creating the service client as shown in:
+//  //   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 //  c, err := gapic.NewRegistryClient(ctx)
 //  if err != nil {
 //  	// TODO: Handle error.
@@ -34,6 +39,11 @@
 // The following is an example of making an API call with the newly created client.
 //
 //  ctx := context.Background()
+//  // This snippet has been automatically generated and should be regarded as a code template only.
+//  // It will require modifications to work:
+//  // - It may require correct/in-range values for request initialization.
+//  // - It may require specifying regional endpoints when creating the service client as shown in:
+//  //   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 //  c, err := gapic.NewRegistryClient(ctx)
 //  if err != nil {
 //  	// TODO: Handle error.
@@ -59,7 +69,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewRegistryClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/gapic/provisioning_client.go
+++ b/gapic/provisioning_client.go
@@ -111,7 +111,8 @@ func (c *ProvisioningClient) setGoogleClientInfo(keyval ...string) {
 
 // Connection returns a connection to the API service.
 //
-// Deprecated.
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
 func (c *ProvisioningClient) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
@@ -220,7 +221,8 @@ func NewProvisioningClient(ctx context.Context, opts ...option.ClientOption) (*P
 
 // Connection returns a connection to the API service.
 //
-// Deprecated.
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
 func (c *provisioningGRPCClient) Connection() *grpc.ClientConn {
 	return c.connPool.Conn()
 }

--- a/gapic/provisioning_client_example_test.go
+++ b/gapic/provisioning_client_example_test.go
@@ -25,6 +25,11 @@ import (
 
 func ExampleNewProvisioningClient() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewProvisioningClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -37,6 +42,11 @@ func ExampleNewProvisioningClient() {
 
 func ExampleProvisioningClient_CreateInstance() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewProvisioningClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -62,6 +72,11 @@ func ExampleProvisioningClient_CreateInstance() {
 
 func ExampleProvisioningClient_DeleteInstance() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewProvisioningClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -85,6 +100,11 @@ func ExampleProvisioningClient_DeleteInstance() {
 
 func ExampleProvisioningClient_GetInstance() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewProvisioningClient(ctx)
 	if err != nil {
 		// TODO: Handle error.

--- a/gapic/registry_client.go
+++ b/gapic/registry_client.go
@@ -655,7 +655,8 @@ func (c *RegistryClient) setGoogleClientInfo(keyval ...string) {
 
 // Connection returns a connection to the API service.
 //
-// Deprecated.
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
 func (c *RegistryClient) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
@@ -910,7 +911,8 @@ func NewRegistryClient(ctx context.Context, opts ...option.ClientOption) (*Regis
 
 // Connection returns a connection to the API service.
 //
-// Deprecated.
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
 func (c *registryGRPCClient) Connection() *grpc.ClientConn {
 	return c.connPool.Conn()
 }

--- a/gapic/registry_client_example_test.go
+++ b/gapic/registry_client_example_test.go
@@ -26,6 +26,11 @@ import (
 
 func ExampleNewRegistryClient() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -38,6 +43,11 @@ func ExampleNewRegistryClient() {
 
 func ExampleRegistryClient_ListApis() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -64,6 +74,11 @@ func ExampleRegistryClient_ListApis() {
 
 func ExampleRegistryClient_GetApi() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -84,6 +99,11 @@ func ExampleRegistryClient_GetApi() {
 
 func ExampleRegistryClient_CreateApi() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -104,6 +124,11 @@ func ExampleRegistryClient_CreateApi() {
 
 func ExampleRegistryClient_UpdateApi() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -124,6 +149,11 @@ func ExampleRegistryClient_UpdateApi() {
 
 func ExampleRegistryClient_DeleteApi() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -142,6 +172,11 @@ func ExampleRegistryClient_DeleteApi() {
 
 func ExampleRegistryClient_ListApiVersions() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -168,6 +203,11 @@ func ExampleRegistryClient_ListApiVersions() {
 
 func ExampleRegistryClient_GetApiVersion() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -188,6 +228,11 @@ func ExampleRegistryClient_GetApiVersion() {
 
 func ExampleRegistryClient_CreateApiVersion() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -208,6 +253,11 @@ func ExampleRegistryClient_CreateApiVersion() {
 
 func ExampleRegistryClient_UpdateApiVersion() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -228,6 +278,11 @@ func ExampleRegistryClient_UpdateApiVersion() {
 
 func ExampleRegistryClient_DeleteApiVersion() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -246,6 +301,11 @@ func ExampleRegistryClient_DeleteApiVersion() {
 
 func ExampleRegistryClient_ListApiSpecs() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -272,6 +332,11 @@ func ExampleRegistryClient_ListApiSpecs() {
 
 func ExampleRegistryClient_GetApiSpec() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -292,6 +357,11 @@ func ExampleRegistryClient_GetApiSpec() {
 
 func ExampleRegistryClient_GetApiSpecContents() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -312,6 +382,11 @@ func ExampleRegistryClient_GetApiSpecContents() {
 
 func ExampleRegistryClient_CreateApiSpec() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -332,6 +407,11 @@ func ExampleRegistryClient_CreateApiSpec() {
 
 func ExampleRegistryClient_UpdateApiSpec() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -352,6 +432,11 @@ func ExampleRegistryClient_UpdateApiSpec() {
 
 func ExampleRegistryClient_DeleteApiSpec() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -370,6 +455,11 @@ func ExampleRegistryClient_DeleteApiSpec() {
 
 func ExampleRegistryClient_TagApiSpecRevision() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -390,6 +480,11 @@ func ExampleRegistryClient_TagApiSpecRevision() {
 
 func ExampleRegistryClient_ListApiSpecRevisions() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -416,6 +511,11 @@ func ExampleRegistryClient_ListApiSpecRevisions() {
 
 func ExampleRegistryClient_RollbackApiSpec() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -436,6 +536,11 @@ func ExampleRegistryClient_RollbackApiSpec() {
 
 func ExampleRegistryClient_DeleteApiSpecRevision() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -456,6 +561,11 @@ func ExampleRegistryClient_DeleteApiSpecRevision() {
 
 func ExampleRegistryClient_ListApiDeployments() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -482,6 +592,11 @@ func ExampleRegistryClient_ListApiDeployments() {
 
 func ExampleRegistryClient_GetApiDeployment() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -502,6 +617,11 @@ func ExampleRegistryClient_GetApiDeployment() {
 
 func ExampleRegistryClient_CreateApiDeployment() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -522,6 +642,11 @@ func ExampleRegistryClient_CreateApiDeployment() {
 
 func ExampleRegistryClient_UpdateApiDeployment() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -542,6 +667,11 @@ func ExampleRegistryClient_UpdateApiDeployment() {
 
 func ExampleRegistryClient_DeleteApiDeployment() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -560,6 +690,11 @@ func ExampleRegistryClient_DeleteApiDeployment() {
 
 func ExampleRegistryClient_TagApiDeploymentRevision() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -580,6 +715,11 @@ func ExampleRegistryClient_TagApiDeploymentRevision() {
 
 func ExampleRegistryClient_ListApiDeploymentRevisions() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -606,6 +746,11 @@ func ExampleRegistryClient_ListApiDeploymentRevisions() {
 
 func ExampleRegistryClient_RollbackApiDeployment() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -626,6 +771,11 @@ func ExampleRegistryClient_RollbackApiDeployment() {
 
 func ExampleRegistryClient_DeleteApiDeploymentRevision() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -646,6 +796,11 @@ func ExampleRegistryClient_DeleteApiDeploymentRevision() {
 
 func ExampleRegistryClient_ListArtifacts() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -672,6 +827,11 @@ func ExampleRegistryClient_ListArtifacts() {
 
 func ExampleRegistryClient_GetArtifact() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -692,6 +852,11 @@ func ExampleRegistryClient_GetArtifact() {
 
 func ExampleRegistryClient_GetArtifactContents() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -712,6 +877,11 @@ func ExampleRegistryClient_GetArtifactContents() {
 
 func ExampleRegistryClient_CreateArtifact() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -732,6 +902,11 @@ func ExampleRegistryClient_CreateArtifact() {
 
 func ExampleRegistryClient_ReplaceArtifact() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
@@ -752,6 +927,11 @@ func ExampleRegistryClient_ReplaceArtifact() {
 
 func ExampleRegistryClient_DeleteArtifact() {
 	ctx := context.Background()
+	// This snippet has been automatically generated and should be regarded as a code template only.
+	// It will require modifications to work:
+	// - It may require correct/in-range values for request initialization.
+	// - It may require specifying regional endpoints when creating the service client as shown in:
+	//   https://pkg.go.dev/cloud.google.com/go#hdr-Client_Options
 	c, err := gapic.NewRegistryClient(ctx)
 	if err != nil {
 		// TODO: Handle error.


### PR DESCRIPTION
This will hopefully reduce noise/churn for anyone regenerating the Go GAPIC.

Generated by running `make all` and committing the changed source files.