### PR TITLE
Remove redundant print of errors - cobra prints errors so we don't need to

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -33,7 +33,6 @@ func main() {
 
 	cmd := cmd.Command()
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Prior to this change, errors were being printed twice by the `registry tool`: once by the Cobra framework and once by our code (which this PR deletes).

```
$ registry get invalid
Error: unsupported entity projects/googleapis/locations/global/invalid
Usage:
  registry get PATTERN [flags]

Flags:
      --filter string   Filter selected resources
  -h, --help            help for get
  -o, --output string   Output type (name, yaml, contents) (default "name")

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the registry api (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the registry location
      --registry.project string    the registry project
      --registry.token string      the token to use for authorization to registry

unsupported entity projects/googleapis/locations/global/invalid
```