### PR TITLE
Always use "openapi" as the spec id for bulk-uploaded openapi specs.

### DIFF
--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -174,8 +174,7 @@ func (task *uploadOpenAPITask) populateFields() error {
 	versionPart := parts[len(parts)-2]
 	task.versionID = sanitize(versionPart)
 
-	specPart := parts[len(parts)-1]
-	task.specID = sanitize(specPart)
+	task.specID = "openapi"
 
 	var err error
 	task.contents, err = os.ReadFile(task.path)
@@ -275,7 +274,7 @@ func (task *uploadOpenAPITask) versionName() string {
 }
 
 func (task *uploadOpenAPITask) specName() string {
-	return fmt.Sprintf("%s/specs/%s", task.versionName(), filepath.Base(task.path))
+	return fmt.Sprintf("%s/specs/%s", task.versionName(), task.specID)
 }
 
 func (task *uploadOpenAPITask) apiPath() string {

--- a/cmd/registry/cmd/upload/bulk/openapi.go
+++ b/cmd/registry/cmd/upload/bulk/openapi.go
@@ -33,6 +33,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const openAPISpecID = "openapi"
+
 func openAPICommand() *cobra.Command {
 	var baseURI string
 	cmd := &cobra.Command{
@@ -129,7 +131,6 @@ type uploadOpenAPITask struct {
 	parent    string
 	apiID     string // computed at runtime
 	versionID string // computed at runtime
-	specID    string // computed at runtime
 	contents  []byte
 	document  PartialOpenAPIDocument
 }
@@ -144,7 +145,7 @@ func (task *uploadOpenAPITask) Run(ctx context.Context) error {
 		log.FromContext(ctx).WithError(err).Debugf("Failed to import API %s", task.apiName())
 		return nil
 	}
-	log.Infof(ctx, "Uploading apis/%s/versions/%s/specs/%s", task.apiID, task.versionID, task.specID)
+	log.Infof(ctx, "Uploading apis/%s/versions/%s/specs/%s", task.apiID, task.versionID, openAPISpecID)
 
 	// If the API does not exist, create it.
 	if err := task.createAPI(ctx); err != nil {
@@ -173,8 +174,6 @@ func (task *uploadOpenAPITask) populateFields() error {
 
 	versionPart := parts[len(parts)-2]
 	task.versionID = sanitize(versionPart)
-
-	task.specID = "openapi"
 
 	var err error
 	task.contents, err = os.ReadFile(task.path)
@@ -274,7 +273,7 @@ func (task *uploadOpenAPITask) versionName() string {
 }
 
 func (task *uploadOpenAPITask) specName() string {
-	return fmt.Sprintf("%s/specs/%s", task.versionName(), task.specID)
+	return fmt.Sprintf("%s/specs/%s", task.versionName(), openAPISpecID)
 }
 
 func (task *uploadOpenAPITask) apiPath() string {

--- a/cmd/registry/cmd/upload/bulk/openapi_test.go
+++ b/cmd/registry/cmd/upload/bulk/openapi_test.go
@@ -74,17 +74,17 @@ func TestOpenAPI(t *testing.T) {
 	}{
 		{
 			desc:     "Apigee Registry",
-			spec:     "apis/apigee-registry/versions/v1/specs/openapi.yaml",
+			spec:     "apis/apigee-registry/versions/v1/specs/openapi",
 			wantType: "application/x.openapi;version=3",
 		},
 		{
 			desc:     "Petstore OpenAPI",
-			spec:     "apis/petstore/versions/3.0/specs/openapi.yaml",
+			spec:     "apis/petstore/versions/3.0/specs/openapi",
 			wantType: "application/x.openapi;version=3",
 		},
 		{
 			desc:     "Petstore Swagger",
-			spec:     "apis/petstore/versions/2.0/specs/swagger.yaml",
+			spec:     "apis/petstore/versions/2.0/specs/openapi",
 			wantType: "application/x.openapi;version=2",
 		},
 	}

--- a/demos/openapi.sh
+++ b/demos/openapi.sh
@@ -46,15 +46,15 @@ registry get projects/$PROJECT/locations/global/apis/wordnik.com
 registry rpc get-api --name projects/$PROJECT/locations/global/apis/wordnik.com --json
 
 # Get the API spec
-registry rpc get-api-spec --name projects/$PROJECT/locations/global/apis/wordnik.com/versions/4.0/specs/openapi.yaml
+registry rpc get-api-spec --name projects/$PROJECT/locations/global/apis/wordnik.com/versions/4.0/specs/openapi
 
 # You might notice that didn't return the actual spec. That's because the spec contents
 # are accessed through a separate method that (when transcoded to HTTP) allows direct download
 # of spec contents.
-registry rpc get-api-spec-contents --name projects/$PROJECT/locations/global/apis/wordnik.com/versions/4.0/specs/openapi.yaml
+registry rpc get-api-spec-contents --name projects/$PROJECT/locations/global/apis/wordnik.com/versions/4.0/specs/openapi
 
 # If you have jq and the base64 tool installed, you can get the spec contents from the RPC response.
-# registry rpc get-api-spec-contents --name projects/$PROJECT/locations/global/apis/wordnik.com/versions/4.0/specs/openapi.yaml --json | jq .data -r | base64 --decode
+# registry rpc get-api-spec-contents --name projects/$PROJECT/locations/global/apis/wordnik.com/versions/4.0/specs/openapi --json | jq .data -r | base64 --decode
 
 # Another way to get the bytes of the spec is to use `registry get` with the `--contents` flag.
 registry get projects/$PROJECT/locations/global/apis/wordnik.com --contents


### PR DESCRIPTION
Closes #865.

This only updates the bulk uploader, related tests, and the demo script that depends on the bulk uploader.

Numerous tests use `openapi.yaml` as a spec ID. I think updating these would obscure the change in this PR and also that updating these tests is not particularly urgent since the ids are isolated within the tests. If that seems ok, I'll create a followup PR to update the tests.