### PR TITLE
Replace ubuntu-latest in actions with ubuntu-22.04

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ env:
   DOCKER_REPOSITORY_OWNER: ${{github.repository_owner}}
 jobs:
   build-registry-server:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
         file: containers/registry-server/Dockerfile
 
   build-registry-tools:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
         file: containers/registry-tools/Dockerfile
 
   build-registry-envoy:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ env:
   DOCKER_REPOSITORY_OWNER: ${{github.repository_owner}}
 jobs:
   build-registry-server:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
         file: containers/registry-server/Dockerfile
 
   build-registry-tools:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
         file: containers/registry-tools/Dockerfile
 
   build-registry-envoy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:14.5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     services:
       postgres:
         image: postgres:14.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Feeling a bit burned by the surprise failures that led to #786, I'd like to also pin the ubuntu image used in testing to an explicit version. Any concerns?