### PR TITLE
move most of wipeout to the server

### DIFF
--- a/pkg/wipeout/tasks.go
+++ b/pkg/wipeout/tasks.go
@@ -41,7 +41,7 @@ func (task *DeleteApiTask) String() string {
 
 func (task *DeleteApiTask) Run(ctx context.Context) error {
 	log.Debugf(ctx, "Deleting %s", task.name)
-	return task.client.DeleteApi(ctx, &rpc.DeleteApiRequest{Name: task.name})
+	return task.client.DeleteApi(ctx, &rpc.DeleteApiRequest{Name: task.name, Force: true})
 }
 
 // DeleteVersionTask deletes a specified version.


### PR DESCRIPTION
Removes much of the wipeout logic from the client and allows server to do the work. This is more efficient and leaves less chance of partial failure. 

In addition, it fixes #755 - the test was hanging on a channel read.