### PR TITLE
Remove environment variable-based configuration from tests.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,6 +64,9 @@ jobs:
     - name: Install protoc (needed for registry upload tests)
       uses: arduino/setup-protoc@v1
 
+    - name: Create default configuration that uses a local server
+      run: registry config configurations create local --registry.address='locahost:8080' --registry.insecure
+
     - name: Test everything with SQLite
       run: go test ./...
 
@@ -100,15 +103,10 @@ jobs:
       run: registry-server &
 
     - name: Test a standalone registry server using the remote proxy
-      env:
-        APG_REGISTRY_ADDRESS: localhost:8080
-        APG_REGISTRY_INSECURE: 1
       run: go test ./server/registry -remote
 
     - name: Test a standalone registry server using the remote proxy in hosted mode
       env:
-        APG_REGISTRY_ADDRESS: localhost:8080
-        APG_REGISTRY_INSECURE: 1
         PROJECTID: hosted-ci-test
       run: |
         registry rpc admin create-project --project_id=$PROJECTID --json
@@ -116,8 +114,6 @@ jobs:
 
     - name: Verify that benchmarks run on a standalone registry server
       env:
-        APG_REGISTRY_ADDRESS: localhost:8080
-        APG_REGISTRY_INSECURE: 1
         PROJECTID: bench
         ITERATIONS: 1
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,7 +65,7 @@ jobs:
       uses: arduino/setup-protoc@v1
 
     - name: Create default configuration that uses a local server
-      run: registry config configurations create local --registry.address='locahost:8080' --registry.insecure
+      run: registry config configurations create local --registry.address='127.0.0.1:8080' --registry.insecure
 
     - name: Test everything with SQLite
       run: go test ./...

--- a/cmd/registry/controller/local-tasks.go
+++ b/cmd/registry/controller/local-tasks.go
@@ -66,7 +66,7 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 	if strings.HasPrefix(task.Action.Command, "registry") {
 		fullCmd := strings.Fields(task.Action.Command)
 
-		// force the exec-ed registry instance to use the same server configuration
+		// force the exec-ed registry tool to use the same server configuration as the controller
 		config, err := connection.ActiveConfig()
 		if err != nil {
 			return err

--- a/cmd/registry/controller/local-tasks.go
+++ b/cmd/registry/controller/local-tasks.go
@@ -66,6 +66,18 @@ func (task *ExecCommandTask) Run(ctx context.Context) error {
 	if strings.HasPrefix(task.Action.Command, "registry") {
 		fullCmd := strings.Fields(task.Action.Command)
 
+		// force the exec-ed registry instance to use the same server configuration
+		config, err := connection.ActiveConfig()
+		if err != nil {
+			return err
+		}
+		if config.Insecure {
+			fullCmd = append(fullCmd, "--registry.insecure")
+		}
+		if config.Address != "" {
+			fullCmd = append(fullCmd, "--registry.address")
+			fullCmd = append(fullCmd, config.Address)
+		}
 		cmd := exec.Command(fullCmd[0], fullCmd[1:]...)
 		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 

--- a/pkg/connection/grpctest/server.go
+++ b/pkg/connection/grpctest/server.go
@@ -122,10 +122,15 @@ func NewServer(rc registry.Config) (*Server, error) {
 		return nil, err
 	}
 
-	// set for internal client
+	// set registry configuration to use test server
 	addr := fmt.Sprintf("localhost:%d", s.Port())
-	os.Setenv("APG_REGISTRY_ADDRESS", addr)
-	os.Setenv("APG_REGISTRY_INSECURE", "1")
+	config, err := connection.ActiveConfig()
+	if err != nil {
+		return nil, err
+	}
+	config.Insecure = true
+	config.Address = addr
+	connection.SetConfig(config)
 
 	return s, nil
 }

--- a/pkg/connection/grpctest/server.go
+++ b/pkg/connection/grpctest/server.go
@@ -83,8 +83,8 @@ func TestMain(m *testing.M, rc registry.Config) {
 // NewServer creates a RegistryServer served by a basic grpc.Server.
 // If rc.Database and rc.DBConfig are blank, a RegistryServer using
 // sqlite3 on a tmpDir is automatically created.
-// APG_REGISTRY_ADDRESS and APG_REGISTRY_INSECURE
-// env vars are set for the client to connect to the created grpc service.
+// registry.address and registry.insecure configuration values are set
+// to cause the in-process client to connect to the created grpc service.
 // Call Close() when done to close server and clean up tmpDir as needed.
 // Example:
 // func TestXXX(t *testing.T) {


### PR DESCRIPTION
Fixes #864 by using a configuration override instead of environment variables.

One glitch noted in #864 was that the controller invokes a separate executable of the registry tool. To configure that invocation to use the test server, this adds flags to the invocation so that it will use `address` and `insecure` settings that match the calling tool.