### PR TITLE
Use WorkerPoolWithWarnings in vocabulary calculations

### DIFF
--- a/cmd/registry/cmd/compute/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary.go
@@ -64,7 +64,7 @@ func vocabularyCommand() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
 			}
-			taskQueue, wait := core.WorkerPool(ctx, jobs)
+			taskQueue, wait := core.WorkerPoolWithWarnings(ctx, jobs)
 			defer wait()
 
 			parsed, err := names.ParseSpecRevision(path)


### PR DESCRIPTION
With this change, a single failure won't abort all other work.

See #870 for context.