### PR TITLE
Replace deprecated `grpc.WithInsecure()`

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -33,9 +34,8 @@ func main() {
 	// This makes a raw gRPC connection.
 	// see the connection package for a simpler way to get a Go client.
 	var opts []grpc.DialOption
-	insecure := os.Getenv("APG_REGISTRY_INSECURE")
-	if insecure != "" {
-		opts = append(opts, grpc.WithInsecure())
+	if os.Getenv("APG_REGISTRY_INSECURE") != "" {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		systemRoots, err := x509.SystemCertPool()
 		if err != nil {

--- a/pkg/connection/client.go
+++ b/pkg/connection/client.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func clientOptions(config Config) ([]option.ClientOption, error) {
@@ -31,7 +32,7 @@ func clientOptions(config Config) ([]option.ClientOption, error) {
 	}
 	opts = append(opts, option.WithEndpoint(config.Address))
 	if config.Insecure {
-		conn, err := grpc.Dial(config.Address, grpc.WithInsecure())
+		conn, err := grpc.Dial(config.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
with `grpc.WithTransportCredentials(insecure.NewCredentials())`

https://stackoverflow.com/a/70482635

This is one of two fixes required to address #843