### PR TITLE
better error message when missing token

### DIFF
--- a/pkg/connection/client.go
+++ b/pkg/connection/client.go
@@ -66,7 +66,11 @@ func NewRegistryClientWithSettings(ctx context.Context, config Config) (Registry
 	if err != nil {
 		return nil, err
 	}
-	return gapic.NewRegistryClient(ctx, opts...)
+	client, err := gapic.NewRegistryClient(ctx, opts...)
+	if err != nil && !config.Insecure && config.Token == "" {
+		err = fmt.Errorf("registry token missing, attempted gcloud credentials: %w", err)
+	}
+	return client, err
 }
 
 type AdminClient = *gapic.AdminClient


### PR DESCRIPTION
Fixes #853

Ultimate error message:

```
 FATAL[0000] Failed to get client      error=registry token missing, attempted gcloud credentials: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information. uid=a2921302
```
