### PR TITLE
Remove ".zip" extension from spec ids created by uploaders.

### DIFF
--- a/cmd/registry/cmd/upload/bulk/protos.go
+++ b/cmd/registry/cmd/upload/bulk/protos.go
@@ -199,7 +199,7 @@ func (task *uploadProtoTask) populateFields() {
 	versionPart := parts[len(parts)-1]
 	task.versionID = sanitize(versionPart)
 
-	specPart := task.fileName()
+	specPart := strings.TrimSuffix(task.fileName(), ".zip")
 	task.specID = sanitize(specPart)
 }
 

--- a/cmd/registry/cmd/upload/bulk/protos_test.go
+++ b/cmd/registry/cmd/upload/bulk/protos_test.go
@@ -79,13 +79,13 @@ func TestProtos(t *testing.T) {
 	}{
 		{
 			desc:              "Apigee Registry",
-			spec:              "apis/apigeeregistry/versions/v1/specs/google-cloud-apigeeregistry-v1.zip",
+			spec:              "apis/apigeeregistry/versions/v1/specs/google-cloud-apigeeregistry-v1",
 			wantProtoCount:    11,
 			wantMetadataCount: 2,
 		},
 		{
 			desc:              "Example Library",
-			spec:              "apis/library-example/versions/v1/specs/google-example-library-v1.zip",
+			spec:              "apis/library-example/versions/v1/specs/google-example-library-v1",
 			wantProtoCount:    6,
 			wantMetadataCount: 3,
 		},

--- a/cmd/registry/cmd/upload/spec.go
+++ b/cmd/registry/cmd/upload/spec.go
@@ -96,7 +96,7 @@ func uploadSpecDirectory(ctx context.Context, dirname string, client *gapic.Regi
 	}
 	request := &rpc.CreateApiSpecRequest{
 		Parent:    version,
-		ApiSpecId: "protos.zip",
+		ApiSpecId: "protos",
 		ApiSpec: &rpc.ApiSpec{
 			MimeType: core.ProtobufMimeType("+zip"),
 			Filename: core.ProtobufMimeType("+zip"),

--- a/demos/protos.sh
+++ b/demos/protos.sh
@@ -51,30 +51,26 @@ registry list projects/$PROJECT/locations/global/apis | wc -l
 registry list projects/$PROJECT/locations/global/apis/-/versions
 
 # Similarly, we can use wildcards for the version ids and list all of the specs.
-# Here you'll see that the spec IDs are "protos.zip". This was set in the registry
-# tool, which uploaded each API description as a zip archive of proto files.
 registry list projects/$PROJECT/locations/global/apis/-/versions/-/specs
 
 # To see more about an individual spec, use the `registry get` command:
-registry get projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3.zip
+registry get projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3
 
 # You can also get this with direct calls to the registry rpc service:
-registry rpc get-api-spec --name projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3.zip
+registry rpc get-api-spec --name projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3
 
 # Add the `--json` flag to get this as JSON:
-registry rpc get-api-spec --name projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3.zip --json
+registry rpc get-api-spec --name projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3 --json
 
 # You might notice that didn't return the actual spec. That's because the spec contents
 # are accessed through a separate method that (when transcoded to HTTP) allows direct download
 # of spec contents.
-registry rpc get-api-spec-contents --name projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3.zip > protos-1.zip
+registry rpc get-api-spec-contents --name projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3 > protos-1.zip
 
 # An easier way to get the bytes of the spec is to use `registry get` with the `--contents` flag.
 # This writes the bytes to stdout, so you probably want to redirect this to a file, as follows:
-registry get projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3.zip \
+registry get projects/$PROJECT/locations/global/apis/translate/versions/v3/specs/google-cloud-translate-v3 \
 	--contents > protos-2.zip
 
 # When you unzip this file, you'll find a directory hierarchy suitable for compiling with `protoc`.
 # protoc google/cloud/translate/v3/translation_service.proto -o.
-# (This requires additional protos that you can find in
-# [github.com/googleapis/api-common-protos](https://github.com/googleapis/api-common-protos).


### PR DESCRIPTION
Partially addresses #865 