### PR TITLE
Test discovery bulk uploads with a local mock server.

### DIFF
--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -90,7 +90,8 @@ func discoveryCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&service, "service", "", "URL of API Discovery Service to use (defaults to Google)")
+	cmd.Flags().StringVar(&service, "service", "",
+		fmt.Sprintf("API Discovery Service URL (default %s)", discovery.APIsListServiceURL))
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/bulk/discovery.go
+++ b/cmd/registry/cmd/upload/bulk/discovery.go
@@ -29,10 +29,24 @@ import (
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 
+	"github.com/google/gnostic/compiler"
 	discovery "github.com/google/gnostic/discovery"
 )
 
+// Read the list of APIs from the Discovery service.
+func fetchDiscoveryList(service string) (*discovery.List, error) {
+	if service == "" {
+		service = discovery.APIsListServiceURL
+	}
+	bytes, err := compiler.FetchFile(service)
+	if err != nil {
+		return nil, err
+	}
+	return discovery.ParseList(bytes)
+}
+
 func discoveryCommand() *cobra.Command {
+	var service string
 	cmd := &cobra.Command{
 		Use:   "discovery",
 		Short: "Bulk-upload API Discovery documents from the Google API Discovery service",
@@ -57,7 +71,7 @@ func discoveryCommand() *cobra.Command {
 			taskQueue, wait := core.WorkerPool(ctx, jobs)
 			defer wait()
 
-			discoveryResponse, err := discovery.FetchList()
+			discoveryResponse, err := fetchDiscoveryList(service)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to fetch discovery list")
 			}
@@ -76,7 +90,7 @@ func discoveryCommand() *cobra.Command {
 			return nil
 		},
 	}
-
+	cmd.Flags().StringVar(&service, "service", "", "URL of API Discovery Service to use (defaults to Google)")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/bulk/discovery_test.go
+++ b/cmd/registry/cmd/upload/bulk/discovery_test.go
@@ -53,7 +53,7 @@ func TestDiscoveryUpload(t *testing.T) {
 	ctx := context.Background()
 	// Start a test server to mock the Discovery Service.
 	testServer := startTestServer()
-	defer testServer.Shutdown(ctx)
+	defer func() { _ = testServer.Shutdown(ctx) }()
 	// Create a registry client.
 	registryClient, err := connection.NewRegistryClient(ctx)
 	if err != nil {

--- a/cmd/registry/cmd/upload/bulk/testdata/discovery/apigeeregistry-v1.json
+++ b/cmd/registry/cmd/upload/bulk/testdata/discovery/apigeeregistry-v1.json
@@ -1,0 +1,4044 @@
+{
+  "ownerDomain": "google.com",
+  "version": "v1",
+  "mtlsRootUrl": "https://apigeeregistry.mtls.googleapis.com/",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "discoveryVersion": "v1",
+  "description": "",
+  "resources": {
+    "projects": {
+      "resources": {
+        "locations": {
+          "resources": {
+            "instances": {
+              "methods": {
+                "create": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances",
+                  "parameters": {
+                    "instanceId": {
+                      "description": "Required. Identifier to assign to the Instance. Must be unique within scope of the parent resource.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "parent": {
+                      "location": "path",
+                      "type": "string",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "description": "Required. Parent resource of the Instance, of the form: `projects/*/locations/*`"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.instances.create",
+                  "request": {
+                    "$ref": "Instance"
+                  },
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "description": "Provisions instance resources for the Registry.",
+                  "path": "v1/{+parent}/instances"
+                },
+                "delete": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}",
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "location": "path",
+                      "description": "Required. The name of the Instance to delete. Format: `projects/*/locations/*/instances/*`.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "httpMethod": "DELETE",
+                  "description": "Deletes the Registry instance.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "id": "apigeeregistry.projects.locations.instances.delete",
+                  "path": "v1/{+name}"
+                },
+                "testIamPermissions": {
+                  "parameters": {
+                    "resource": {
+                      "required": true,
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$"
+                    }
+                  },
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:testIamPermissions",
+                  "id": "apigeeregistry.projects.locations.instances.testIamPermissions",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "setIamPolicy": {
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "id": "apigeeregistry.projects.locations.instances.setIamPolicy",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:setIamPolicy",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "POST"
+                },
+                "get": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "response": {
+                    "$ref": "Instance"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "GET",
+                  "id": "apigeeregistry.projects.locations.instances.get",
+                  "path": "v1/{+name}",
+                  "description": "Gets details of a single Instance.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}",
+                  "parameters": {
+                    "name": {
+                      "description": "Required. The name of the Instance to retrieve. Format: `projects/*/locations/*/instances/*`.",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "type": "string",
+                      "location": "path"
+                    }
+                  }
+                },
+                "getIamPolicy": {
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "options.requestedPolicyVersion": {
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                    },
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "id": "apigeeregistry.projects.locations.instances.getIamPolicy",
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:getIamPolicy"
+                }
+              }
+            },
+            "apis": {
+              "resources": {
+                "deployments": {
+                  "resources": {
+                    "artifacts": {
+                      "methods": {
+                        "replaceArtifact": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "httpMethod": "PUT",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "path": "v1/{+name}",
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "description": "Used to replace a specified artifact.",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "location": "path",
+                              "description": "Resource name.",
+                              "type": "string",
+                              "required": true
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.replaceArtifact"
+                        },
+                        "get": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.get",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`"
+                            }
+                          },
+                          "description": "Returns a specified artifact.",
+                          "path": "v1/{+name}"
+                        },
+                        "list": {
+                          "response": {
+                            "$ref": "ListArtifactsResponse"
+                          },
+                          "path": "v1/{+parent}/artifacts",
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts",
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.list",
+                          "httpMethod": "GET",
+                          "parameters": {
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                              "required": true,
+                              "type": "string",
+                              "location": "path",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                            },
+                            "filter": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                            },
+                            "orderBy": {
+                              "type": "string",
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "location": "query"
+                            },
+                            "pageSize": {
+                              "type": "integer",
+                              "format": "int32",
+                              "location": "query",
+                              "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000."
+                            },
+                            "pageToken": {
+                              "type": "string",
+                              "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                              "location": "query"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Returns matching artifacts."
+                        },
+                        "create": {
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.create",
+                          "parameters": {
+                            "parent": {
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "required": true,
+                              "type": "string",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                            },
+                            "artifactId": {
+                              "type": "string",
+                              "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "location": "query"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Creates a specified artifact.",
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "path": "v1/{+parent}/artifacts",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts",
+                          "httpMethod": "POST"
+                        },
+                        "delete": {
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                              "location": "path",
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.delete",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "path": "v1/{+name}",
+                          "description": "Removes a specified artifact.",
+                          "httpMethod": "DELETE",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}"
+                        },
+                        "getContents": {
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "parameters": {
+                            "name": {
+                              "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                              "required": true,
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "type": "string"
+                            }
+                          },
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.getContents",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}:getContents",
+                          "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}:getContents"
+                        }
+                      }
+                    }
+                  },
+                  "methods": {
+                    "tagRevision": {
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.tagRevision",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "description": "Adds a tag to a specified revision of a deployment.",
+                      "parameters": {
+                        "name": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "required": true,
+                          "type": "string",
+                          "description": "Required. The name of the deployment to be tagged, including the revision ID.",
+                          "location": "path"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:tagRevision",
+                      "path": "v1/{+name}:tagRevision",
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "request": {
+                        "$ref": "TagApiDeploymentRevisionRequest"
+                      }
+                    },
+                    "create": {
+                      "description": "Creates a specified deployment.",
+                      "parameters": {
+                        "parent": {
+                          "type": "string",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of deployments. Format: `projects/*/locations/*/apis/*`",
+                          "required": true
+                        },
+                        "apiDeploymentId": {
+                          "description": "Required. The ID to use for the deployment, which will become the final component of the deployment's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                          "location": "query",
+                          "type": "string"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments",
+                      "path": "v1/{+parent}/deployments",
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "httpMethod": "POST",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.create",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "request": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ]
+                    },
+                    "deleteRevision": {
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "description": "Deletes a revision of a deployment.",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "DELETE",
+                      "parameters": {
+                        "name": {
+                          "description": "Required. The name of the deployment revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/deployments/prod@c7cfa2a8`",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:deleteRevision",
+                      "path": "v1/{+name}:deleteRevision",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.deleteRevision"
+                    },
+                    "listRevisions": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:listRevisions",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "parameters": {
+                        "pageToken": {
+                          "type": "string",
+                          "location": "query",
+                          "description": "The page token, received from a previous ListApiDeploymentRevisions call. Provide this to retrieve the subsequent page."
+                        },
+                        "pageSize": {
+                          "location": "query",
+                          "description": "The maximum number of revisions to return per page.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "description": "Required. The name of the deployment to list revisions for.",
+                          "type": "string",
+                          "location": "path"
+                        }
+                      },
+                      "description": "Lists all revisions of a deployment. Revisions are returned in descending order of revision creation time.",
+                      "httpMethod": "GET",
+                      "path": "v1/{+name}:listRevisions",
+                      "response": {
+                        "$ref": "ListApiDeploymentRevisionsResponse"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.listRevisions"
+                    },
+                    "setIamPolicy": {
+                      "httpMethod": "POST",
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:setIamPolicy",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "type": "string",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.setIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ]
+                    },
+                    "rollback": {
+                      "httpMethod": "POST",
+                      "request": {
+                        "$ref": "RollbackApiDeploymentRequest"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.rollback",
+                      "description": "Sets the current revision to a specified prior revision. Note that this creates a new revision with a new revision ID.",
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "description": "Required. The deployment being rolled back.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:rollback",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+name}:rollback"
+                    },
+                    "getIamPolicy": {
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:getIamPolicy",
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "parameters": {
+                        "options.requestedPolicyVersion": {
+                          "type": "integer",
+                          "location": "query",
+                          "format": "int32",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                        },
+                        "resource": {
+                          "required": true,
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "httpMethod": "GET",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.getIamPolicy"
+                    },
+                    "patch": {
+                      "httpMethod": "PATCH",
+                      "request": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "parameters": {
+                        "allowMissing": {
+                          "location": "query",
+                          "description": "If set to true, and the deployment is not found, a new deployment will be created. In this situation, `update_mask` is ignored.",
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "required": true,
+                          "type": "string",
+                          "description": "Resource name.",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        },
+                        "updateMask": {
+                          "format": "google-fieldmask",
+                          "location": "query",
+                          "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                          "type": "string"
+                        }
+                      },
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.patch",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "path": "v1/{+name}",
+                      "description": "Used to modify a specified deployment.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "delete": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "description": "Required. The name of the deployment to delete. Format: `projects/*/locations/*/apis/*/deployments/*`",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string"
+                        },
+                        "force": {
+                          "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                          "location": "query",
+                          "type": "boolean"
+                        }
+                      },
+                      "httpMethod": "DELETE",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.delete",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Removes a specified deployment, all revisions, and all child resources (e.g., artifacts).",
+                      "path": "v1/{+name}",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}"
+                    },
+                    "get": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "path": "v1/{+name}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Returns a specified deployment.",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "type": "string",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "description": "Required. The name of the deployment to retrieve. Format: `projects/*/locations/*/apis/*/deployments/*`"
+                        }
+                      },
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.get",
+                      "httpMethod": "GET"
+                    },
+                    "testIamPermissions": {
+                      "id": "apigeeregistry.projects.locations.apis.deployments.testIamPermissions",
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "httpMethod": "POST",
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:testIamPermissions",
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "type": "string",
+                          "required": true
+                        }
+                      }
+                    },
+                    "list": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+parent}/deployments",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.list",
+                      "description": "Returns matching deployments.",
+                      "response": {
+                        "$ref": "ListApiDeploymentsResponse"
+                      },
+                      "httpMethod": "GET",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments",
+                      "parameters": {
+                        "parent": {
+                          "type": "string",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "location": "path",
+                          "description": "Required. The parent, which owns this collection of deployments. Format: `projects/*/locations/*/apis/*`"
+                        },
+                        "pageToken": {
+                          "description": "A page token, received from a previous `ListApiDeployments` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiDeployments` must match the call that provided the page token.",
+                          "location": "query",
+                          "type": "string"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields."
+                        },
+                        "pageSize": {
+                          "type": "integer",
+                          "description": "The maximum number of deployments to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "location": "query",
+                          "format": "int32"
+                        },
+                        "orderBy": {
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "type": "string",
+                          "location": "query"
+                        }
+                      }
+                    }
+                  }
+                },
+                "versions": {
+                  "resources": {
+                    "specs": {
+                      "resources": {
+                        "artifacts": {
+                          "methods": {
+                            "replaceArtifact": {
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "path": "v1/{+name}",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "description": "Used to replace a specified artifact.",
+                              "request": {
+                                "$ref": "Artifact"
+                              },
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.replaceArtifact",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "httpMethod": "PUT",
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "parameters": {
+                                "name": {
+                                  "description": "Resource name.",
+                                  "required": true,
+                                  "type": "string",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path"
+                                }
+                              }
+                            },
+                            "getContents": {
+                              "parameters": {
+                                "name": {
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`"
+                                }
+                              },
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "httpMethod": "GET",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:getContents",
+                              "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.getContents",
+                              "path": "v1/{+name}:getContents",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "response": {
+                                "$ref": "HttpBody"
+                              }
+                            },
+                            "setIamPolicy": {
+                              "httpMethod": "POST",
+                              "path": "v1/{+resource}:setIamPolicy",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.setIamPolicy",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "parameters": {
+                                "resource": {
+                                  "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "location": "path",
+                                  "type": "string",
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$"
+                                }
+                              },
+                              "response": {
+                                "$ref": "Policy"
+                              },
+                              "request": {
+                                "$ref": "SetIamPolicyRequest"
+                              },
+                              "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:setIamPolicy"
+                            },
+                            "create": {
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "parameterOrder": [
+                                "parent"
+                              ],
+                              "httpMethod": "POST",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts",
+                              "description": "Creates a specified artifact.",
+                              "parameters": {
+                                "artifactId": {
+                                  "location": "query",
+                                  "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                                  "type": "string"
+                                },
+                                "parent": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                                  "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                                  "required": true,
+                                  "location": "path",
+                                  "type": "string"
+                                }
+                              },
+                              "request": {
+                                "$ref": "Artifact"
+                              },
+                              "path": "v1/{+parent}/artifacts",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.create",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ]
+                            },
+                            "list": {
+                              "parameters": {
+                                "orderBy": {
+                                  "type": "string",
+                                  "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                                  "location": "query"
+                                },
+                                "parent": {
+                                  "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                                  "type": "string",
+                                  "required": true,
+                                  "location": "path"
+                                },
+                                "filter": {
+                                  "type": "string",
+                                  "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                                  "location": "query"
+                                },
+                                "pageToken": {
+                                  "location": "query",
+                                  "type": "string",
+                                  "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token."
+                                },
+                                "pageSize": {
+                                  "location": "query",
+                                  "format": "int32",
+                                  "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                                  "type": "integer"
+                                }
+                              },
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.list",
+                              "path": "v1/{+parent}/artifacts",
+                              "response": {
+                                "$ref": "ListArtifactsResponse"
+                              },
+                              "httpMethod": "GET",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameterOrder": [
+                                "parent"
+                              ],
+                              "description": "Returns matching artifacts.",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts"
+                            },
+                            "get": {
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.get",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "path": "v1/{+name}",
+                              "description": "Returns a specified artifact.",
+                              "httpMethod": "GET",
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "parameters": {
+                                "name": {
+                                  "location": "path",
+                                  "required": true,
+                                  "type": "string",
+                                  "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$"
+                                }
+                              },
+                              "parameterOrder": [
+                                "name"
+                              ]
+                            },
+                            "testIamPermissions": {
+                              "request": {
+                                "$ref": "TestIamPermissionsRequest"
+                              },
+                              "httpMethod": "POST",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.testIamPermissions",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:testIamPermissions",
+                              "path": "v1/{+resource}:testIamPermissions",
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "parameters": {
+                                "resource": {
+                                  "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "location": "path",
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "type": "string"
+                                }
+                              },
+                              "response": {
+                                "$ref": "TestIamPermissionsResponse"
+                              },
+                              "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ]
+                            },
+                            "getIamPolicy": {
+                              "parameters": {
+                                "options.requestedPolicyVersion": {
+                                  "format": "int32",
+                                  "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                                  "location": "query",
+                                  "type": "integer"
+                                },
+                                "resource": {
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "type": "string",
+                                  "location": "path"
+                                }
+                              },
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:getIamPolicy",
+                              "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "path": "v1/{+resource}:getIamPolicy",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.getIamPolicy",
+                              "response": {
+                                "$ref": "Policy"
+                              },
+                              "httpMethod": "GET"
+                            },
+                            "delete": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "description": "Removes a specified artifact.",
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "httpMethod": "DELETE",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.delete",
+                              "path": "v1/{+name}",
+                              "parameters": {
+                                "name": {
+                                  "type": "string",
+                                  "location": "path",
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`"
+                                }
+                              },
+                              "response": {
+                                "$ref": "Empty"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "methods": {
+                        "getContents": {
+                          "httpMethod": "GET",
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true,
+                              "location": "path",
+                              "description": "Required. The name of the spec whose contents should be retrieved. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "type": "string"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.getContents",
+                          "path": "v1/{+name}:getContents",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:getContents",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "description": "Returns the contents of a specified spec. If specs are stored with GZip compression, the default behavior is to return the spec uncompressed (the mime_type response field indicates the exact format returned).",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ]
+                        },
+                        "setIamPolicy": {
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameters": {
+                            "resource": {
+                              "required": true,
+                              "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "location": "path",
+                              "type": "string"
+                            }
+                          },
+                          "path": "v1/{+resource}:setIamPolicy",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.setIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "httpMethod": "POST",
+                          "request": {
+                            "$ref": "SetIamPolicyRequest"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:setIamPolicy"
+                        },
+                        "listRevisions": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:listRevisions",
+                          "description": "Lists all revisions of a spec. Revisions are returned in descending order of revision creation time.",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "GET",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "parameters": {
+                            "pageSize": {
+                              "location": "query",
+                              "type": "integer",
+                              "format": "int32",
+                              "description": "The maximum number of revisions to return per page."
+                            },
+                            "name": {
+                              "required": true,
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Required. The name of the spec to list revisions for.",
+                              "location": "path"
+                            },
+                            "pageToken": {
+                              "location": "query",
+                              "description": "The page token, received from a previous ListApiSpecRevisions call. Provide this to retrieve the subsequent page.",
+                              "type": "string"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.listRevisions",
+                          "response": {
+                            "$ref": "ListApiSpecRevisionsResponse"
+                          },
+                          "path": "v1/{+name}:listRevisions"
+                        },
+                        "deleteRevision": {
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "DELETE",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:deleteRevision",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.deleteRevision",
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Required. The name of the spec revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8`",
+                              "type": "string"
+                            }
+                          },
+                          "path": "v1/{+name}:deleteRevision",
+                          "description": "Deletes a revision of a spec.",
+                          "parameterOrder": [
+                            "name"
+                          ]
+                        },
+                        "testIamPermissions": {
+                          "response": {
+                            "$ref": "TestIamPermissionsResponse"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:testIamPermissions",
+                          "path": "v1/{+resource}:testIamPermissions",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "parameters": {
+                            "resource": {
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "type": "string",
+                              "required": true
+                            }
+                          },
+                          "httpMethod": "POST",
+                          "request": {
+                            "$ref": "TestIamPermissionsRequest"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.testIamPermissions",
+                          "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ]
+                        },
+                        "get": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "httpMethod": "GET",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "type": "string",
+                              "required": true,
+                              "description": "Required. The name of the spec to retrieve. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "location": "path"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "path": "v1/{+name}",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "description": "Returns a specified spec.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.get",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          }
+                        },
+                        "getIamPolicy": {
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameters": {
+                            "resource": {
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "location": "path",
+                              "required": true
+                            },
+                            "options.requestedPolicyVersion": {
+                              "type": "integer",
+                              "location": "query",
+                              "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                              "format": "int32"
+                            }
+                          },
+                          "path": "v1/{+resource}:getIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.getIamPolicy",
+                          "httpMethod": "GET",
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:getIamPolicy",
+                          "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set."
+                        },
+                        "tagRevision": {
+                          "description": "Adds a tag to a specified revision of a spec.",
+                          "parameters": {
+                            "name": {
+                              "description": "Required. The name of the spec to be tagged, including the revision ID.",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true,
+                              "type": "string"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:tagRevision",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.tagRevision",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "request": {
+                            "$ref": "TagApiSpecRevisionRequest"
+                          },
+                          "httpMethod": "POST",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "path": "v1/{+name}:tagRevision"
+                        },
+                        "patch": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.patch",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "httpMethod": "PATCH",
+                          "request": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Used to modify a specified spec.",
+                          "parameters": {
+                            "allowMissing": {
+                              "type": "boolean",
+                              "description": "If set to true, and the spec is not found, a new spec will be created. In this situation, `update_mask` is ignored.",
+                              "location": "query"
+                            },
+                            "updateMask": {
+                              "format": "google-fieldmask",
+                              "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                              "location": "query",
+                              "type": "string"
+                            },
+                            "name": {
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Resource name.",
+                              "required": true,
+                              "type": "string"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}"
+                        },
+                        "create": {
+                          "request": {
+                            "$ref": "ApiSpec"
+                          },
+                          "path": "v1/{+parent}/specs",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "httpMethod": "POST",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameters": {
+                            "apiSpecId": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "Required. The ID to use for the spec, which will become the final component of the spec's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                            },
+                            "parent": {
+                              "description": "Required. The parent, which owns this collection of specs. Format: `projects/*/locations/*/apis/*/versions/*`",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "type": "string",
+                              "location": "path"
+                            }
+                          },
+                          "description": "Creates a specified spec.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.create",
+                          "parameterOrder": [
+                            "parent"
+                          ]
+                        },
+                        "list": {
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs",
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Returns matching specs.",
+                          "path": "v1/{+parent}/specs",
+                          "httpMethod": "GET",
+                          "response": {
+                            "$ref": "ListApiSpecsResponse"
+                          },
+                          "parameters": {
+                            "filter": {
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                              "type": "string",
+                              "location": "query"
+                            },
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of specs. Format: `projects/*/locations/*/apis/*/versions/*`",
+                              "required": true,
+                              "location": "path"
+                            },
+                            "pageSize": {
+                              "location": "query",
+                              "format": "int32",
+                              "type": "integer",
+                              "description": "The maximum number of specs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000."
+                            },
+                            "pageToken": {
+                              "description": "A page token, received from a previous `ListApiSpecs` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiSpecs` must match the call that provided the page token.",
+                              "type": "string",
+                              "location": "query"
+                            },
+                            "orderBy": {
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "type": "string",
+                              "location": "query"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.list"
+                        },
+                        "rollback": {
+                          "path": "v1/{+name}:rollback",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The spec being rolled back.",
+                              "location": "path"
+                            }
+                          },
+                          "description": "Sets the current revision to a specified prior revision. Note that this creates a new revision with a new revision ID.",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:rollback",
+                          "request": {
+                            "$ref": "RollbackApiSpecRequest"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.rollback",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "POST"
+                        },
+                        "delete": {
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.delete",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Removes a specified spec, all revisions, and all child resources (e.g., artifacts).",
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The name of the spec to delete. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$"
+                            },
+                            "force": {
+                              "location": "query",
+                              "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                              "type": "boolean"
+                            }
+                          },
+                          "httpMethod": "DELETE"
+                        }
+                      }
+                    },
+                    "artifacts": {
+                      "methods": {
+                        "create": {
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.create",
+                          "description": "Creates a specified artifact.",
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "parameters": {
+                            "artifactId": {
+                              "type": "string",
+                              "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "location": "query"
+                            },
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                            }
+                          },
+                          "httpMethod": "POST",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts",
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "path": "v1/{+parent}/artifacts"
+                        },
+                        "delete": {
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.delete",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`"
+                            }
+                          },
+                          "path": "v1/{+name}",
+                          "description": "Removes a specified artifact.",
+                          "httpMethod": "DELETE"
+                        },
+                        "list": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.list",
+                          "parameters": {
+                            "pageSize": {
+                              "type": "integer",
+                              "location": "query",
+                              "format": "int32",
+                              "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000."
+                            },
+                            "filter": {
+                              "location": "query",
+                              "type": "string",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                            },
+                            "parent": {
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                            },
+                            "pageToken": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token."
+                            },
+                            "orderBy": {
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "type": "string",
+                              "location": "query"
+                            }
+                          },
+                          "response": {
+                            "$ref": "ListArtifactsResponse"
+                          },
+                          "httpMethod": "GET",
+                          "path": "v1/{+parent}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Returns matching artifacts."
+                        },
+                        "setIamPolicy": {
+                          "httpMethod": "POST",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:setIamPolicy",
+                          "parameters": {
+                            "resource": {
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "type": "string",
+                              "required": true,
+                              "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.setIamPolicy",
+                          "request": {
+                            "$ref": "SetIamPolicyRequest"
+                          },
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "path": "v1/{+resource}:setIamPolicy"
+                        },
+                        "testIamPermissions": {
+                          "parameters": {
+                            "resource": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "location": "path",
+                              "type": "string",
+                              "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "required": true
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:testIamPermissions",
+                          "request": {
+                            "$ref": "TestIamPermissionsRequest"
+                          },
+                          "path": "v1/{+resource}:testIamPermissions",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "response": {
+                            "$ref": "TestIamPermissionsResponse"
+                          },
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.testIamPermissions",
+                          "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning."
+                        },
+                        "getContents": {
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}:getContents",
+                          "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                              "location": "path"
+                            }
+                          },
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.getContents",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:getContents"
+                        },
+                        "replaceArtifact": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "description": "Resource name.",
+                              "location": "path",
+                              "type": "string",
+                              "required": true
+                            }
+                          },
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "path": "v1/{+name}",
+                          "description": "Used to replace a specified artifact.",
+                          "httpMethod": "PUT",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.replaceArtifact",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "request": {
+                            "$ref": "Artifact"
+                          }
+                        },
+                        "get": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "description": "Returns a specified artifact.",
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "location": "path"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.get"
+                        },
+                        "getIamPolicy": {
+                          "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                          "parameters": {
+                            "options.requestedPolicyVersion": {
+                              "type": "integer",
+                              "location": "query",
+                              "format": "int32",
+                              "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                            },
+                            "resource": {
+                              "type": "string",
+                              "required": true,
+                              "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:getIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "GET",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.getIamPolicy",
+                          "path": "v1/{+resource}:getIamPolicy",
+                          "response": {
+                            "$ref": "Policy"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "methods": {
+                    "delete": {
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "DELETE",
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "description": "Removes a specified version and all of the resources that it owns.",
+                      "path": "v1/{+name}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "location": "path",
+                          "description": "Required. The name of the version to delete. Format: `projects/*/locations/*/apis/*/versions/*`"
+                        },
+                        "force": {
+                          "type": "boolean",
+                          "location": "query",
+                          "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "id": "apigeeregistry.projects.locations.apis.versions.delete"
+                    },
+                    "get": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+name}",
+                      "httpMethod": "GET",
+                      "id": "apigeeregistry.projects.locations.apis.versions.get",
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "description": "Required. The name of the version to retrieve. Format: `projects/*/locations/*/apis/*/versions/*`"
+                        }
+                      },
+                      "description": "Returns a specified version.",
+                      "parameterOrder": [
+                        "name"
+                      ]
+                    },
+                    "testIamPermissions": {
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.versions.testIamPermissions",
+                      "httpMethod": "POST",
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "type": "string",
+                          "required": true
+                        }
+                      },
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:testIamPermissions",
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      }
+                    },
+                    "setIamPolicy": {
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "type": "string"
+                        }
+                      },
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "httpMethod": "POST",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.versions.setIamPolicy",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:setIamPolicy"
+                    },
+                    "list": {
+                      "parameters": {
+                        "pageToken": {
+                          "location": "query",
+                          "description": "A page token, received from a previous `ListApiVersions` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiVersions` must match the call that provided the page token.",
+                          "type": "string"
+                        },
+                        "filter": {
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                          "location": "query",
+                          "type": "string"
+                        },
+                        "orderBy": {
+                          "type": "string",
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "location": "query"
+                        },
+                        "pageSize": {
+                          "description": "The maximum number of versions to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "format": "int32",
+                          "type": "integer",
+                          "location": "query"
+                        },
+                        "parent": {
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of versions. Format: `projects/*/locations/*/apis/*`",
+                          "type": "string",
+                          "required": true
+                        }
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions",
+                      "id": "apigeeregistry.projects.locations.apis.versions.list",
+                      "path": "v1/{+parent}/versions",
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "ListApiVersionsResponse"
+                      },
+                      "description": "Returns matching versions."
+                    },
+                    "patch": {
+                      "request": {
+                        "$ref": "ApiVersion"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "description": "Used to modify a specified version.",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "PATCH",
+                      "parameters": {
+                        "allowMissing": {
+                          "type": "boolean",
+                          "description": "If set to true, and the version is not found, a new version will be created. In this situation, `update_mask` is ignored.",
+                          "location": "query"
+                        },
+                        "name": {
+                          "type": "string",
+                          "required": true,
+                          "description": "Resource name.",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$"
+                        },
+                        "updateMask": {
+                          "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                          "location": "query",
+                          "type": "string",
+                          "format": "google-fieldmask"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.versions.patch",
+                      "path": "v1/{+name}"
+                    },
+                    "getIamPolicy": {
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "id": "apigeeregistry.projects.locations.apis.versions.getIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "parameters": {
+                        "resource": {
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "location": "path",
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        },
+                        "options.requestedPolicyVersion": {
+                          "type": "integer",
+                          "format": "int32",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                          "location": "query"
+                        }
+                      },
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:getIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ]
+                    },
+                    "create": {
+                      "httpMethod": "POST",
+                      "description": "Creates a specified version.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "parent": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of versions. Format: `projects/*/locations/*/apis/*`",
+                          "required": true,
+                          "location": "path",
+                          "type": "string"
+                        },
+                        "apiVersionId": {
+                          "type": "string",
+                          "location": "query",
+                          "description": "Required. The ID to use for the version, which will become the final component of the version's resource name. This value should be 1-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                        }
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "request": {
+                        "$ref": "ApiVersion"
+                      },
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "path": "v1/{+parent}/versions",
+                      "id": "apigeeregistry.projects.locations.apis.versions.create",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions"
+                    }
+                  }
+                },
+                "artifacts": {
+                  "methods": {
+                    "get": {
+                      "httpMethod": "GET",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.get",
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "location": "path"
+                        }
+                      },
+                      "description": "Returns a specified artifact.",
+                      "path": "v1/{+name}"
+                    },
+                    "testIamPermissions": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:testIamPermissions",
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "resource": {
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "location": "path",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.testIamPermissions",
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning."
+                    },
+                    "setIamPolicy": {
+                      "httpMethod": "POST",
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.setIamPolicy",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:setIamPolicy",
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "type": "string",
+                          "required": true,
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      }
+                    },
+                    "getIamPolicy": {
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.getIamPolicy",
+                      "parameters": {
+                        "options.requestedPolicyVersion": {
+                          "format": "int32",
+                          "location": "query",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                          "type": "integer"
+                        },
+                        "resource": {
+                          "type": "string",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "httpMethod": "GET",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:getIamPolicy"
+                    },
+                    "getContents": {
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "type": "string",
+                          "required": true,
+                          "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                          "location": "path"
+                        }
+                      },
+                      "path": "v1/{+name}:getContents",
+                      "response": {
+                        "$ref": "HttpBody"
+                      },
+                      "httpMethod": "GET",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.getContents",
+                      "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:getContents"
+                    },
+                    "replaceArtifact": {
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "description": "Used to replace a specified artifact.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "PUT",
+                      "request": {
+                        "$ref": "Artifact"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "path": "v1/{+name}",
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "Resource name.",
+                          "location": "path"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.replaceArtifact"
+                    },
+                    "create": {
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.create",
+                      "description": "Creates a specified artifact.",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                          "location": "path",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$"
+                        },
+                        "artifactId": {
+                          "location": "query",
+                          "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                          "type": "string"
+                        }
+                      },
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "request": {
+                        "$ref": "Artifact"
+                      },
+                      "httpMethod": "POST",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts",
+                      "path": "v1/{+parent}/artifacts"
+                    },
+                    "list": {
+                      "path": "v1/{+parent}/artifacts",
+                      "response": {
+                        "$ref": "ListArtifactsResponse"
+                      },
+                      "httpMethod": "GET",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "parameters": {
+                        "orderBy": {
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "pageToken": {
+                          "type": "string",
+                          "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                          "location": "query"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                        },
+                        "parent": {
+                          "type": "string",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                          "required": true
+                        },
+                        "pageSize": {
+                          "type": "integer",
+                          "location": "query",
+                          "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "format": "int32"
+                        }
+                      },
+                      "description": "Returns matching artifacts.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.list",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts"
+                    },
+                    "delete": {
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "location": "path",
+                          "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "required": true
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.delete",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "path": "v1/{+name}",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "httpMethod": "DELETE",
+                      "description": "Removes a specified artifact."
+                    }
+                  }
+                }
+              },
+              "methods": {
+                "create": {
+                  "description": "Creates a specified API.",
+                  "id": "apigeeregistry.projects.locations.apis.create",
+                  "httpMethod": "POST",
+                  "request": {
+                    "$ref": "Api"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis",
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "path": "v1/{+parent}/apis",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "parent": {
+                      "location": "path",
+                      "description": "Required. The parent, which owns this collection of APIs. Format: `projects/*/locations/*`",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "required": true
+                    },
+                    "apiId": {
+                      "location": "query",
+                      "description": "Required. The ID to use for the API, which will become the final component of the API's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                      "type": "string"
+                    }
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ]
+                },
+                "list": {
+                  "description": "Returns matching APIs.",
+                  "path": "v1/{+parent}/apis",
+                  "httpMethod": "GET",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis",
+                  "response": {
+                    "$ref": "ListApisResponse"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "parameters": {
+                    "pageSize": {
+                      "description": "The maximum number of APIs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                      "format": "int32",
+                      "type": "integer",
+                      "location": "query"
+                    },
+                    "filter": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields."
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "description": "A page token, received from a previous `ListApis` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApis` must match the call that provided the page token.",
+                      "location": "query"
+                    },
+                    "parent": {
+                      "description": "Required. The parent, which owns this collection of APIs. Format: `projects/*/locations/*`",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "required": true,
+                      "location": "path",
+                      "type": "string"
+                    },
+                    "orderBy": {
+                      "location": "query",
+                      "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                      "type": "string"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.list"
+                },
+                "delete": {
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "required": true,
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the API to delete. Format: `projects/*/locations/*/apis/*`"
+                    },
+                    "force": {
+                      "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                      "location": "query",
+                      "type": "boolean"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Removes a specified API and all of the resources that it owns.",
+                  "id": "apigeeregistry.projects.locations.apis.delete",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}",
+                  "httpMethod": "DELETE",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "path": "v1/{+name}"
+                },
+                "setIamPolicy": {
+                  "id": "apigeeregistry.projects.locations.apis.setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:setIamPolicy",
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "parameters": {
+                    "resource": {
+                      "required": true,
+                      "type": "string",
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$"
+                    }
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ]
+                },
+                "getIamPolicy": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:getIamPolicy",
+                  "parameters": {
+                    "options.requestedPolicyVersion": {
+                      "location": "query",
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                    },
+                    "resource": {
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "id": "apigeeregistry.projects.locations.apis.getIamPolicy",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "testIamPermissions": {
+                  "parameters": {
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "location": "path"
+                    }
+                  },
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:testIamPermissions",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "id": "apigeeregistry.projects.locations.apis.testIamPermissions",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "POST",
+                  "path": "v1/{+resource}:testIamPermissions"
+                },
+                "patch": {
+                  "path": "v1/{+name}",
+                  "request": {
+                    "$ref": "Api"
+                  },
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "description": "Used to modify a specified API.",
+                  "parameters": {
+                    "allowMissing": {
+                      "location": "query",
+                      "description": "If set to true, and the API is not found, a new API will be created. In this situation, `update_mask` is ignored.",
+                      "type": "boolean"
+                    },
+                    "updateMask": {
+                      "type": "string",
+                      "location": "query",
+                      "format": "google-fieldmask",
+                      "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request."
+                    },
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "required": true,
+                      "description": "Resource name."
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.patch",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "PATCH",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}"
+                },
+                "get": {
+                  "path": "v1/{+name}",
+                  "httpMethod": "GET",
+                  "description": "Returns a specified API.",
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.get",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}",
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "location": "path",
+                      "description": "Required. The name of the API to retrieve. Format: `projects/*/locations/*/apis/*`",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                }
+              }
+            },
+            "artifacts": {
+              "methods": {
+                "delete": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Removes a specified artifact.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "httpMethod": "DELETE",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.delete",
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "required": true,
+                      "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "location": "path"
+                    }
+                  },
+                  "path": "v1/{+name}"
+                },
+                "testIamPermissions": {
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "required": true,
+                      "location": "path",
+                      "type": "string",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:testIamPermissions",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.testIamPermissions"
+                },
+                "setIamPolicy": {
+                  "id": "apigeeregistry.projects.locations.artifacts.setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:setIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "type": "string",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "location": "path"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST"
+                },
+                "replaceArtifact": {
+                  "request": {
+                    "$ref": "Artifact"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "required": true,
+                      "type": "string",
+                      "description": "Resource name."
+                    }
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.artifacts.replaceArtifact",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "description": "Used to replace a specified artifact.",
+                  "httpMethod": "PUT"
+                },
+                "list": {
+                  "id": "apigeeregistry.projects.locations.artifacts.list",
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "ListArtifactsResponse"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "description": "Returns matching artifacts.",
+                  "path": "v1/{+parent}/artifacts",
+                  "parameters": {
+                    "orderBy": {
+                      "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "parent": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                      "type": "string",
+                      "required": true,
+                      "location": "path"
+                    },
+                    "pageSize": {
+                      "location": "query",
+                      "type": "integer",
+                      "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                      "format": "int32"
+                    },
+                    "pageToken": {
+                      "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "filter": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts"
+                },
+                "get": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "GET",
+                  "id": "apigeeregistry.projects.locations.artifacts.get",
+                  "description": "Returns a specified artifact.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "path": "v1/{+name}",
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$"
+                    }
+                  }
+                },
+                "getIamPolicy": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:getIamPolicy",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "id": "apigeeregistry.projects.locations.artifacts.getIamPolicy",
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "type": "string",
+                      "required": true
+                    },
+                    "options.requestedPolicyVersion": {
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer"
+                    }
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ]
+                },
+                "getContents": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:getContents",
+                  "path": "v1/{+name}:getContents",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                      "location": "path",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                  "id": "apigeeregistry.projects.locations.artifacts.getContents",
+                  "response": {
+                    "$ref": "HttpBody"
+                  },
+                  "httpMethod": "GET"
+                },
+                "create": {
+                  "path": "v1/{+parent}/artifacts",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "description": "Creates a specified artifact.",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "Artifact"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.create",
+                  "parameters": {
+                    "parent": {
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                      "location": "path"
+                    },
+                    "artifactId": {
+                      "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                      "type": "string",
+                      "location": "query"
+                    }
+                  },
+                  "httpMethod": "POST"
+                }
+              }
+            },
+            "operations": {
+              "methods": {
+                "get": {
+                  "parameters": {
+                    "name": {
+                      "description": "The name of the operation resource.",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "type": "string"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}",
+                  "id": "apigeeregistry.projects.locations.operations.get",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "description": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "GET",
+                  "path": "v1/{+name}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "list": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "response": {
+                    "$ref": "ListOperationsResponse"
+                  },
+                  "description": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE: the `name` binding allows API services to override the binding to use different resource name schemes, such as `users/*/operations`. To override the binding, API services can add a binding such as `\"/v1/{name=users/*}/operations\"` to their service configuration. For backwards compatibility, the default name includes the operations collection id, however overriding users must ensure the name binding is the parent resource, without the operations collection id.",
+                  "parameters": {
+                    "filter": {
+                      "description": "The standard list filter.",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "pageToken": {
+                      "description": "The standard list page token.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "pageSize": {
+                      "location": "query",
+                      "description": "The standard list page size.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the operation's parent resource.",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    }
+                  },
+                  "path": "v1/{+name}/operations",
+                  "httpMethod": "GET",
+                  "id": "apigeeregistry.projects.locations.operations.list",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations",
+                  "parameterOrder": [
+                    "name"
+                  ]
+                },
+                "cancel": {
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "request": {
+                    "$ref": "CancelOperationRequest"
+                  },
+                  "id": "apigeeregistry.projects.locations.operations.cancel",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}:cancel",
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "description": "The name of the operation resource to be cancelled.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$"
+                    }
+                  },
+                  "path": "v1/{+name}:cancel",
+                  "httpMethod": "POST"
+                },
+                "delete": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "required": true,
+                      "description": "The name of the operation resource to be deleted.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}",
+                  "description": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`.",
+                  "httpMethod": "DELETE",
+                  "id": "apigeeregistry.projects.locations.operations.delete",
+                  "path": "v1/{+name}"
+                }
+              }
+            },
+            "runtime": {
+              "methods": {
+                "setIamPolicy": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:setIamPolicy",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "type": "string",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "required": true
+                    }
+                  },
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "id": "apigeeregistry.projects.locations.runtime.setIamPolicy",
+                  "httpMethod": "POST",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  }
+                },
+                "getIamPolicy": {
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.getIamPolicy",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:getIamPolicy",
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "location": "path",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "type": "string"
+                    },
+                    "options.requestedPolicyVersion": {
+                      "format": "int32",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query",
+                      "type": "integer"
+                    }
+                  }
+                },
+                "testIamPermissions": {
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:testIamPermissions",
+                  "id": "apigeeregistry.projects.locations.runtime.testIamPermissions",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  }
+                }
+              }
+            }
+          },
+          "methods": {
+            "list": {
+              "path": "v1/{+name}/locations",
+              "flatPath": "v1/projects/{projectsId}/locations",
+              "id": "apigeeregistry.projects.locations.list",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Lists information about the supported locations for this service.",
+              "response": {
+                "$ref": "ListLocationsResponse"
+              },
+              "httpMethod": "GET",
+              "parameters": {
+                "name": {
+                  "pattern": "^projects/[^/]+$",
+                  "description": "The resource that owns the locations collection, if applicable.",
+                  "type": "string",
+                  "location": "path",
+                  "required": true
+                },
+                "pageSize": {
+                  "location": "query",
+                  "format": "int32",
+                  "type": "integer",
+                  "description": "The maximum number of results to return. If not set, the service selects a default."
+                },
+                "filter": {
+                  "location": "query",
+                  "type": "string",
+                  "description": "A filter to narrow down results to a preferred subset. The filtering language accepts strings like `\"displayName=tokyo\"`, and is documented in more detail in [AIP-160](https://google.aip.dev/160)."
+                },
+                "pageToken": {
+                  "type": "string",
+                  "location": "query",
+                  "description": "A page token received from the `next_page_token` field in the response. Send that page token to receive the subsequent page."
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ]
+            },
+            "get": {
+              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}",
+              "path": "v1/{+name}",
+              "parameterOrder": [
+                "name"
+              ],
+              "httpMethod": "GET",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "response": {
+                "$ref": "Location"
+              },
+              "id": "apigeeregistry.projects.locations.get",
+              "parameters": {
+                "name": {
+                  "type": "string",
+                  "location": "path",
+                  "required": true,
+                  "description": "Resource name for the location.",
+                  "pattern": "^projects/[^/]+/locations/[^/]+$"
+                }
+              },
+              "description": "Gets information about a location."
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "uploadType": {
+      "location": "query",
+      "type": "string",
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
+    },
+    "upload_protocol": {
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true"
+    },
+    "oauth_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user."
+    },
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "location": "query",
+      "type": "string",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "enum": [
+        "1",
+        "2"
+      ]
+    },
+    "quotaUser": {
+      "type": "string",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "location": "query"
+    },
+    "key": {
+      "location": "query",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string"
+    },
+    "access_token": {
+      "type": "string",
+      "description": "OAuth access token.",
+      "location": "query"
+    },
+    "fields": {
+      "type": "string",
+      "location": "query",
+      "description": "Selector specifying which fields to include in a partial response."
+    },
+    "callback": {
+      "type": "string",
+      "description": "JSONP",
+      "location": "query"
+    },
+    "alt": {
+      "location": "query",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "description": "Data format for response.",
+      "type": "string",
+      "default": "json"
+    }
+  },
+  "schemas": {
+    "Config": {
+      "properties": {
+        "cmekKeyName": {
+          "type": "string",
+          "description": "Required. The Customer Managed Encryption Key (CMEK) used for data encryption. The CMEK name should follow the format of `projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)`, where the `location` must match InstanceConfig.location."
+        },
+        "location": {
+          "readOnly": true,
+          "description": "Output only. The GCP location where the Instance resides.",
+          "type": "string"
+        }
+      },
+      "id": "Config",
+      "type": "object",
+      "description": "Available configurations to provision an Instance."
+    },
+    "Status": {
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        },
+        "details": {
+          "items": {
+            "additionalProperties": {
+              "type": "any",
+              "description": "Properties of the object. Contains field @type with type URL."
+            },
+            "type": "object"
+          },
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "Status"
+    },
+    "ListApiSpecsResponse": {
+      "description": "Response message for ListApiSpecs.",
+      "id": "ListApiSpecsResponse",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "apiSpecs": {
+          "items": {
+            "$ref": "ApiSpec"
+          },
+          "description": "The specs from the specified publisher.",
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ListApiSpecRevisionsResponse": {
+      "description": "Response message for ListApiSpecRevisionsResponse.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "apiSpecs": {
+          "description": "The revisions of the spec.",
+          "type": "array",
+          "items": {
+            "$ref": "ApiSpec"
+          }
+        }
+      },
+      "id": "ListApiSpecRevisionsResponse"
+    },
+    "ApiDeployment": {
+      "properties": {
+        "description": {
+          "description": "A detailed description.",
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. Creation timestamp; when the deployment resource was created.",
+          "format": "google-datetime"
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "accessGuidance": {
+          "type": "string",
+          "description": "Text briefly describing how to access the endpoint. Changes to this value will not affect the revision."
+        },
+        "apiSpecRevision": {
+          "type": "string",
+          "description": "The full resource name (including revision ID) of the spec of the API being served by the deployment. Changes to this value will update the revision. Format: `apis/{api}/deployments/{deployment}`"
+        },
+        "labels": {
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "revisionCreateTime": {
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Revision creation timestamp; when the represented revision was created."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts."
+        },
+        "revisionUpdateTime": {
+          "type": "string",
+          "description": "Output only. Last update timestamp: when the represented revision was last modified.",
+          "readOnly": true,
+          "format": "google-datetime"
+        },
+        "endpointUri": {
+          "type": "string",
+          "description": "The address where the deployment is serving. Changes to this value will update the revision."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "intendedAudience": {
+          "description": "Text briefly identifying the intended audience of the API. Changes to this value will not affect the revision.",
+          "type": "string"
+        },
+        "externalChannelUri": {
+          "type": "string",
+          "description": "The address of the external channel of the API (e.g., the Developer Portal). Changes to this value will not affect the revision."
+        },
+        "revisionId": {
+          "description": "Output only. Immutable. The revision ID of the deployment. A new revision is committed whenever the deployment contents are changed. The format is an 8-character hexadecimal string.",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "id": "ApiDeployment",
+      "description": "Describes a service running at particular address that provides a particular version of an API. ApiDeployments have revisions which correspond to different configurations of a single deployment in time. Revision identifiers should be updated whenever the served API spec or endpoint address changes.",
+      "type": "object"
+    },
+    "Operation": {
+      "id": "Operation",
+      "description": "This resource represents a long-running operation that is the result of a network API call.",
+      "type": "object",
+      "properties": {
+        "response": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "The normal response of the operation in case of success. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "type": "object"
+        },
+        "done": {
+          "type": "boolean",
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+        },
+        "name": {
+          "type": "string",
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
+        },
+        "error": {
+          "description": "The error result of the operation in case of failure or cancellation.",
+          "$ref": "Status"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "type": "object",
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
+        }
+      }
+    },
+    "Expr": {
+      "description": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() \u003c 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.",
+      "id": "Expr",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
+        },
+        "description": {
+          "description": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
+          "type": "string"
+        },
+        "location": {
+          "description": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.",
+          "type": "string"
+        },
+        "expression": {
+          "type": "string",
+          "description": "Textual representation of an expression in Common Expression Language syntax."
+        }
+      },
+      "type": "object"
+    },
+    "CancelOperationRequest": {
+      "id": "CancelOperationRequest",
+      "properties": {},
+      "description": "The request message for Operations.CancelOperation.",
+      "type": "object"
+    },
+    "ListApiDeploymentsResponse": {
+      "type": "object",
+      "description": "Response message for ListApiDeployments.",
+      "id": "ListApiDeploymentsResponse",
+      "properties": {
+        "apiDeployments": {
+          "type": "array",
+          "items": {
+            "$ref": "ApiDeployment"
+          },
+          "description": "The deployments from the specified publisher."
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        }
+      }
+    },
+    "TagApiSpecRevisionRequest": {
+      "id": "TagApiSpecRevisionRequest",
+      "description": "Request message for TagApiSpecRevision.",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "Required. The tag to apply. The tag should be at most 40 characters, and match `a-z{3,39}`."
+        }
+      },
+      "type": "object"
+    },
+    "RollbackApiDeploymentRequest": {
+      "description": "Request message for RollbackApiDeployment.",
+      "id": "RollbackApiDeploymentRequest",
+      "type": "object",
+      "properties": {
+        "revisionId": {
+          "description": "Required. The revision ID to roll back to. It must be a revision of the same deployment. Example: `c7cfa2a8`",
+          "type": "string"
+        }
+      }
+    },
+    "Binding": {
+      "id": "Binding",
+      "type": "object",
+      "description": "Associates `members`, or principals, with a `role`.",
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`."
+        },
+        "condition": {
+          "description": "The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+          "$ref": "Expr"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. "
+        }
+      }
+    },
+    "SetIamPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "Policy",
+          "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them."
+        }
+      },
+      "description": "Request message for `SetIamPolicy` method.",
+      "id": "SetIamPolicyRequest"
+    },
+    "TestIamPermissionsResponse": {
+      "description": "Response message for `TestIamPermissions` method.",
+      "properties": {
+        "permissions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed."
+        }
+      },
+      "id": "TestIamPermissionsResponse",
+      "type": "object"
+    },
+    "ListApiDeploymentRevisionsResponse": {
+      "description": "Response message for ListApiDeploymentRevisionsResponse.",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "apiDeployments": {
+          "type": "array",
+          "items": {
+            "$ref": "ApiDeployment"
+          },
+          "description": "The revisions of the deployment."
+        }
+      },
+      "type": "object",
+      "id": "ListApiDeploymentRevisionsResponse"
+    },
+    "ListOperationsResponse": {
+      "description": "The response message for Operations.ListOperations.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "The standard List next-page token."
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "Operation"
+          },
+          "description": "A list of operations that matches the specified filter in the request."
+        }
+      },
+      "id": "ListOperationsResponse"
+    },
+    "ApiVersion": {
+      "description": "Describes a particular version of an API. ApiVersions are what consumers actually use.",
+      "id": "ApiVersion",
+      "properties": {
+        "createTime": {
+          "type": "string",
+          "description": "Output only. Creation timestamp.",
+          "readOnly": true,
+          "format": "google-datetime"
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        },
+        "labels": {
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object"
+        },
+        "state": {
+          "type": "string",
+          "description": "A user-definable description of the lifecycle phase of this API version. Format: free-form, but we expect single words that describe API maturity, e.g., \"CONCEPT\", \"DESIGN\", \"DEVELOPMENT\", \"STAGING\", \"PRODUCTION\", \"DEPRECATED\", \"RETIRED\"."
+        },
+        "updateTime": {
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Last update timestamp."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-meaningful name."
+        }
+      },
+      "type": "object"
+    },
+    "Api": {
+      "id": "Api",
+      "properties": {
+        "recommendedDeployment": {
+          "description": "The recommended deployment of the API. Format: `projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}`",
+          "type": "string"
+        },
+        "updateTime": {
+          "description": "Output only. Last update timestamp.",
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "recommendedVersion": {
+          "type": "string",
+          "description": "The recommended version of the API. Format: `projects/{project}/locations/{location}/apis/{api}/versions/{version}`"
+        },
+        "createTime": {
+          "readOnly": true,
+          "description": "Output only. Creation timestamp.",
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-meaningful name."
+        },
+        "annotations": {
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "availability": {
+          "type": "string",
+          "description": "A user-definable description of the availability of this service. Format: free-form, but we expect single words that describe availability, e.g., \"NONE\", \"TESTING\", \"PREVIEW\", \"GENERAL\", \"DEPRECATED\", \"SHUTDOWN\"."
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores, and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "type": "object"
+        }
+      },
+      "description": "A top-level description of an API. Produced by producers and are commitments to provide services.",
+      "type": "object"
+    },
+    "ListApisResponse": {
+      "description": "Response message for ListApis.",
+      "id": "ListApisResponse",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "apis": {
+          "description": "The APIs from the specified publisher.",
+          "items": {
+            "$ref": "Api"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Artifact": {
+      "properties": {
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "sizeBytes": {
+          "readOnly": true,
+          "format": "int32",
+          "description": "Output only. The size of the artifact in bytes. If the artifact is gzipped, this is the size of the uncompressed artifact.",
+          "type": "integer"
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. Creation timestamp."
+        },
+        "mimeType": {
+          "description": "A content type specifier for the artifact. Content type specifiers are Media Types (https://en.wikipedia.org/wiki/Media_type) with a possible \"schema\" parameter that specifies a schema for the stored information. Content types can specify compression. Currently only GZip compression is supported (indicated with \"+gzip\").",
+          "type": "string"
+        },
+        "hash": {
+          "type": "string",
+          "description": "Output only. A SHA-256 hash of the artifact's contents. If the artifact is gzipped, this is the hash of the uncompressed artifact.",
+          "readOnly": true
+        },
+        "updateTime": {
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime",
+          "description": "Output only. Last update timestamp."
+        },
+        "contents": {
+          "type": "string",
+          "format": "byte",
+          "description": "Input only. The contents of the artifact. Provided by API callers when artifacts are created or replaced. To access the contents of an artifact, use GetArtifactContents."
+        }
+      },
+      "type": "object",
+      "description": "Artifacts of resources. Artifacts are unique (single-value) per resource and are used to store metadata that is too large or numerous to be stored directly on the resource. Since artifacts are stored separately from parent resources, they should generally be used for metadata that is needed infrequently, i.e., not for display in primary views of the resource but perhaps displayed or downloaded upon request. The `ListArtifacts` method allows artifacts to be quickly enumerated and checked for presence without downloading their (potentially-large) contents.",
+      "id": "Artifact"
+    },
+    "ListApiVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "apiVersions": {
+          "type": "array",
+          "description": "The versions from the specified publisher.",
+          "items": {
+            "$ref": "ApiVersion"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        }
+      },
+      "description": "Response message for ListApiVersions.",
+      "id": "ListApiVersionsResponse"
+    },
+    "ListLocationsResponse": {
+      "type": "object",
+      "id": "ListLocationsResponse",
+      "description": "The response message for Locations.ListLocations.",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "A list of locations that matches the specified filter in the request.",
+          "items": {
+            "$ref": "Location"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The standard List next-page token."
+        }
+      }
+    },
+    "HttpBody": {
+      "type": "object",
+      "properties": {
+        "extensions": {
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "any",
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          },
+          "description": "Application specific response metadata. Must be set in the first response for streaming APIs.",
+          "type": "array"
+        },
+        "data": {
+          "format": "byte",
+          "type": "string",
+          "description": "The HTTP request/response body as raw binary."
+        },
+        "contentType": {
+          "description": "The HTTP Content-Type header value specifying the content type of the body.",
+          "type": "string"
+        }
+      },
+      "id": "HttpBody",
+      "description": "Message that represents an arbitrary HTTP body. It should only be used for payload formats that can't be represented as JSON, such as raw binary or an HTML page. This message can be used both in streaming and non-streaming API methods in the request as well as the response. It can be used as a top-level request field, which is convenient if one wants to extract parameters from either the URL or HTTP template into the request fields and also want access to the raw HTTP body. Example: message GetResourceRequest { // A unique request id. string request_id = 1; // The raw HTTP body is bound to this field. google.api.HttpBody http_body = 2; } service ResourceService { rpc GetResource(GetResourceRequest) returns (google.api.HttpBody); rpc UpdateResource(google.api.HttpBody) returns (google.protobuf.Empty); } Example with streaming methods: service CaldavService { rpc GetCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); rpc UpdateCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); } Use of this type only changes how the request and response bodies are handled, all other features will continue to work unchanged."
+    },
+    "Location": {
+      "properties": {
+        "labels": {
+          "description": "Cross-service attributes for the location. For example {\"cloud.googleapis.com/region\": \"us-east1\"}",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "locationId": {
+          "description": "The canonical id for this location. For example: `\"us-east1\"`.",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "type": "object",
+          "description": "Service-specific metadata. For example the available capacity at the given location."
+        },
+        "displayName": {
+          "description": "The friendly name for this location, typically a nearby city name. For example, \"Tokyo\".",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name for the location, which may vary between implementations. For example: `\"projects/example-project/locations/us-east1\"`"
+        }
+      },
+      "type": "object",
+      "description": "A resource that represents Google Cloud Platform location.",
+      "id": "Location"
+    },
+    "Instance": {
+      "description": "An Instance represents the instance resources of the Registry. Currently, only one instance is allowed for each project.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Format: `projects/*/locations/*/instance`. Currently only `locations/global` is supported.",
+          "type": "string"
+        },
+        "state": {
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "The Instance has not been initialized or has been deleted.",
+            "The Instance is being created.",
+            "The Instance has been created and is ready for use.",
+            "The Instance is being updated.",
+            "The Instance is being deleted.",
+            "The Instance encountered an error during a state change."
+          ],
+          "type": "string",
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "INACTIVE",
+            "CREATING",
+            "ACTIVE",
+            "UPDATING",
+            "DELETING",
+            "FAILED"
+          ],
+          "readOnly": true,
+          "description": "Output only. The current state of the Instance."
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. Creation timestamp.",
+          "readOnly": true
+        },
+        "updateTime": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. Last update timestamp.",
+          "format": "google-datetime"
+        },
+        "config": {
+          "$ref": "Config",
+          "description": "Required. Config of the Instance."
+        },
+        "stateMessage": {
+          "description": "Output only. Extra information of Instance.State if the state is `FAILED`.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "id": "Instance"
+    },
+    "Policy": {
+      "id": "Policy",
+      "properties": {
+        "version": {
+          "description": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "bindings": {
+          "items": {
+            "$ref": "Binding"
+          },
+          "type": "array",
+          "description": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`."
+        },
+        "etag": {
+          "type": "string",
+          "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost.",
+          "format": "byte"
+        }
+      },
+      "type": "object",
+      "description": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time \u003c timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/)."
+    },
+    "ListArtifactsResponse": {
+      "id": "ListArtifactsResponse",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "$ref": "Artifact"
+          },
+          "description": "The artifacts from the specified publisher."
+        }
+      },
+      "description": "Response message for ListArtifacts.",
+      "type": "object"
+    },
+    "TagApiDeploymentRevisionRequest": {
+      "id": "TagApiDeploymentRevisionRequest",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "Required. The tag to apply. The tag should be at most 40 characters, and match `a-z{3,39}`."
+        }
+      },
+      "type": "object",
+      "description": "Request message for TagApiDeploymentRevision."
+    },
+    "ApiSpec": {
+      "type": "object",
+      "properties": {
+        "sizeBytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Output only. The size of the spec file in bytes. If the spec is gzipped, this is the size of the uncompressed spec.",
+          "readOnly": true
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "A style (format) descriptor for this spec that is specified as a Media Type (https://en.wikipedia.org/wiki/Media_type). Possible values include `application/vnd.apigee.proto`, `application/vnd.apigee.openapi`, and `application/vnd.apigee.graphql`, with possible suffixes representing compression types. These hypothetical names are defined in the vendor tree defined in RFC6838 (https://tools.ietf.org/html/rfc6838) and are not final. Content types can specify compression. Currently only GZip compression is supported (indicated with \"+gzip\")."
+        },
+        "revisionCreateTime": {
+          "type": "string",
+          "description": "Output only. Revision creation timestamp; when the represented revision was created.",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "contents": {
+          "description": "Input only. The contents of the spec. Provided by API callers when specs are created or updated. To access the contents of a spec, use GetApiSpecContents.",
+          "type": "string",
+          "format": "byte"
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "description": "Output only. Creation timestamp; when the spec resource was created.",
+          "type": "string",
+          "readOnly": true
+        },
+        "labels": {
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "filename": {
+          "description": "A possibly-hierarchical name used to refer to the spec from other specs.",
+          "type": "string"
+        },
+        "sourceUri": {
+          "description": "The original source URI of the spec (if one exists). This is an external location that can be used for reference purposes but which may not be authoritative since this external resource may change after the spec is retrieved.",
+          "type": "string"
+        },
+        "revisionUpdateTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "description": "Output only. Last update timestamp: when the represented revision was last modified.",
+          "readOnly": true
+        },
+        "hash": {
+          "readOnly": true,
+          "description": "Output only. A SHA-256 hash of the spec's contents. If the spec is gzipped, this is the hash of the uncompressed spec.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "revisionId": {
+          "type": "string",
+          "description": "Output only. Immutable. The revision ID of the spec. A new revision is committed whenever the spec contents are changed. The format is an 8-character hexadecimal string.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        }
+      },
+      "description": "Describes a version of an API in a structured way. ApiSpecs provide formal descriptions that consumers can use to use a version. ApiSpec resources are intended to be fully-resolved descriptions of an ApiVersion. When specs consist of multiple files, these should be bundled together (e.g., in a zip archive) and stored as a unit. Multiple specs can exist to provide representations in different API description formats. Synchronization of these representations would be provided by tooling and background services.",
+      "id": "ApiSpec"
+    },
+    "TestIamPermissionsRequest": {
+      "type": "object",
+      "description": "Request message for `TestIamPermissions` method.",
+      "properties": {
+        "permissions": {
+          "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "TestIamPermissionsRequest"
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
+      "type": "object",
+      "id": "Empty",
+      "properties": {}
+    },
+    "RollbackApiSpecRequest": {
+      "id": "RollbackApiSpecRequest",
+      "description": "Request message for RollbackApiSpec.",
+      "properties": {
+        "revisionId": {
+          "description": "Required. The revision ID to roll back to. It must be a revision of the same spec. Example: `c7cfa2a8`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OperationMetadata": {
+      "properties": {
+        "cancellationRequested": {
+          "type": "boolean",
+          "description": "Identifies whether the user has requested cancellation of the operation. Operations that have successfully been cancelled have Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`."
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "description": "The time the operation was created.",
+          "type": "string"
+        },
+        "endTime": {
+          "type": "string",
+          "description": "The time the operation finished running.",
+          "format": "google-datetime"
+        },
+        "verb": {
+          "type": "string",
+          "description": "Name of the verb executed by the operation."
+        },
+        "statusMessage": {
+          "description": "Human-readable status of the operation, if any.",
+          "type": "string"
+        },
+        "target": {
+          "description": "Server-defined resource path for the target of the operation.",
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "API version used to start the operation."
+        }
+      },
+      "type": "object",
+      "description": "Represents the metadata of the long-running operation.",
+      "id": "OperationMetadata"
+    }
+  },
+  "documentationLink": "https://cloud.google.com/apigee/docs/api-hub/what-is-api-hub",
+  "basePath": "",
+  "canonicalName": "Apigee Registry",
+  "kind": "discovery#restDescription",
+  "fullyEncodeReservedExpansion": true,
+  "protocol": "rest",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account."
+        }
+      }
+    }
+  },
+  "baseUrl": "https://apigeeregistry.googleapis.com/",
+  "version_module": true,
+  "id": "apigeeregistry:v1",
+  "batchPath": "batch",
+  "name": "apigeeregistry",
+  "revision": "20221026",
+  "ownerName": "Google",
+  "rootUrl": "https://apigeeregistry.googleapis.com/",
+  "servicePath": "",
+  "title": "Apigee Registry API"
+}

--- a/cmd/registry/cmd/upload/bulk/testdata/discovery/apis.json
+++ b/cmd/registry/cmd/upload/bulk/testdata/discovery/apis.json
@@ -1,0 +1,36 @@
+{
+  "kind": "discovery#directoryList",
+  "discoveryVersion": "v1",
+  "items": [
+    {
+      "kind": "discovery#directoryItem",
+      "id": "apigeeregistry:v1",
+      "name": "apigeeregistry",
+      "version": "v1",
+      "title": "Apigee Registry API",
+      "description": "",
+      "discoveryRestUrl": "http://localhost:8081/apigeeregistry-v1.json",
+      "icons": {
+        "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+        "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
+      },
+      "documentationLink": "https://cloud.google.com/apigee/docs/api-hub/what-is-api-hub",
+      "preferred": true
+    },
+    {
+      "kind": "discovery#directoryItem",
+      "id": "discovery:v1",
+      "name": "discovery",
+      "version": "v1",
+      "title": "API Discovery Service",
+      "description": "Google API Discovery Service allows service consumers to list the discovery metadata of all public APIs managed by the API Platform.",
+      "discoveryRestUrl": "http://localhost:8081/discovery-v1.json",
+      "icons": {
+        "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
+        "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
+      },
+      "documentationLink": "https://developers.google.com/discovery",
+      "preferred": true
+    }
+  ]
+}

--- a/cmd/registry/cmd/upload/bulk/testdata/discovery/discovery-v1.json
+++ b/cmd/registry/cmd/upload/bulk/testdata/discovery/discovery-v1.json
@@ -1,0 +1,689 @@
+{
+  "name": "discovery",
+  "resources": {
+    "apis": {
+      "methods": {
+        "getRest": {
+          "parameterOrder": [
+            "api",
+            "version"
+          ],
+          "parameters": {
+            "api": {
+              "location": "path",
+              "description": "The name of the API.",
+              "type": "string",
+              "required": true
+            },
+            "version": {
+              "description": "The version of the API.",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "httpMethod": "GET",
+          "path": "apis/{api}/{version}/rest",
+          "response": {
+            "$ref": "RestDescription"
+          },
+          "id": "discovery.apis.getRest",
+          "description": "Retrieve the description of a particular version of an api."
+        },
+        "list": {
+          "response": {
+            "$ref": "DirectoryList"
+          },
+          "parameters": {
+            "name": {
+              "description": "Only include APIs with the given name.",
+              "location": "query",
+              "type": "string"
+            },
+            "preferred": {
+              "type": "boolean",
+              "description": "Return only the preferred version of an API.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "description": "Retrieve the list of APIs supported at this endpoint.",
+          "id": "discovery.apis.list",
+          "httpMethod": "GET",
+          "path": "apis"
+        }
+      }
+    }
+  },
+  "kind": "discovery#restDescription",
+  "ownerName": "Google",
+  "parameters": {
+    "userIp": {
+      "type": "string",
+      "description": "Deprecated. Please use quotaUser instead.",
+      "location": "query"
+    },
+    "alt": {
+      "enum": [
+        "json"
+      ],
+      "default": "json",
+      "description": "Data format for the response.",
+      "location": "query",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "type": "string"
+    },
+    "key": {
+      "location": "query",
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+    },
+    "quotaUser": {
+      "location": "query",
+      "type": "string",
+      "description": "An opaque string that represents a user for quota purposes. Must not exceed 40 characters."
+    },
+    "fields": {
+      "location": "query",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string"
+    },
+    "oauth_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user."
+    },
+    "prettyPrint": {
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "location": "query",
+      "type": "boolean"
+    }
+  },
+  "documentationLink": "https://developers.google.com/discovery/",
+  "version": "v1",
+  "protocol": "rest",
+  "id": "discovery:v1",
+  "schemas": {
+    "RestMethod": {
+      "properties": {
+        "scopes": {
+          "description": "OAuth 2.0 scopes applicable to this method.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "useMediaDownloadService": {
+          "description": "Indicates that downloads from this method should use the download service URL (i.e. \"/download\"). Only applies if the method supports media download.",
+          "type": "boolean"
+        },
+        "httpMethod": {
+          "description": "HTTP method used by this method.",
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "JsonSchema",
+            "description": "Details for a single parameter in this method."
+          },
+          "description": "Details for all parameters in this method."
+        },
+        "parameterOrder": {
+          "type": "array",
+          "description": "Ordered list of required parameters, serves as a hint to clients on how to structure their method signatures. The array is ordered such that the \"most-significant\" parameter appears first.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "description": "The URI path of this REST method. Should be used in conjunction with the basePath property at the api-level.",
+          "type": "string"
+        },
+        "etagRequired": {
+          "description": "Whether this method requires an ETag to be specified. The ETag is sent as an HTTP If-Match or If-None-Match header.",
+          "type": "boolean"
+        },
+        "supportsMediaUpload": {
+          "type": "boolean",
+          "description": "Whether this method supports media uploads."
+        },
+        "response": {
+          "description": "The schema for the response.",
+          "properties": {
+            "$ref": {
+              "description": "Schema ID for the response schema.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "mediaUpload": {
+          "description": "Media upload parameters.",
+          "properties": {
+            "maxSize": {
+              "type": "string",
+              "description": "Maximum size of a media upload, such as \"1MB\", \"2GB\" or \"3TB\"."
+            },
+            "accept": {
+              "description": "MIME Media Ranges for acceptable media uploads to this method.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "protocols": {
+              "properties": {
+                "simple": {
+                  "type": "object",
+                  "description": "Supports uploading as a single HTTP request.",
+                  "properties": {
+                    "multipart": {
+                      "type": "boolean",
+                      "default": "true",
+                      "description": "True if this endpoint supports upload multipart media."
+                    },
+                    "path": {
+                      "description": "The URI path to be used for upload. Should be used in conjunction with the basePath property at the api-level.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "resumable": {
+                  "properties": {
+                    "multipart": {
+                      "type": "boolean",
+                      "default": "true",
+                      "description": "True if this endpoint supports uploading multipart media."
+                    },
+                    "path": {
+                      "type": "string",
+                      "description": "The URI path to be used for upload. Should be used in conjunction with the basePath property at the api-level."
+                    }
+                  },
+                  "type": "object",
+                  "description": "Supports the Resumable Media Upload protocol."
+                }
+              },
+              "type": "object",
+              "description": "Supported upload protocols."
+            }
+          },
+          "type": "object"
+        },
+        "request": {
+          "description": "The schema for the request.",
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "description": "Schema ID for the request schema."
+            },
+            "parameterName": {
+              "type": "string",
+              "description": "parameter name."
+            }
+          }
+        },
+        "id": {
+          "description": "A unique ID for this method. This property can be used to match methods between different versions of Discovery.",
+          "type": "string"
+        },
+        "flatPath": {
+          "type": "string",
+          "description": "The URI path of this REST method in (RFC 6570) format without level 2 features ({+var}). Supplementary to the path property."
+        },
+        "supportsMediaDownload": {
+          "description": "Whether this method supports media downloads.",
+          "type": "boolean"
+        },
+        "supportsSubscription": {
+          "type": "boolean",
+          "description": "Whether this method supports subscriptions."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of this method."
+        }
+      },
+      "id": "RestMethod",
+      "type": "object"
+    },
+    "RestDescription": {
+      "properties": {
+        "ownerDomain": {
+          "description": "The domain of the owner of this API. Together with the ownerName and a packagePath values, this can be used to generate a library for this API which would have a unique fully qualified name.",
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "default": "discovery#restDescription",
+          "description": "The kind for this response."
+        },
+        "batchPath": {
+          "description": "The path for REST batch requests.",
+          "type": "string"
+        },
+        "rootUrl": {
+          "description": "The root URL under which all API services live.",
+          "type": "string"
+        },
+        "exponentialBackoffDefault": {
+          "type": "boolean",
+          "description": "Enable exponential backoff for suitable methods in the generated clients."
+        },
+        "id": {
+          "description": "The ID of this API.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Links to 16x16 and 32x32 icons representing the API.",
+          "type": "object",
+          "properties": {
+            "x32": {
+              "type": "string",
+              "description": "The URL of the 32x32 icon."
+            },
+            "x16": {
+              "type": "string",
+              "description": "The URL of the 16x16 icon."
+            }
+          }
+        },
+        "auth": {
+          "description": "Authentication information.",
+          "properties": {
+            "oauth2": {
+              "description": "OAuth 2.0 authentication information.",
+              "type": "object",
+              "properties": {
+                "scopes": {
+                  "description": "Available OAuth 2.0 scopes.",
+                  "additionalProperties": {
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "Description of scope."
+                      }
+                    },
+                    "description": "The scope value.",
+                    "type": "object"
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "type": "object"
+        },
+        "etag": {
+          "description": "The ETag for this response.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "parameters": {
+          "description": "Common parameters that apply across all apis.",
+          "additionalProperties": {
+            "description": "Description of a single parameter.",
+            "$ref": "JsonSchema"
+          },
+          "type": "object"
+        },
+        "revision": {
+          "description": "The version of this API.",
+          "type": "string"
+        },
+        "schemas": {
+          "type": "object",
+          "description": "The schemas for this API.",
+          "additionalProperties": {
+            "description": "An individual schema description.",
+            "$ref": "JsonSchema"
+          }
+        },
+        "ownerName": {
+          "type": "string",
+          "description": "The name of the owner of this API. See ownerDomain."
+        },
+        "discoveryVersion": {
+          "type": "string",
+          "description": "Indicate the version of the Discovery API used to generate this doc.",
+          "default": "v1"
+        },
+        "version": {
+          "description": "The version of this API.",
+          "type": "string"
+        },
+        "canonicalName": {
+          "description": "Indicates how the API name should be capitalized and split into various parts. Useful for generating pretty class names.",
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of this API."
+        },
+        "packagePath": {
+          "type": "string",
+          "description": "The package of the owner of this API. See ownerDomain."
+        },
+        "version_module": {
+          "type": "boolean"
+        },
+        "methods": {
+          "description": "API-level methods for this API.",
+          "additionalProperties": {
+            "description": "An individual method description.",
+            "$ref": "RestMethod"
+          },
+          "type": "object"
+        },
+        "baseUrl": {
+          "type": "string",
+          "description": "[DEPRECATED] The base URL for REST requests."
+        },
+        "documentationLink": {
+          "type": "string",
+          "description": "A link to human readable documentation for the API."
+        },
+        "protocol": {
+          "default": "rest",
+          "description": "The protocol described by this document.",
+          "type": "string"
+        },
+        "features": {
+          "description": "A list of supported features for this API.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "basePath": {
+          "type": "string",
+          "description": "[DEPRECATED] The base path for REST requests."
+        },
+        "resources": {
+          "additionalProperties": {
+            "description": "An individual resource description. Contains methods and sub-resources related to this resource.",
+            "$ref": "RestResource"
+          },
+          "description": "The resources in this API.",
+          "type": "object"
+        },
+        "servicePath": {
+          "type": "string",
+          "description": "The base path for all REST requests."
+        },
+        "labels": {
+          "description": "Labels for the status of this API, such as labs or deprecated.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of this API."
+        },
+        "name": {
+          "description": "The name of this API.",
+          "type": "string"
+        }
+      },
+      "id": "RestDescription",
+      "type": "object"
+    },
+    "DirectoryList": {
+      "type": "object",
+      "id": "DirectoryList",
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "name": {
+                "description": "The name of the API.",
+                "type": "string"
+              },
+              "preferred": {
+                "description": "True if this version is the preferred version to use.",
+                "type": "boolean"
+              },
+              "icons": {
+                "type": "object",
+                "properties": {
+                  "x16": {
+                    "type": "string",
+                    "description": "The URL of the 16x16 icon."
+                  },
+                  "x32": {
+                    "description": "The URL of the 32x32 icon.",
+                    "type": "string"
+                  }
+                },
+                "description": "Links to 16x16 and 32x32 icons representing the API."
+              },
+              "kind": {
+                "description": "The kind for this response.",
+                "type": "string",
+                "default": "discovery#directoryItem"
+              },
+              "discoveryLink": {
+                "description": "A link to the discovery document.",
+                "type": "string"
+              },
+              "documentationLink": {
+                "description": "A link to human readable documentation for the API.",
+                "type": "string"
+              },
+              "labels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "Labels for the status of this API, such as labs or deprecated."
+              },
+              "title": {
+                "type": "string",
+                "description": "The title of this API."
+              },
+              "version": {
+                "type": "string",
+                "description": "The version of the API."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of this API."
+              },
+              "discoveryRestUrl": {
+                "type": "string",
+                "description": "The URL for the discovery REST document."
+              },
+              "id": {
+                "description": "The id of this API.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": "The individual directory entries. One entry per api/version pair.",
+          "type": "array"
+        },
+        "kind": {
+          "description": "The kind for this response.",
+          "default": "discovery#directoryList",
+          "type": "string"
+        },
+        "discoveryVersion": {
+          "description": "Indicate the version of the Discovery API used to generate this doc.",
+          "default": "v1",
+          "type": "string"
+        }
+      }
+    },
+    "RestResource": {
+      "properties": {
+        "resources": {
+          "additionalProperties": {
+            "$ref": "RestResource",
+            "description": "Description for any sub-resources on this resource."
+          },
+          "type": "object",
+          "description": "Sub-resources on this resource."
+        },
+        "methods": {
+          "type": "object",
+          "additionalProperties": {
+            "description": "Description for any methods on this resource.",
+            "$ref": "RestMethod"
+          },
+          "description": "Methods on this resource."
+        }
+      },
+      "type": "object",
+      "id": "RestResource"
+    },
+    "JsonSchema": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "description": "If this is a schema for an object, list the schema for each property of this object.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "A single property of this object. The value is itself a JSON Schema object describing this property.",
+            "$ref": "JsonSchema"
+          }
+        },
+        "maximum": {
+          "description": "The maximum value of this parameter.",
+          "type": "string"
+        },
+        "items": {
+          "description": "If this is a schema for an array, this property is the schema for each element in the array.",
+          "$ref": "JsonSchema"
+        },
+        "id": {
+          "description": "Unique identifier for this schema.",
+          "type": "string"
+        },
+        "variant": {
+          "description": "In a variant data type, the value of one property is used to determine how to interpret the entire entity. Its value must exist in a map of descriminant values to schema names.",
+          "type": "object",
+          "properties": {
+            "discriminant": {
+              "description": "The name of the type discriminant property.",
+              "type": "string"
+            },
+            "map": {
+              "items": {
+                "type": "object",
+                "properties": {
+                  "$ref": {
+                    "type": "string"
+                  },
+                  "type_value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "type": "array",
+              "description": "The map of discriminant value to schema to use for parsing.."
+            }
+          }
+        },
+        "format": {
+          "type": "string",
+          "description": "An additional regular expression or key that helps constrain the value. For more details see: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.23"
+        },
+        "location": {
+          "description": "Whether this parameter goes in the query or the path for REST requests.",
+          "type": "string"
+        },
+        "enumDescriptions": {
+          "description": "The descriptions for the enums. Each position maps to the corresponding value in the \"enum\" array.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "readOnly": {
+          "type": "boolean",
+          "description": "The value is read-only, generated by the service. The value cannot be modified by the client. If the value is included in a POST, PUT, or PATCH request, it is ignored by the service."
+        },
+        "default": {
+          "description": "The default value of this property (if one exists).",
+          "type": "string"
+        },
+        "type": {
+          "description": "The value type for this schema. A list of values can be found here: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1",
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "description": "Values this parameter may take (if it is an enum).",
+          "type": "array"
+        },
+        "repeated": {
+          "type": "boolean",
+          "description": "Whether this parameter may appear multiple times."
+        },
+        "annotations": {
+          "description": "Additional information about this property.",
+          "properties": {
+            "required": {
+              "description": "A list of methods for which this property is required on requests.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "type": "object"
+        },
+        "minimum": {
+          "description": "The minimum value of this parameter.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of this object.",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether the parameter is required.",
+          "type": "boolean"
+        },
+        "additionalProperties": {
+          "$ref": "JsonSchema",
+          "description": "If this is a schema for an object, this property is the schema for any additional properties with dynamic keys on this object."
+        },
+        "pattern": {
+          "type": "string",
+          "description": "The regular expression this parameter must conform to. Uses Java 6 regex format: http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html"
+        },
+        "$ref": {
+          "type": "string",
+          "description": "A reference to another schema. The value of this property is the \"id\" of another schema."
+        }
+      },
+      "id": "JsonSchema"
+    }
+  },
+  "basePath": "/discovery/v1/",
+  "discoveryVersion": "v1",
+  "etag": "\"-2NioU2H8y8siEzrBOV_qzRI6kQ/vabF8Q1ADCm_Bt9EBq9rkrRawQA\"",
+  "icons": {
+    "x32": "http://www.google.com/images/icons/feature/filing_cabinet_search-g32.png",
+    "x16": "http://www.google.com/images/icons/feature/filing_cabinet_search-g16.png"
+  },
+  "baseUrl": "https://www.googleapis.com/discovery/v1/",
+  "rootUrl": "https://www.googleapis.com/",
+  "description": "Provides information about other Google APIs, such as what APIs are available, the resource, and method details for each API.",
+  "ownerDomain": "google.com",
+  "title": "API Discovery Service",
+  "servicePath": "discovery/v1/",
+  "revision": "20200806",
+  "batchPath": "batch/discovery/v1"
+}


### PR DESCRIPTION
Completes #739. The Discovery Service is easy to mock - here we just serve static files from the `testdata/discovery` directory.