### PR TITLE
Report foreign key errors as InvalidArgument errors.

### DIFF
--- a/server/registry/internal/storage/errors.go
+++ b/server/registry/internal/storage/errors.go
@@ -77,7 +77,7 @@ func grpcErrorForDBError(ctx context.Context, err error) error {
 		} else if v.Code.Name() == "query_canceled" {
 			return status.Error(codes.Canceled, cause.Error())
 		} else if v.Code.Name() == "foreign_key_violation" {
-			return status.Error(codes.NotFound, cause.Error())
+			return status.Error(codes.InvalidArgument, cause.Error())
 		}
 		log.Infof(ctx, "Unhandled %T %+v code=%s name=%s", v, v, v.Code, v.Code.Name())
 	case *net.OpError:

--- a/server/registry/internal/storage/errors_cgo_enabled.go
+++ b/server/registry/internal/storage/errors_cgo_enabled.go
@@ -48,7 +48,7 @@ func grpcErrorForSQLite3Error(ctx context.Context, err error) error {
 			return status.Error(codes.Unavailable, err.Error())
 		}
 		if v.Code == sqlite3.ErrConstraint && v.ExtendedCode == sqlite3.ErrConstraintForeignKey {
-			return status.Error(codes.NotFound, v.ExtendedCode.Error())
+			return status.Error(codes.InvalidArgument, v.ExtendedCode.Error())
 		}
 		log.Infof(ctx, "Unhandled %T %+v code=%d extended=%d", v, v, v.Code, v.ExtendedCode)
 	}


### PR DESCRIPTION
Just curious to see what happens if we return `InvalidArgument` instead of `NotFound` for foreign key violations.