### PR TITLE
Registry tool: Deprecate `--contents` flag on `registry get`, replace it with `--print` and `--raw`

### DIFF
--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -24,6 +24,9 @@ import (
 
 func Command() *cobra.Command {
 	var getContents bool
+	var getRawContents bool
+	var getPrintedContents bool
+
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get resources from the API Registry",
@@ -35,6 +38,10 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
 			args[0] = c.FQName(args[0])
+			if getContents {
+				getPrintedContents = true
+				log.FromContext(ctx).Warn("--contents is deprecated, please use --print or --raw instead.")
+			}
 
 			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
@@ -57,22 +64,26 @@ func Command() *cobra.Command {
 			} else if version, err := names.ParseVersion(args[0]); err == nil {
 				err2 = core.GetVersion(ctx, client, version, core.PrintVersionDetail)
 			} else if spec, err := names.ParseSpec(args[0]); err == nil {
-				if getContents {
-					err2 = core.GetSpec(ctx, client, spec, getContents, core.PrintSpecContents)
+				// for specs, these options are synonymous
+				if getPrintedContents || getRawContents {
+					err2 = core.GetSpec(ctx, client, spec, true, core.WriteSpecContents)
 				} else {
-					err2 = core.GetSpec(ctx, client, spec, getContents, core.PrintSpecDetail)
+					err2 = core.GetSpec(ctx, client, spec, false, core.PrintSpecDetail)
 				}
 			} else if spec, err := names.ParseSpecRevision(args[0]); err == nil {
-				if getContents {
-					err2 = core.GetSpecRevision(ctx, client, spec, getContents, core.PrintSpecContents)
+				// for specs, these options are synonymous
+				if getPrintedContents || getRawContents {
+					err2 = core.GetSpecRevision(ctx, client, spec, true, core.WriteSpecContents)
 				} else {
-					err2 = core.GetSpecRevision(ctx, client, spec, getContents, core.PrintSpecDetail)
+					err2 = core.GetSpecRevision(ctx, client, spec, false, core.PrintSpecDetail)
 				}
 			} else if artifact, err := names.ParseArtifact(args[0]); err == nil {
-				if getContents {
-					err2 = core.GetArtifact(ctx, client, artifact, getContents, core.PrintArtifactContents)
+				if getPrintedContents {
+					err2 = core.GetArtifact(ctx, client, artifact, true, core.PrintArtifactContents)
+				} else if getRawContents {
+					err2 = core.GetArtifact(ctx, client, artifact, true, core.WriteArtifactContents)
 				} else {
-					err2 = core.GetArtifact(ctx, client, artifact, getContents, core.PrintArtifactDetail)
+					err2 = core.GetArtifact(ctx, client, artifact, false, core.PrintArtifactDetail)
 				}
 			} else {
 				log.Debugf(ctx, "Unsupported entity %+v", args)
@@ -83,6 +94,8 @@ func Command() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&getContents, "contents", false, "Include resource contents if available")
+	cmd.Flags().BoolVar(&getContents, "contents", false, "Get resource contents if available (deprecated)")
+	cmd.Flags().BoolVar(&getRawContents, "raw", false, "Get raw resource contents if available")
+	cmd.Flags().BoolVar(&getPrintedContents, "print", false, "Print resource contents if available")
 	return cmd
 }

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -89,10 +89,10 @@ func Command() *cobra.Command {
 					err2 = core.GetArtifact(ctx, client, artifact, false, core.PrintArtifactDetail)
 				}
 			} else {
-				log.Debugf(ctx, "Unsupported entity %+v", args)
+				log.Errorf(ctx, "Unsupported entity %+v", args)
 			}
 			if err2 != nil {
-				log.FromContext(ctx).WithError(err2).Debugf("Failed to get resource")
+				log.FromContext(ctx).WithError(err2).Errorf("Failed to get resource")
 			}
 		},
 	}

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -38,6 +38,9 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
 			args[0] = c.FQName(args[0])
+			if getContents && getRawContents || getContents && getPrintedContents || getRawContents && getPrintedContents {
+				log.FromContext(ctx).Fatal("Please use at most one of --print, --raw, and --contents.")
+			}
 			if getContents {
 				getPrintedContents = true
 				log.FromContext(ctx).Warn("--contents is deprecated, please use --print or --raw instead.")

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -156,9 +156,6 @@ func PrintArtifactContents(artifact *rpc.Artifact) error {
 		return unmarshalAndPrint(artifact.GetContents(), &openapiv2.Document{})
 	case "gnostic.openapiv3.Document":
 		return unmarshalAndPrint(artifact.GetContents(), &openapiv3.Document{})
-	case "google.protobuf.FileDescriptorSet":
-		os.Stdout.Write(artifact.GetContents())
-		return nil
 	default:
 		fmt.Printf("Unsupported message type: %s, please use --contents to get raw contents", messageType)
 		return nil

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -78,7 +78,7 @@ func PrintSpecDetail(message *rpc.ApiSpec) error {
 	return nil
 }
 
-func PrintSpecContents(message *rpc.ApiSpec) error {
+func WriteSpecContents(message *rpc.ApiSpec) error {
 	contents := message.GetContents()
 	if strings.Contains(message.GetMimeType(), "+gzip") {
 		contents, _ = GUnzippedBytes(contents)
@@ -94,6 +94,16 @@ func PrintArtifact(artifact *rpc.Artifact) error {
 
 func PrintArtifactDetail(artifact *rpc.Artifact) error {
 	PrintMessage(artifact)
+	return nil
+}
+
+func WriteArtifactContents(artifact *rpc.Artifact) error {
+	contents := artifact.GetContents()
+	if strings.Contains(artifact.GetMimeType(), "+gzip") {
+		contents, _ = GUnzippedBytes(contents)
+	}
+	os.Stdout.Write(contents)
+	os.Stdout.Write(artifact.GetContents())
 	return nil
 }
 
@@ -151,8 +161,11 @@ func PrintArtifactContents(artifact *rpc.Artifact) error {
 		return unmarshalAndPrint(artifact.GetContents(), &openapiv2.Document{})
 	case "gnostic.openapiv3.Document":
 		return unmarshalAndPrint(artifact.GetContents(), &openapiv3.Document{})
+	case "google.protobuf.FileDescriptorSet":
+		os.Stdout.Write(artifact.GetContents())
+		return nil
 	default:
-		fmt.Printf("%+v", artifact.GetContents())
+		fmt.Printf("Unsupported message type: %s, please use --contents to get raw contents", messageType)
 		return nil
 	}
 }

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -15,10 +15,12 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -157,7 +159,8 @@ func PrintArtifactContents(artifact *rpc.Artifact) error {
 	case "gnostic.openapiv3.Document":
 		return unmarshalAndPrint(artifact.GetContents(), &openapiv3.Document{})
 	default:
-		fmt.Printf("Unsupported message type: %s, please use --contents to get raw contents", messageType)
+		// To get a parent context here would require changing the ArtifactHandler type in handlers.go
+		log.FromContext(context.TODO()).Fatalf("Unsupported message type: %s, please use --raw to get raw contents", messageType)
 		return nil
 	}
 }

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -98,11 +98,6 @@ func PrintArtifactDetail(artifact *rpc.Artifact) error {
 }
 
 func WriteArtifactContents(artifact *rpc.Artifact) error {
-	contents := artifact.GetContents()
-	if strings.Contains(artifact.GetMimeType(), "+gzip") {
-		contents, _ = GUnzippedBytes(contents)
-	}
-	os.Stdout.Write(contents)
 	os.Stdout.Write(artifact.GetContents())
 	return nil
 }

--- a/cmd/registry/core/print.go
+++ b/cmd/registry/core/print.go
@@ -15,12 +15,10 @@
 package core
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -160,8 +158,7 @@ func PrintArtifactContents(artifact *rpc.Artifact) error {
 		return unmarshalAndPrint(artifact.GetContents(), &openapiv3.Document{})
 	default:
 		// To get a parent context here would require changing the ArtifactHandler type in handlers.go
-		log.FromContext(context.TODO()).Fatalf("Unsupported message type: %s, please use --raw to get raw contents", messageType)
-		return nil
+		return fmt.Errorf("Unsupported message type: %s, please use --raw to get raw contents", messageType)
 	}
 }
 


### PR DESCRIPTION
Prior to this change, the `registry get` command did not offer a way to directly access the raw contents of artifacts - it printed known types as JSON and for unknown types, it printed a nearly-useless text dump of bytes for unknown types. This adds two new flags to `registry get`:

- `--raw`, which causes the command to write the raw bytes of the artifact to standard output.
- `--print`, which causes the command to print a formatted version of known artifact types to standard output. For unknown types, an error is printed with a message to use `--raw` to access the raw bytes.

To avoid disruption, the `--contents` flag is kept and associated with `--print` but a deprecation warning is printed when it is used.

Likely followup issues:
1. modify `--print` for specs to disallow printing of zip archives.
2. unit testing of `registry get`.
3. (eventual) deletion of the `--contents` flag.