### PR TITLE
Enhance UpdateSequence tests to verify create and update timestamps.

### DIFF
--- a/server/registry/actions_apis_test.go
+++ b/server/registry/actions_apis_test.go
@@ -1156,6 +1156,9 @@ func TestUpdateApiSequence(t *testing.T) {
 	}
 	var createTime time.Time
 	var updateTime time.Time
+	// NOTE: in the following sequence of tests, each test depends on its predecessor.
+	// Resources are successively created and updated using the "Update" RPC and the
+	// tests verify that CreateTime/UpdateTime fields are modified appropriately.
 	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var result *rpc.Api

--- a/server/registry/actions_apis_test.go
+++ b/server/registry/actions_apis_test.go
@@ -1143,7 +1143,7 @@ func TestUpdateApiSequence(t *testing.T) {
 				Api: &rpc.Api{
 					Name: "projects/my-project/locations/global/apis/a",
 				},
-				AllowMissing: true,
+				AllowMissing: false,
 			},
 			want: codes.OK,
 		},

--- a/server/registry/actions_apis_test.go
+++ b/server/registry/actions_apis_test.go
@@ -1168,10 +1168,10 @@ func TestUpdateApiSequence(t *testing.T) {
 					createTime = result.CreateTime.AsTime()
 					updateTime = result.UpdateTime.AsTime()
 				} else {
-					if (!createTime.Equal(result.CreateTime.AsTime())) {
+					if !createTime.Equal(result.CreateTime.AsTime()) {
 						t.Errorf("UpdateApi create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
 					}
-					if (!updateTime.Before(result.UpdateTime.AsTime())) {
+					if !updateTime.Before(result.UpdateTime.AsTime()) {
 						t.Errorf("UpdateApi update time did not increase after update (%v %v)", updateTime, result.UpdateTime.AsTime())
 					}
 					updateTime = result.UpdateTime.AsTime()

--- a/server/registry/actions_artifacts.go
+++ b/server/registry/actions_artifacts.go
@@ -290,6 +290,7 @@ func (s *RegistryServer) ReplaceArtifact(ctx context.Context, req *rpc.ReplaceAr
 		if err != nil {
 			return err
 		}
+		artifact.CreateTime = art.CreateTime // preserve creation time
 		artifact.RevisionID = art.RevisionID // revision is optional in request
 		if err := db.SaveArtifact(ctx, artifact); err != nil {
 			return err

--- a/server/registry/actions_artifacts_test.go
+++ b/server/registry/actions_artifacts_test.go
@@ -1313,7 +1313,9 @@ func TestReplaceArtifactSequence(t *testing.T) {
 	}
 	createTime := a.CreateTime.AsTime()
 	updateTime := a.UpdateTime.AsTime()
-
+	// NOTE: in the following sequence of tests, each test depends on its predecessor.
+	// Resources are successively updated using the "Replace" RPC and the
+	// tests verify that CreateTime/UpdateTime fields are modified appropriately.
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var result *rpc.Artifact

--- a/server/registry/actions_artifacts_test.go
+++ b/server/registry/actions_artifacts_test.go
@@ -1313,6 +1313,66 @@ func TestReplaceArtifactResponseCodes(t *testing.T) {
 	}
 }
 
+func TestReplaceArtifactSequence(t *testing.T) {
+	tests := []struct {
+		desc string
+		req  *rpc.ReplaceArtifactRequest
+		want codes.Code
+	}{
+		{
+			desc: "first replacement",
+			req: &rpc.ReplaceArtifactRequest{
+				Artifact: &rpc.Artifact{
+					Name: "projects/my-project/locations/global/artifacts/a",
+				},
+			},
+			want: codes.OK,
+		},
+		{
+			desc: "second replacement",
+			req: &rpc.ReplaceArtifactRequest{
+				Artifact: &rpc.Artifact{
+					Name: "projects/my-project/locations/global/artifacts/a",
+				},
+			},
+			want: codes.OK,
+		},
+	}
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seed := &rpc.Artifact{Name: "projects/my-project/locations/global/artifacts/a"}
+	if err := seeder.SeedArtifacts(ctx, server, seed); err != nil {
+		t.Fatalf("Setup/Seeding: Failed to seed registry: %s", err)
+	}
+	a, err := server.GetArtifact(ctx, &rpc.GetArtifactRequest{
+		Name: "projects/my-project/locations/global/artifacts/a",
+	})
+	if err != nil {
+		t.Fatalf("Setup/Seeding: Failed to get seeded artifact: %s", err)
+	}
+	createTime := a.CreateTime.AsTime()
+	updateTime := a.UpdateTime.AsTime()
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var result *rpc.Artifact
+			var err error
+			if result, err = server.ReplaceArtifact(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("UpdateApi(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+			if result != nil {
+				if !createTime.Equal(result.CreateTime.AsTime()) {
+					t.Errorf("ReplaceArtifact create time changed after replace (%v %v)", createTime, result.CreateTime.AsTime())
+				}
+				if !updateTime.Before(result.UpdateTime.AsTime()) {
+					t.Errorf("ReplaceArtifact update time did not increase after replace (%v %v)", updateTime, result.UpdateTime.AsTime())
+				}
+				updateTime = result.UpdateTime.AsTime()
+			}
+		})
+	}
+}
+
 func TestDeleteArtifact(t *testing.T) {
 	tests := []struct {
 		desc string

--- a/server/registry/actions_deployments_test.go
+++ b/server/registry/actions_deployments_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/test/seeder"
@@ -1172,6 +1173,91 @@ func TestUpdateApiDeploymentResponseCodes(t *testing.T) {
 
 			if _, err := server.UpdateApiDeployment(ctx, test.req); status.Code(err) != test.want {
 				t.Errorf("UpdateApiDeployment(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
+func TestUpdateApiDeploymentSequence(t *testing.T) {
+	tests := []struct {
+		desc string
+		req  *rpc.UpdateApiDeploymentRequest
+		want codes.Code
+	}{
+		{
+			desc: "create using update with allow_missing=false",
+			req: &rpc.UpdateApiDeploymentRequest{
+				ApiDeployment: &rpc.ApiDeployment{
+					Name: "projects/my-project/locations/global/apis/a/deployments/d",
+				},
+				AllowMissing: false,
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "create using update with allow_missing=true",
+			req: &rpc.UpdateApiDeploymentRequest{
+				ApiDeployment: &rpc.ApiDeployment{
+					Name: "projects/my-project/locations/global/apis/a/deployments/d",
+				},
+				AllowMissing: true,
+			},
+			want: codes.OK,
+		},
+		{
+			desc: "update existing resource with allow_missing=true",
+			req: &rpc.UpdateApiDeploymentRequest{
+				ApiDeployment: &rpc.ApiDeployment{
+					Name: "projects/my-project/locations/global/apis/a/deployments/d",
+				},
+				AllowMissing: true,
+			},
+			want: codes.OK,
+		},
+		{
+			desc: "update existing resource with allow_missing=false",
+			req: &rpc.UpdateApiDeploymentRequest{
+				ApiDeployment: &rpc.ApiDeployment{
+					Name: "projects/my-project/locations/global/apis/a/deployments/d",
+				},
+				AllowMissing: true,
+			},
+			want: codes.OK,
+		},
+	}
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seed := &rpc.Api{Name: "projects/my-project/locations/global/apis/a"}
+	if err := seeder.SeedApis(ctx, server, seed); err != nil {
+		t.Fatalf("Setup/Seeding: Failed to seed registry: %s", err)
+	}
+	var createTime time.Time
+	var revisionCreateTime time.Time
+	var revisionUpdateTime time.Time
+	for i, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var result *rpc.ApiDeployment
+			var err error
+			if result, err = server.UpdateApiDeployment(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("UpdateApiDeployment(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+			if result != nil {
+				if i == 1 {
+					createTime = result.CreateTime.AsTime()
+					revisionCreateTime = result.RevisionCreateTime.AsTime()
+					revisionUpdateTime = result.RevisionUpdateTime.AsTime()
+				} else {
+					if !createTime.Equal(result.CreateTime.AsTime()) {
+						t.Errorf("UpdateApiDeployment create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
+					}
+					if !revisionCreateTime.Equal(result.RevisionCreateTime.AsTime()) {
+						t.Errorf("UpdateApiDeployment revision create time changed after update (%v %v)", revisionCreateTime, result.RevisionCreateTime.AsTime())
+					}
+					if !revisionUpdateTime.Before(result.RevisionUpdateTime.AsTime()) {
+						t.Errorf("UpdateApiDeployment update time did not increase after update (%v %v)", revisionUpdateTime, result.RevisionUpdateTime.AsTime())
+					}
+					revisionUpdateTime = result.RevisionUpdateTime.AsTime()
+				}
 			}
 		})
 	}

--- a/server/registry/actions_deployments_test.go
+++ b/server/registry/actions_deployments_test.go
@@ -1234,6 +1234,9 @@ func TestUpdateApiDeploymentSequence(t *testing.T) {
 	var createTime time.Time
 	var revisionCreateTime time.Time
 	var revisionUpdateTime time.Time
+	// NOTE: in the following sequence of tests, each test depends on its predecessor.
+	// Resources are successively created and updated using the "Update" RPC and the
+	// tests verify that CreateTime/UpdateTime fields are modified appropriately.
 	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var result *rpc.ApiDeployment

--- a/server/registry/actions_deployments_test.go
+++ b/server/registry/actions_deployments_test.go
@@ -1220,7 +1220,7 @@ func TestUpdateApiDeploymentSequence(t *testing.T) {
 				ApiDeployment: &rpc.ApiDeployment{
 					Name: "projects/my-project/locations/global/apis/a/deployments/d",
 				},
-				AllowMissing: true,
+				AllowMissing: false,
 			},
 			want: codes.OK,
 		},

--- a/server/registry/actions_projects_test.go
+++ b/server/registry/actions_projects_test.go
@@ -1037,7 +1037,7 @@ func TestUpdateProjectSequence(t *testing.T) {
 				Project: &rpc.Project{
 					Name: "projects/my-project",
 				},
-				AllowMissing: true,
+				AllowMissing: false,
 			},
 			want: codes.OK,
 		},

--- a/server/registry/actions_projects_test.go
+++ b/server/registry/actions_projects_test.go
@@ -1046,6 +1046,9 @@ func TestUpdateProjectSequence(t *testing.T) {
 	server := defaultTestServer(t)
 	var createTime time.Time
 	var updateTime time.Time
+	// NOTE: in the following sequence of tests, each test depends on its predecessor.
+	// Resources are successively created and updated using the "Update" RPC and the
+	// tests verify that CreateTime/UpdateTime fields are modified appropriately
 	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var result *rpc.Project

--- a/server/registry/actions_projects_test.go
+++ b/server/registry/actions_projects_test.go
@@ -1058,10 +1058,10 @@ func TestUpdateProjectSequence(t *testing.T) {
 					createTime = result.CreateTime.AsTime()
 					updateTime = result.UpdateTime.AsTime()
 				} else {
-					if (!createTime.Equal(result.CreateTime.AsTime())) {
+					if !createTime.Equal(result.CreateTime.AsTime()) {
 						t.Errorf("UpdateProject create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
 					}
-					if (!updateTime.Before(result.UpdateTime.AsTime())) {
+					if !updateTime.Before(result.UpdateTime.AsTime()) {
 						t.Errorf("UpdateProject update time did not increase after update (%v %v)", updateTime, result.UpdateTime.AsTime())
 					}
 					updateTime = result.UpdateTime.AsTime()

--- a/server/registry/actions_projects_test.go
+++ b/server/registry/actions_projects_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/test/seeder"
@@ -1043,10 +1044,28 @@ func TestUpdateProjectSequence(t *testing.T) {
 	}
 	ctx := context.Background()
 	server := defaultTestServer(t)
-	for _, test := range tests {
+	var createTime time.Time
+	var updateTime time.Time
+	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			if _, err := server.UpdateProject(ctx, test.req); status.Code(err) != test.want {
+			var result *rpc.Project
+			var err error
+			if result, err = server.UpdateProject(ctx, test.req); status.Code(err) != test.want {
 				t.Errorf("UpdateProject(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+			if result != nil {
+				if i == 1 {
+					createTime = result.CreateTime.AsTime()
+					updateTime = result.UpdateTime.AsTime()
+				} else {
+					if (!createTime.Equal(result.CreateTime.AsTime())) {
+						t.Errorf("UpdateProject create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
+					}
+					if (!updateTime.Before(result.UpdateTime.AsTime())) {
+						t.Errorf("UpdateProject update time did not increase after update (%v %v)", updateTime, result.UpdateTime.AsTime())
+					}
+					updateTime = result.UpdateTime.AsTime()
+				}
 			}
 		})
 	}

--- a/server/registry/actions_specs_test.go
+++ b/server/registry/actions_specs_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/test/seeder"
@@ -1479,6 +1480,91 @@ func TestUpdateApiSpecResponseCodes(t *testing.T) {
 
 			if _, err := server.UpdateApiSpec(ctx, test.req); status.Code(err) != test.want {
 				t.Errorf("UpdateApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+		})
+	}
+}
+
+func TestUpdateApiSpecSequence(t *testing.T) {
+	tests := []struct {
+		desc string
+		req  *rpc.UpdateApiSpecRequest
+		want codes.Code
+	}{
+		{
+			desc: "create using update with allow_missing=false",
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/my-project/locations/global/apis/a/versions/v/specs/s",
+				},
+				AllowMissing: false,
+			},
+			want: codes.NotFound,
+		},
+		{
+			desc: "create using update with allow_missing=true",
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/my-project/locations/global/apis/a/versions/v/specs/s",
+				},
+				AllowMissing: true,
+			},
+			want: codes.OK,
+		},
+		{
+			desc: "update existing resource with allow_missing=true",
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/my-project/locations/global/apis/a/versions/v/specs/s",
+				},
+				AllowMissing: true,
+			},
+			want: codes.OK,
+		},
+		{
+			desc: "update existing resource with allow_missing=false",
+			req: &rpc.UpdateApiSpecRequest{
+				ApiSpec: &rpc.ApiSpec{
+					Name: "projects/my-project/locations/global/apis/a/versions/v/specs/s",
+				},
+				AllowMissing: true,
+			},
+			want: codes.OK,
+		},
+	}
+	ctx := context.Background()
+	server := defaultTestServer(t)
+	seed := &rpc.ApiVersion{Name: "projects/my-project/locations/global/apis/a/versions/v"}
+	if err := seeder.SeedVersions(ctx, server, seed); err != nil {
+		t.Fatalf("Setup/Seeding: Failed to seed registry: %s", err)
+	}
+	var createTime time.Time
+	var revisionCreateTime time.Time
+	var revisionUpdateTime time.Time
+	for i, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var result *rpc.ApiSpec
+			var err error
+			if result, err = server.UpdateApiSpec(ctx, test.req); status.Code(err) != test.want {
+				t.Errorf("UpdateApiSpec(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+			if result != nil {
+				if i == 1 {
+					createTime = result.CreateTime.AsTime()
+					revisionCreateTime = result.RevisionCreateTime.AsTime()
+					revisionUpdateTime = result.RevisionUpdateTime.AsTime()
+				} else {
+					if !createTime.Equal(result.CreateTime.AsTime()) {
+						t.Errorf("UpdateApiSpec create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
+					}
+					if !revisionCreateTime.Equal(result.RevisionCreateTime.AsTime()) {
+						t.Errorf("UpdateApiSpec revision create time changed after update (%v %v)", revisionCreateTime, result.RevisionCreateTime.AsTime())
+					}
+					if !revisionUpdateTime.Before(result.RevisionUpdateTime.AsTime()) {
+						t.Errorf("UpdateApiSpec update time did not increase after update (%v %v)", revisionUpdateTime, result.RevisionUpdateTime.AsTime())
+					}
+					revisionUpdateTime = result.RevisionUpdateTime.AsTime()
+				}
 			}
 		})
 	}

--- a/server/registry/actions_specs_test.go
+++ b/server/registry/actions_specs_test.go
@@ -1527,7 +1527,7 @@ func TestUpdateApiSpecSequence(t *testing.T) {
 				ApiSpec: &rpc.ApiSpec{
 					Name: "projects/my-project/locations/global/apis/a/versions/v/specs/s",
 				},
-				AllowMissing: true,
+				AllowMissing: false,
 			},
 			want: codes.OK,
 		},

--- a/server/registry/actions_specs_test.go
+++ b/server/registry/actions_specs_test.go
@@ -1541,6 +1541,9 @@ func TestUpdateApiSpecSequence(t *testing.T) {
 	var createTime time.Time
 	var revisionCreateTime time.Time
 	var revisionUpdateTime time.Time
+	// NOTE: in the following sequence of tests, each test depends on its predecessor.
+	// Resources are successively created and updated using the "Update" RPC and the
+	// tests verify that CreateTime/UpdateTime fields are modified appropriately.
 	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var result *rpc.ApiSpec

--- a/server/registry/actions_versions_test.go
+++ b/server/registry/actions_versions_test.go
@@ -1181,6 +1181,9 @@ func TestUpdateApiVersionSequence(t *testing.T) {
 	}
 	var createTime time.Time
 	var updateTime time.Time
+	// NOTE: in the following sequence of tests, each test depends on its predecessor.
+	// Resources are successively created and updated using the "Update" RPC and the
+	// tests verify that CreateTime/UpdateTime fields are modified appropriately.
 	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var result *rpc.ApiVersion

--- a/server/registry/actions_versions_test.go
+++ b/server/registry/actions_versions_test.go
@@ -1193,10 +1193,10 @@ func TestUpdateApiVersionSequence(t *testing.T) {
 					createTime = result.CreateTime.AsTime()
 					updateTime = result.UpdateTime.AsTime()
 				} else {
-					if (!createTime.Equal(result.CreateTime.AsTime())) {
+					if !createTime.Equal(result.CreateTime.AsTime()) {
 						t.Errorf("UpdateApiVersion create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
 					}
-					if (!updateTime.Before(result.UpdateTime.AsTime())) {
+					if !updateTime.Before(result.UpdateTime.AsTime()) {
 						t.Errorf("UpdateApiVersion update time did not increase after update (%v %v)", updateTime, result.UpdateTime.AsTime())
 					}
 					updateTime = result.UpdateTime.AsTime()

--- a/server/registry/actions_versions_test.go
+++ b/server/registry/actions_versions_test.go
@@ -1168,7 +1168,7 @@ func TestUpdateApiVersionSequence(t *testing.T) {
 				ApiVersion: &rpc.ApiVersion{
 					Name: "projects/my-project/locations/global/apis/a/versions/v",
 				},
-				AllowMissing: true,
+				AllowMissing: false,
 			},
 			want: codes.OK,
 		},

--- a/server/registry/actions_versions_test.go
+++ b/server/registry/actions_versions_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry/test/seeder"
@@ -1178,10 +1179,28 @@ func TestUpdateApiVersionSequence(t *testing.T) {
 	if err := seeder.SeedApis(ctx, server, seed); err != nil {
 		t.Fatalf("Setup/Seeding: Failed to seed registry: %s", err)
 	}
-	for _, test := range tests {
+	var createTime time.Time
+	var updateTime time.Time
+	for i, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			if _, err := server.UpdateApiVersion(ctx, test.req); status.Code(err) != test.want {
+			var result *rpc.ApiVersion
+			var err error
+			if result, err = server.UpdateApiVersion(ctx, test.req); status.Code(err) != test.want {
 				t.Errorf("UpdateApiVersion(%+v) returned status code %q, want %q: %v", test.req, status.Code(err), test.want, err)
+			}
+			if result != nil {
+				if i == 1 {
+					createTime = result.CreateTime.AsTime()
+					updateTime = result.UpdateTime.AsTime()
+				} else {
+					if (!createTime.Equal(result.CreateTime.AsTime())) {
+						t.Errorf("UpdateApiVersion create time changed after update (%v %v)", createTime, result.CreateTime.AsTime())
+					}
+					if (!updateTime.Before(result.UpdateTime.AsTime())) {
+						t.Errorf("UpdateApiVersion update time did not increase after update (%v %v)", updateTime, result.UpdateTime.AsTime())
+					}
+					updateTime = result.UpdateTime.AsTime()
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This fixes #792 and verifies with tests. Projects, APIs, and versions were already setting timestamps correctly, and artifacts weren't (and are fixed). Although specs and deployments weren't mentioned in #792, this also adds similar tests for them, too.