### PR TITLE
Enhance registry compute complexity to support gzipped specs, add test.

### DIFF
--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -17,6 +17,7 @@ package compute
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
@@ -109,57 +110,64 @@ func (task *computeComplexityTask) String() string {
 }
 
 func (task *computeComplexityTask) Run(ctx context.Context) error {
-	request := &rpc.GetApiSpecContentsRequest{
-		Name: task.specName,
-	}
-	spec, err := task.client.GetApiSpecContents(ctx, request)
+	specName, err := names.ParseSpecRevision(task.specName)
 	if err != nil {
 		return err
 	}
-	relation := "complexity"
-	log.Debugf(ctx, "Computing %s/artifacts/%s", task.specName, relation)
-	var complexity *metrics.Complexity
-	if core.IsOpenAPIv2(spec.GetContentType()) {
-		document, err := oas2.ParseDocument(spec.GetData())
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Errorf("Invalid OpenAPI: %s", task.specName)
-			return nil
-		}
-		complexity = core.SummarizeOpenAPIv2Document(document)
-	} else if core.IsOpenAPIv3(spec.GetContentType()) {
-		document, err := oas3.ParseDocument(spec.GetData())
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Errorf("Invalid OpenAPI: %s", task.specName)
-			return nil
-		}
-		complexity = core.SummarizeOpenAPIv3Document(document)
-	} else if core.IsDiscovery(spec.GetContentType()) {
-		document, err := discovery.ParseDocument(spec.GetData())
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Errorf("Invalid Discovery: %s", task.specName)
-			return nil
-		}
-		complexity = core.SummarizeDiscoveryDocument(document)
-	} else if core.IsProto(spec.GetContentType()) && core.IsZipArchive(spec.GetContentType()) {
-		complexity, err = core.SummarizeZippedProtos(spec.GetData())
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Errorf("Error processing protos: %s", task.specName)
-			return nil
-		}
-	} else {
-		return fmt.Errorf("we don't know how to summarize %s", task.specName)
-	}
+	return core.GetSpecRevision(ctx, task.client, specName, true,
+		func(spec *rpc.ApiSpec) error {
+			relation := "complexity"
+			log.Debugf(ctx, "Computing %s/artifacts/%s", task.specName, relation)
+			contents := spec.GetContents()
+			if strings.Contains(spec.GetMimeType(), "+gzip") {
+				if contents, err = core.GUnzippedBytes(contents); err != nil {
+					return err
+				}
+			}
+			var complexity *metrics.Complexity
+			if core.IsOpenAPIv2(spec.GetMimeType()) {
+				document, err := oas2.ParseDocument(contents)
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Errorf("Invalid OpenAPI: %s", task.specName)
+					return nil
+				}
+				complexity = core.SummarizeOpenAPIv2Document(document)
+			} else if core.IsOpenAPIv3(spec.GetMimeType()) {
+				document, err := oas3.ParseDocument(contents)
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Errorf("Invalid OpenAPI: %s", task.specName)
+					return nil
+				}
+				complexity = core.SummarizeOpenAPIv3Document(document)
+			} else if core.IsDiscovery(spec.GetMimeType()) {
+				document, err := discovery.ParseDocument(contents)
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Errorf("Invalid Discovery: %s", task.specName)
+					return nil
+				}
+				complexity = core.SummarizeDiscoveryDocument(document)
+			} else if core.IsProto(spec.GetMimeType()) && core.IsZipArchive(spec.GetMimeType()) {
+				complexity, err = core.SummarizeZippedProtos(spec.GetContents())
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Errorf("Error processing protos: %s", task.specName)
+					return nil
+				}
+			} else {
+				return fmt.Errorf("we don't know how to summarize %s", task.specName)
+			}
 
-	if task.dryRun {
-		core.PrintMessage(complexity)
-		return nil
-	}
-	subject := task.specName
-	messageData, _ := proto.Marshal(complexity)
-	artifact := &rpc.Artifact{
-		Name:     subject + "/artifacts/" + relation,
-		MimeType: core.MimeTypeForMessageType("gnostic.metrics.Complexity"),
-		Contents: messageData,
-	}
-	return core.SetArtifact(ctx, task.client, artifact)
+			if task.dryRun {
+				core.PrintMessage(complexity)
+				return nil
+			}
+			subject := task.specName
+			messageData, _ := proto.Marshal(complexity)
+			artifact := &rpc.Artifact{
+				Name:     subject + "/artifacts/" + relation,
+				MimeType: core.MimeTypeForMessageType("gnostic.metrics.Complexity"),
+				Contents: messageData,
+			}
+			return core.SetArtifact(ctx, task.client, artifact)
+		},
+	)
 }

--- a/cmd/registry/cmd/compute/complexity.go
+++ b/cmd/registry/cmd/compute/complexity.go
@@ -153,7 +153,7 @@ func (task *computeComplexityTask) Run(ctx context.Context) error {
 		}
 		complexity = core.SummarizeDiscoveryDocument(document)
 	} else if core.IsProto(spec.GetMimeType()) && core.IsZipArchive(spec.GetMimeType()) {
-		complexity, err = core.SummarizeZippedProtos(spec.GetContents())
+		complexity, err = core.SummarizeZippedProtos(contents)
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Errorf("Error processing protos: %s", task.specName)
 			return nil

--- a/cmd/registry/cmd/compute/complexity_test.go
+++ b/cmd/registry/cmd/compute/complexity_test.go
@@ -1,0 +1,159 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry/names"
+	metrics "github.com/google/gnostic/metrics"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestComplexity(t *testing.T) {
+	tests := []struct {
+		desc       string
+		apiId      string
+		versionId  string
+		specId     string
+		specFile   string
+		mimeType   string
+		getPattern string
+		wantProto  *metrics.Complexity
+	}{
+		{
+			desc:      "petstore-openapi",
+			apiId:     "petstore",
+			versionId: "1.0.0",
+			specId:    "openapi",
+			specFile:  "openapi.yaml",
+			mimeType:  "application/x.openapi+gzip;version=3.0.0",
+			wantProto: &metrics.Complexity{
+				PathCount:           2,
+				GetCount:            2,
+				PostCount:           1,
+				PutCount:            0,
+				DeleteCount:         0,
+				SchemaCount:         8,
+				SchemaPropertyCount: 5,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			client, err := connection.NewRegistryClient(ctx)
+			if err != nil {
+				t.Fatalf("Setup: Failed to create client: %s", err)
+			}
+			adminClient, err := connection.NewAdminClient(ctx)
+			if err != nil {
+				t.Fatalf("Setup: Failed to create client: %s", err)
+			}
+			testProject := "complexity-test"
+			err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+				Name:  "projects/" + testProject,
+				Force: true,
+			})
+			if err != nil && status.Code(err) != codes.NotFound {
+				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+			project, err := adminClient.CreateProject(ctx, &rpc.CreateProjectRequest{
+				ProjectId: testProject,
+				Project: &rpc.Project{
+					DisplayName: testProject,
+					Description: "Test project",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create project %s: %s", testProject, err.Error())
+			}
+			api, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
+				Parent: project.Name + "/locations/global",
+				ApiId:  test.apiId,
+				Api: &rpc.Api{
+					DisplayName: test.apiId,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API %s: %s", test.apiId, err.Error())
+			}
+			v1, err := client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
+				Parent:       api.Name,
+				ApiVersionId: test.versionId,
+				ApiVersion:   &rpc.ApiVersion{},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create version %s: %s", test.versionId, err.Error())
+			}
+			buf, err := readAndGZipFile(t, filepath.Join("testdata", test.specFile))
+			if err != nil {
+				t.Fatalf("Failed reading spec contents: %s", err.Error())
+			}
+			req := &rpc.CreateApiSpecRequest{
+				Parent:    v1.Name,
+				ApiSpecId: test.specId,
+				ApiSpec: &rpc.ApiSpec{
+					MimeType: test.mimeType,
+					Contents: buf.Bytes(),
+				},
+			}
+			spec, err := client.CreateApiSpec(ctx, req)
+			if err != nil {
+				t.Fatalf("Failed CreateApiSpec(%v): %s", req, err.Error())
+			}
+			complexityCommand := Command()
+			args := []string{"complexity", spec.Name}
+			complexityCommand.SetArgs(args)
+			if err = complexityCommand.Execute(); err != nil {
+				t.Fatalf("Execute() with args %v returned error: %s", args, err)
+			}
+			specName, err := names.ParseSpec(spec.Name)
+			if err != nil {
+				t.Fatalf("Failed parsing spec name %s: %s", spec.Name, err)
+			}
+			contents, err := client.GetArtifactContents(ctx, &rpc.GetArtifactContentsRequest{
+				Name: specName.Artifact("complexity").String(),
+			})
+			if err != nil {
+				t.Fatalf("Failed getting artifact contents %s: %s", test.getPattern, err)
+			}
+			gotProto := &metrics.Complexity{}
+			if err := proto.Unmarshal(contents.GetData(), gotProto); err != nil {
+				t.Fatalf("Failed to unmarshal artifact: %s", err)
+			}
+			opts := cmp.Options{protocmp.Transform()}
+			if !cmp.Equal(test.wantProto, gotProto, opts) {
+				t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(test.wantProto, gotProto, opts))
+			}
+			err = adminClient.DeleteProject(ctx, &rpc.DeleteProjectRequest{
+				Name:  "projects/" + testProject,
+				Force: true,
+			})
+			if err != nil && status.Code(err) != codes.NotFound {
+				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I noticed that `registry compute complexity` wasn't working for large specs, even if they were stored gzipped, because it was downloading them without allowing for gzip encoding. This change uses a standard utility from the `registry` tool's `core` package and now supports both gzipped and plain specs. I've also added one test for `compute complexity` and think we could easily add more if needed.