### PR TITLE
Allow overriding the registry tool configuration in tests.

### DIFF
--- a/cmd/registry/cmd/apply/apply_test.go
+++ b/cmd/registry/cmd/apply/apply_test.go
@@ -174,7 +174,10 @@ func TestApplyProject(t *testing.T) {
 	}
 
 	// set the configured registry.project to the test project
-	config, _ := connection.ActiveConfig()
+	config, err := connection.ActiveConfig()
+	if err != nil {
+		t.Fatalf("Setup: Failed to get registry configuration: %s", err)
+	}
 	config.Project = project.ProjectID
 	connection.SetConfig(config)
 

--- a/cmd/registry/cmd/apply/apply_test.go
+++ b/cmd/registry/cmd/apply/apply_test.go
@@ -174,7 +174,9 @@ func TestApplyProject(t *testing.T) {
 	}
 
 	// set the configured registry.project to the test project
-	connection.OverrideActiveConfigRegistryProject(project.ProjectID)
+	config, _ := connection.ActiveConfig()
+	config.Project = project.ProjectID
+	connection.SetConfig(config)
 
 	registryClient, err := connection.NewRegistryClient(ctx)
 	if err != nil {

--- a/cmd/registry/cmd/apply/apply_test.go
+++ b/cmd/registry/cmd/apply/apply_test.go
@@ -173,6 +173,9 @@ func TestApplyProject(t *testing.T) {
 		t.Fatalf("Setup: Failed to create test project: %s", err)
 	}
 
+	// set the configured registry.project to the test project
+	connection.OverrideActiveConfigRegistryProject(project.ProjectID)
+
 	registryClient, err := connection.NewRegistryClient(ctx)
 	if err != nil {
 		t.Fatalf("Setup: Failed to create registry client: %s", err)
@@ -180,7 +183,7 @@ func TestApplyProject(t *testing.T) {
 	defer registryClient.Close()
 
 	cmd := Command()
-	cmd.SetArgs([]string{"-f", sampleDir, "-R", "--parent", project.String() + "/locations/global"})
+	cmd.SetArgs([]string{"-f", sampleDir, "-R"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() with args %+v returned error: %s", cmd.Args, err)
 	}

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -33,17 +33,17 @@ type Config struct {
 
 // If set, ActiveConfig() returns this configuration.
 // This is intended for use in testing.
-var override *Config
+var active *Config
 
 // SetConfig forces the active configuration to use the specified value.
 func SetConfig(config Config) {
-	override = &config
+	active = &config
 }
 
 // ActiveConfig returns the active config.
 func ActiveConfig() (Config, error) {
-	if override != nil {
-		return *override, nil
+	if active != nil {
+		return *active, nil
 	}
 
 	name, err := config.ActiveName()

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -31,27 +31,19 @@ type Config struct {
 	Token    string `mapstructure:"token"`    // bearer token
 }
 
-// OverrideActiveConfigRegistryProject forces the active configuration to use the specified project.
-func OverrideActiveConfigRegistryProject(project string) {
-	// force the config to be read and cached
-	useCache = true
-	_, err := ActiveConfig()
-	if err == nil && cachedConfig != nil {
-		cachedConfig.Project = project
-	}
-}
+// If set, ActiveConfig() returns this configuration.
+// This is intended for use in testing.
+var override *Config
 
-var cachedConfig *Config
-var useCache bool
-
-func ClearCachedConfig() {
-	cachedConfig = nil
+// SetConfig forces the active configuration to use the specified value.
+func SetConfig(config Config) {
+	override = &config
 }
 
 // ActiveConfig returns the active config.
 func ActiveConfig() (Config, error) {
-	if cachedConfig != nil {
-		return *cachedConfig, nil
+	if override != nil {
+		return *override, nil
 	}
 
 	name, err := config.ActiveName()
@@ -59,11 +51,7 @@ func ActiveConfig() (Config, error) {
 		return Config{}, err
 	}
 
-	c, err := ReadConfig(name)
-	if useCache {
-		cachedConfig = &c
-	}
-	return c, err
+	return ReadConfig(name)
 }
 
 // Reads a Config from a file. If name is empty, no


### PR DESCRIPTION
This includes modifications to the config package that allow the registry.project to be forced to particular values during testing.

I'm not attached to the implementation, this is just one way to pursue a goal of testing the registry tool under different configurations without modifying files in possibly-surprising ways.