### PR TITLE
In testing, don't fallback to sqlite when postgres is specified and unavailable.

### DIFF
--- a/server/registry/server_test.go
+++ b/server/registry/server_test.go
@@ -65,22 +65,21 @@ func defaultTestServer(t *testing.T) TestServer {
 	if hostedProject != "" {
 		p := remote.NewProxyForHostedService(hostedProject)
 		if err = p.Open(context.Background()); err != nil {
-			t.Fatalf("Fatalf: failed to connect to remote server: %s", err)
+			t.Fatalf("Setup: failed to connect to remote server: %s", err)
 		}
 		return p
 	}
 	if useRemote {
 		p := &remote.Proxy{}
 		if err = p.Open(context.Background()); err != nil {
-			t.Fatalf("Fatalf: failed to connect to remote server: %s", err)
+			t.Fatalf("Setup: failed to connect to remote server: %s", err)
 		}
 		return p
 	}
 	if usePostgres {
 		server, err = serverWithPostgres(t)
 		if err != nil {
-			t.Errorf("Setup: failed to get server with postgres: %s", err)
-			t.Log("Falling back to server with SQLite storage")
+			t.Fatalf("Setup: failed to get server with postgres: %s", err)
 		}
 	}
 	if server == nil {


### PR DESCRIPTION
While debugging #786 I saw a lot of messages in the logs saying that we were falling back to sqlite after the postgres setup failed.

What do we lose by removing that fallback? Here's a change that does so. The postgres test setup seems to be tied to the `-postgres` flag, so I think it would be reasonable to fail when we can't connect to postgres.