### PR TITLE
Ensure that spec and revision tags contain no uppercase characters and are not "-".

### DIFF
--- a/server/registry/actions_deployment_revisions.go
+++ b/server/registry/actions_deployment_revisions.go
@@ -106,6 +106,10 @@ func (s *RegistryServer) TagApiDeploymentRevision(ctx context.Context, req *rpc.
 	if len(req.GetTag()) > 40 {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid tag %q, must be 40 characters or less", req.GetTag())
 	}
+	// The tag must match the required format.
+	if err := names.ValidateRevisionTag(req.GetTag()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
 	// The requested deployment revision name must be valid. It may include a tag name.
 	name, err := names.ParseDeploymentRevision(req.GetName())
 	if err != nil {

--- a/server/registry/actions_spec_revisions.go
+++ b/server/registry/actions_spec_revisions.go
@@ -106,6 +106,10 @@ func (s *RegistryServer) TagApiSpecRevision(ctx context.Context, req *rpc.TagApi
 	if len(req.GetTag()) > 40 {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid tag %q, must be 40 characters or less", req.GetTag())
 	}
+	// The tag must match the required format.
+	if err := names.ValidateRevisionTag(req.GetTag()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
 	// The requested spec revision name must be valid. It may include a tag name.
 	name, err := names.ParseSpecRevision(req.GetName())
 	if err != nil {

--- a/server/registry/names/common.go
+++ b/server/registry/names/common.go
@@ -60,6 +60,18 @@ func validateID(id string) error {
 	return nil
 }
 
+// ValidateRevisionTag returns an error if the provided revision tag is invalid.
+func ValidateRevisionTag(tag string) error {
+	r := regexp.MustCompile("^" + revisionTag + "$")
+	if !r.MatchString(tag) {
+		return fmt.Errorf("invalid revision tag %q: must contain only lowercase letters, digits, and dashes", tag)
+	} else if tag == "-" {
+		return fmt.Errorf("invalid revision tag %q: must not be a single dash", tag)
+	}
+
+	return nil
+}
+
 // Normalize is an idempotent operation for normalizing resource names and identifiers.
 // Identifiers `a` and `b` should be considered equal if and only if normalize(a) == normalize(b).
 func normalize(identifier string) string {


### PR DESCRIPTION
Fixes #250.
