### PR TITLE
Enhance "registry apply" to infer --parent from registry configuration.

### DIFF
--- a/cmd/registry/cmd/apply/apply.go
+++ b/cmd/registry/cmd/apply/apply.go
@@ -36,6 +36,16 @@ func Command() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
+			if parent == "" {
+				c, err := connection.ActiveConfig()
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Fatal("Unable to identify parent: please use --parent or registry configuration")
+				}
+				parent, err = c.ProjectWithLocation()
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Fatal("Unable to identify parent: please use --parent or set registy.project in configuration")
+				}
+			}
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -15,6 +15,7 @@
 package connection
 
 import (
+	"errors"
 	"path"
 	"strings"
 
@@ -72,4 +73,14 @@ func (c Config) FQName(name string) string {
 		}
 	}
 	return name
+}
+
+func (c Config) ProjectWithLocation() (string, error) {
+	if c.Project == "" {
+		return "", errors.New("registry.project is not specified")
+	}
+	if c.Location == "" {
+		return "projects/" + c.Project + "/locations/global", nil
+	}
+	return "projects/" + c.Project + "/locations/" + c.Location, nil
 }


### PR DESCRIPTION
This makes `--parent` optional for `registry apply` by using the configured `registry.project` when it is nonempty.

Manually verified... I looked into writing tests for this and didn't see a good way to set the registry configuration in an isolated way. Reviewers, WDYT? I'm thinking maybe the tests should save the configuration, modify it as needed, and put it back afterwards, but that seems risky and messy. Since we're not actually running the registry tool in tests, could there be a better way to do this by writing the configuration data structures directly?