### PR TITLE
Increase gRPC client timeout to 60 seconds

### DIFF
--- a/gapic/admin_client.go
+++ b/gapic/admin_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gapic/admin_client_example_test.go
+++ b/gapic/admin_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gapic/doc.go
+++ b/gapic/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gapic/grpc_service_config.json
+++ b/gapic/grpc_service_config.json
@@ -6,7 +6,7 @@
             "service": "google.cloud.apigeeregistry.v1.Registry"
           }
         ],
-        "timeout": "20s",
+        "timeout": "60s",
         "retryPolicy": {
           "initialBackoff": "0.200s",
           "maxBackoff": "10s",

--- a/gapic/provisioning_client.go
+++ b/gapic/provisioning_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gapic/provisioning_client_example_test.go
+++ b/gapic/provisioning_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gapic/registry_client.go
+++ b/gapic/registry_client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -979,7 +979,7 @@ func (c *registryGRPCClient) ListApis(ctx context.Context, req *rpcpb.ListApisRe
 
 func (c *registryGRPCClient) GetApi(ctx context.Context, req *rpcpb.GetApiRequest, opts ...gax.CallOption) (*rpcpb.Api, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1001,7 +1001,7 @@ func (c *registryGRPCClient) GetApi(ctx context.Context, req *rpcpb.GetApiReques
 
 func (c *registryGRPCClient) CreateApi(ctx context.Context, req *rpcpb.CreateApiRequest, opts ...gax.CallOption) (*rpcpb.Api, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1023,7 +1023,7 @@ func (c *registryGRPCClient) CreateApi(ctx context.Context, req *rpcpb.CreateApi
 
 func (c *registryGRPCClient) UpdateApi(ctx context.Context, req *rpcpb.UpdateApiRequest, opts ...gax.CallOption) (*rpcpb.Api, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1045,7 +1045,7 @@ func (c *registryGRPCClient) UpdateApi(ctx context.Context, req *rpcpb.UpdateApi
 
 func (c *registryGRPCClient) DeleteApi(ctx context.Context, req *rpcpb.DeleteApiRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1108,7 +1108,7 @@ func (c *registryGRPCClient) ListApiVersions(ctx context.Context, req *rpcpb.Lis
 
 func (c *registryGRPCClient) GetApiVersion(ctx context.Context, req *rpcpb.GetApiVersionRequest, opts ...gax.CallOption) (*rpcpb.ApiVersion, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1130,7 +1130,7 @@ func (c *registryGRPCClient) GetApiVersion(ctx context.Context, req *rpcpb.GetAp
 
 func (c *registryGRPCClient) CreateApiVersion(ctx context.Context, req *rpcpb.CreateApiVersionRequest, opts ...gax.CallOption) (*rpcpb.ApiVersion, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1152,7 +1152,7 @@ func (c *registryGRPCClient) CreateApiVersion(ctx context.Context, req *rpcpb.Cr
 
 func (c *registryGRPCClient) UpdateApiVersion(ctx context.Context, req *rpcpb.UpdateApiVersionRequest, opts ...gax.CallOption) (*rpcpb.ApiVersion, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1174,7 +1174,7 @@ func (c *registryGRPCClient) UpdateApiVersion(ctx context.Context, req *rpcpb.Up
 
 func (c *registryGRPCClient) DeleteApiVersion(ctx context.Context, req *rpcpb.DeleteApiVersionRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1237,7 +1237,7 @@ func (c *registryGRPCClient) ListApiSpecs(ctx context.Context, req *rpcpb.ListAp
 
 func (c *registryGRPCClient) GetApiSpec(ctx context.Context, req *rpcpb.GetApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1259,7 +1259,7 @@ func (c *registryGRPCClient) GetApiSpec(ctx context.Context, req *rpcpb.GetApiSp
 
 func (c *registryGRPCClient) GetApiSpecContents(ctx context.Context, req *rpcpb.GetApiSpecContentsRequest, opts ...gax.CallOption) (*httpbodypb.HttpBody, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1281,7 +1281,7 @@ func (c *registryGRPCClient) GetApiSpecContents(ctx context.Context, req *rpcpb.
 
 func (c *registryGRPCClient) CreateApiSpec(ctx context.Context, req *rpcpb.CreateApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1303,7 +1303,7 @@ func (c *registryGRPCClient) CreateApiSpec(ctx context.Context, req *rpcpb.Creat
 
 func (c *registryGRPCClient) UpdateApiSpec(ctx context.Context, req *rpcpb.UpdateApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1325,7 +1325,7 @@ func (c *registryGRPCClient) UpdateApiSpec(ctx context.Context, req *rpcpb.Updat
 
 func (c *registryGRPCClient) DeleteApiSpec(ctx context.Context, req *rpcpb.DeleteApiSpecRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1343,7 +1343,7 @@ func (c *registryGRPCClient) DeleteApiSpec(ctx context.Context, req *rpcpb.Delet
 
 func (c *registryGRPCClient) TagApiSpecRevision(ctx context.Context, req *rpcpb.TagApiSpecRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1410,7 +1410,7 @@ func (c *registryGRPCClient) ListApiSpecRevisions(ctx context.Context, req *rpcp
 
 func (c *registryGRPCClient) RollbackApiSpec(ctx context.Context, req *rpcpb.RollbackApiSpecRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1432,7 +1432,7 @@ func (c *registryGRPCClient) RollbackApiSpec(ctx context.Context, req *rpcpb.Rol
 
 func (c *registryGRPCClient) DeleteApiSpecRevision(ctx context.Context, req *rpcpb.DeleteApiSpecRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiSpec, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1499,7 +1499,7 @@ func (c *registryGRPCClient) ListApiDeployments(ctx context.Context, req *rpcpb.
 
 func (c *registryGRPCClient) GetApiDeployment(ctx context.Context, req *rpcpb.GetApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1521,7 +1521,7 @@ func (c *registryGRPCClient) GetApiDeployment(ctx context.Context, req *rpcpb.Ge
 
 func (c *registryGRPCClient) CreateApiDeployment(ctx context.Context, req *rpcpb.CreateApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1543,7 +1543,7 @@ func (c *registryGRPCClient) CreateApiDeployment(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) UpdateApiDeployment(ctx context.Context, req *rpcpb.UpdateApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1565,7 +1565,7 @@ func (c *registryGRPCClient) UpdateApiDeployment(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) DeleteApiDeployment(ctx context.Context, req *rpcpb.DeleteApiDeploymentRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1583,7 +1583,7 @@ func (c *registryGRPCClient) DeleteApiDeployment(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) TagApiDeploymentRevision(ctx context.Context, req *rpcpb.TagApiDeploymentRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1650,7 +1650,7 @@ func (c *registryGRPCClient) ListApiDeploymentRevisions(ctx context.Context, req
 
 func (c *registryGRPCClient) RollbackApiDeployment(ctx context.Context, req *rpcpb.RollbackApiDeploymentRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1672,7 +1672,7 @@ func (c *registryGRPCClient) RollbackApiDeployment(ctx context.Context, req *rpc
 
 func (c *registryGRPCClient) DeleteApiDeploymentRevision(ctx context.Context, req *rpcpb.DeleteApiDeploymentRevisionRequest, opts ...gax.CallOption) (*rpcpb.ApiDeployment, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1739,7 +1739,7 @@ func (c *registryGRPCClient) ListArtifacts(ctx context.Context, req *rpcpb.ListA
 
 func (c *registryGRPCClient) GetArtifact(ctx context.Context, req *rpcpb.GetArtifactRequest, opts ...gax.CallOption) (*rpcpb.Artifact, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1761,7 +1761,7 @@ func (c *registryGRPCClient) GetArtifact(ctx context.Context, req *rpcpb.GetArti
 
 func (c *registryGRPCClient) GetArtifactContents(ctx context.Context, req *rpcpb.GetArtifactContentsRequest, opts ...gax.CallOption) (*httpbodypb.HttpBody, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1783,7 +1783,7 @@ func (c *registryGRPCClient) GetArtifactContents(ctx context.Context, req *rpcpb
 
 func (c *registryGRPCClient) CreateArtifact(ctx context.Context, req *rpcpb.CreateArtifactRequest, opts ...gax.CallOption) (*rpcpb.Artifact, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1805,7 +1805,7 @@ func (c *registryGRPCClient) CreateArtifact(ctx context.Context, req *rpcpb.Crea
 
 func (c *registryGRPCClient) ReplaceArtifact(ctx context.Context, req *rpcpb.ReplaceArtifactRequest, opts ...gax.CallOption) (*rpcpb.Artifact, error) {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}
@@ -1827,7 +1827,7 @@ func (c *registryGRPCClient) ReplaceArtifact(ctx context.Context, req *rpcpb.Rep
 
 func (c *registryGRPCClient) DeleteArtifact(ctx context.Context, req *rpcpb.DeleteArtifactRequest, opts ...gax.CallOption) error {
 	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
-		cctx, cancel := context.WithTimeout(ctx, 20000*time.Millisecond)
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
 		defer cancel()
 		ctx = cctx
 	}

--- a/gapic/registry_client_example_test.go
+++ b/gapic/registry_client_example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This works around some issues that we're seeing in hosted implementations which cause API calls to be cancelled prematurely. Proxies are subtracting time from the deadlines that we send and cancelling if the remaining time is less than some threshold. Specifically, we see our 20s timeout become 10s, and then with a fraction of a second removed during processing, the operation is canceled because the hosting platform requires 10s minimums. This seems like a bug in the hosting configuration, so we might revisit this when that's better understood.

See also: https://github.com/googleapis/gapic-generator-go/issues/1206