### PR TITLE
Fix patterns for revision collection names.

### DIFF
--- a/server/registry/names/deployment_revision.go
+++ b/server/registry/names/deployment_revision.go
@@ -22,7 +22,7 @@ import (
 var deploymentRevisionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/deployments/%s(?:@%s)?$",
 	identifier, Location, identifier, identifier, revisionTag))
 
-var deploymentRevisionCollectionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/deployments/%s@",
+var deploymentRevisionCollectionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/deployments/%s@$",
 	identifier, Location, identifier, identifier))
 
 // DeploymentRevision represents a resource name for an API deployment revision.

--- a/server/registry/names/names_test.go
+++ b/server/registry/names/names_test.go
@@ -162,6 +162,22 @@ func TestResourceNames(t *testing.T) {
 			},
 		},
 		{
+			name: "spec revision collections",
+			check: func(name string) bool {
+				_, err := ParseSpecRevisionCollection(name)
+				return err == nil
+			},
+			pass: []string{
+				"projects/google/locations/global/apis/sample/versions/v1/specs/s@",
+				"projects/-/locations/global/apis/-/versions/-/specs/-@",
+			},
+			fail: []string{
+				"-",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/s@123",
+				"projects/-/locations/global/apis/-/versions/-/specs/-",
+			},
+		},
+		{
 			name: "spec revision",
 			check: func(name string) bool {
 				_, err := ParseSpecRevision(name)
@@ -216,6 +232,22 @@ func TestResourceNames(t *testing.T) {
 				"projects/123/locations/global/invalid/123",
 				"projects/123/locations/global/apis/ 123",
 				"projects/google/locations/global/apis/sample/deployments/v1@1234567890abcdef",
+			},
+		},
+		{
+			name: "deployment revision collections",
+			check: func(name string) bool {
+				_, err := ParseDeploymentRevisionCollection(name)
+				return err == nil
+			},
+			pass: []string{
+				"projects/google/locations/global/apis/sample/deployments/d@",
+				"projects/-/locations/global/apis/-/deployments/d@",
+			},
+			fail: []string{
+				"-",
+				"projects/google/locations/global/apis/sample/deployments/d@123",
+				"projects/-/locations/global/apis/-/deployments/d",
 			},
 		},
 		{

--- a/server/registry/names/spec_revision.go
+++ b/server/registry/names/spec_revision.go
@@ -22,8 +22,8 @@ import (
 var specRevisionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs/%s(?:@%s)?$",
 	identifier, Location, identifier, identifier, identifier, revisionTag))
 
-var specRevisionCollectionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs@$",
-	identifier, Location, identifier, identifier))
+var specRevisionCollectionRegexp = regexp.MustCompile(fmt.Sprintf("^projects/%s/locations/%s/apis/%s/versions/%s/specs/%s@$",
+	identifier, Location, identifier, identifier, identifier))
 
 // SpecRevision represents a resource name for an API spec revision.
 type SpecRevision struct {


### PR DESCRIPTION
Patterns used to match spec and deployment revision collections were breaking changes that I was testing for #896. Here's the fix in a standalone PR.