### PR TITLE
Temporarily disable flaky bulk upload tests.

### DIFF
--- a/cmd/registry/cmd/upload/bulk/openapi_test.go
+++ b/cmd/registry/cmd/upload/bulk/openapi_test.go
@@ -34,6 +34,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpenAPI(t *testing.T) {
+	t.Skip("temporarily disabled due to flakiness")
 	const (
 		projectID   = "openapi-test"
 		projectName = "projects/" + projectID

--- a/cmd/registry/cmd/upload/bulk/protos_test.go
+++ b/cmd/registry/cmd/upload/bulk/protos_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestProtos(t *testing.T) {
+	t.Skip("temporarily disabled due to flakiness")
 	const (
 		projectID   = "protos-test"
 		projectName = "projects/" + projectID


### PR DESCRIPTION
Discussed in #785, these tests are adding too much noise to CI.