### PR TITLE
Address postgres failures in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:14.5
         env:
           # Define a super user. Password for super user is required.
           POSTGRES_USER: postgres


### PR DESCRIPTION
Something started suddenly going wrong with our Postgres tests:
```
Run go test ./server/registry -postgresql
 ERROR[0000] Failed database operation. duration=[6](https://github.com/apigee/registry/actions/runs/3284143678/jobs/5410886922#step:10:7)44.309µs error=pq: permission denied for schema public query=CREATE TABLE "projects" ("key" text,"project_id" text,"display_name" text,"description" text,"create_time" timestamptz,"update_time" timestamptz,PRIMARY KEY ("key"))
  INFO[0000] Unhandled *pq.Error pq: permission denied for schema public code=42501 name=insufficient_privilege
--- FAIL: TestCreateApi (0.05s)
    --- FAIL: TestCreateApi/fully_populated_resource (0.05s)
        actions_apis_test.go:[8](https://github.com/apigee/registry/actions/runs/3284143678/jobs/5410886922#step:10:9)1: Setup: failed to get server with postgres: rpc error: code = Internal desc = pq: permission denied for schema public
        actions_apis_test.go:81: Falling back to server with SQLite storage
```
This was occurring in multiple branches with no apparent relationship to recent changes.

The latest postgres image on dockerhub looks pretty fresh: four days old as of now. https://hub.docker.com/_/postgres/tags

Pinning to postgres:14.5 seems to fix the problems. Going forward, I think it would be good to avoid floating dependencies in tests.