### PR TITLE
Add tests for `names` package.

### DIFF
--- a/server/registry/names/api_test.go
+++ b/server/registry/names/api_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestApiNames(t *testing.T) {
+	a := &Api{
+		ProjectID: "p",
+		ApiID:     "a",
+	}
+	err := a.Validate()
+	if err != nil {
+		t.Errorf("Validate() failed for name %s: %s", a, err)
+	}
+	if a.Project().String() != "projects/p" {
+		t.Errorf("%s Project() returned incorrect value %s", a, a.Project())
+	}
+	if a.Version("v").String() != "projects/p/locations/global/apis/a/versions/v" {
+		t.Errorf("%s Version() returned incorrect value %s", a, a.Version("v"))
+	}
+	if a.Deployment("d").String() != "projects/p/locations/global/apis/a/deployments/d" {
+		t.Errorf("%s Deployment() returned incorrect value %s", a, a.Deployment("d"))
+	}
+	if a.Artifact("x").String() != "projects/p/locations/global/apis/a/artifacts/x" {
+		t.Errorf("%s Artifact() returned incorrect value %s", a, a.Artifact("x"))
+	}
+	if a.Parent() != "projects/p/locations/global" {
+		t.Errorf("%s Parent() returned incorrect value %s", a, a.Parent())
+	}
+}
+
+func TestInvalidApiNames(t *testing.T) {
+	names := []Api{
+		{
+			ProjectID: "!!",
+			ApiID:     "a",
+		},
+		{
+			ProjectID: "p",
+			ApiID:     "!!",
+		},
+	}
+	for _, name := range names {
+		err := name.Validate()
+		if err == nil {
+			t.Errorf("Validate() succeeded for %s and should have failed", name)
+		}
+	}
+}

--- a/server/registry/names/artifact_test.go
+++ b/server/registry/names/artifact_test.go
@@ -1,0 +1,249 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestArtifactNames(t *testing.T) {
+	tests := []struct {
+		name         Artifact
+		projectID    string
+		apiID        string
+		versionID    string
+		specID       string
+		deploymentID string
+		revisionID   string
+		artifactID   string
+		parent       string
+	}{
+		{
+			name: Artifact{
+				name: projectArtifact{
+					ProjectID:  "p",
+					ArtifactID: "x",
+				},
+			},
+			projectID:  "p",
+			artifactID: "x",
+			parent:     "projects/p/locations/global",
+		},
+		{
+			name: Artifact{
+				name: apiArtifact{
+					ProjectID:  "p",
+					ApiID:      "a",
+					ArtifactID: "x",
+				},
+			},
+			projectID:  "p",
+			apiID:      "a",
+			artifactID: "x",
+			parent:     "projects/p/locations/global/apis/a",
+		},
+		{
+			name: Artifact{
+				name: versionArtifact{
+					ProjectID:  "p",
+					ApiID:      "a",
+					VersionID:  "v",
+					ArtifactID: "x",
+				},
+			},
+			projectID:  "p",
+			apiID:      "a",
+			versionID:  "v",
+			artifactID: "x",
+			parent:     "projects/p/locations/global/apis/a/versions/v",
+		},
+		{
+			name: Artifact{
+				name: specArtifact{
+					ProjectID:  "p",
+					ApiID:      "a",
+					VersionID:  "v",
+					SpecID:     "s",
+					RevisionID: "123",
+					ArtifactID: "x",
+				},
+			},
+			projectID:  "p",
+			apiID:      "a",
+			versionID:  "v",
+			specID:     "s",
+			revisionID: "123",
+			artifactID: "x",
+			parent:     "projects/p/locations/global/apis/a/versions/v/specs/s@123",
+		},
+		{
+			name: Artifact{
+				name: deploymentArtifact{
+					ProjectID:    "p",
+					ApiID:        "a",
+					DeploymentID: "d",
+					RevisionID:   "123",
+					ArtifactID:   "x",
+				},
+			},
+			projectID:    "p",
+			apiID:        "a",
+			deploymentID: "d",
+			revisionID:   "123",
+			artifactID:   "x",
+			parent:       "projects/p/locations/global/apis/a/deployments/d@123",
+		},
+	}
+	for _, test := range tests {
+		err := test.name.Validate()
+		if err != nil {
+			t.Errorf("Validate() failed for name %s: %s", test.name, err)
+		}
+		if test.name.ProjectID() != test.projectID {
+			t.Errorf("%s ProjectID() returned incorrect value %s", test.name, test.name.ProjectID())
+		}
+		if test.name.ApiID() != test.apiID {
+			t.Errorf("%s ApiID() returned incorrect value %s", test.name, test.name.ApiID())
+		}
+		if test.name.VersionID() != test.versionID {
+			t.Errorf("%s VersionID() returned incorrect value %s", test.name, test.name.VersionID())
+		}
+		if test.name.SpecID() != test.specID {
+			t.Errorf("%s SpecID() returned incorrect value %s", test.name, test.name.SpecID())
+		}
+		if test.name.DeploymentID() != test.deploymentID {
+			t.Errorf("%s DeploymentID() returned incorrect value %s", test.name, test.name.DeploymentID())
+		}
+		if test.name.RevisionID() != test.revisionID {
+			t.Errorf("%s RevisionID() returned incorrect value %s", test.name, test.name.RevisionID())
+		}
+		if test.name.ArtifactID() != test.artifactID {
+			t.Errorf("%s ArtifactID() returned incorrect value %s", test.name, test.name.ArtifactID())
+		}
+		if test.name.Parent() != test.parent {
+			t.Errorf("%s Parent() returned incorrect value %s", test.name, test.name.Parent())
+		}
+	}
+}
+
+func TestInvalidArtifactNames(t *testing.T) {
+	names := []Artifact{
+		{
+			name: projectArtifact{
+				ProjectID:  "!!",
+				ArtifactID: "x",
+			},
+		},
+		{
+			name: projectArtifact{
+				ProjectID:  "p",
+				ArtifactID: "!!",
+			},
+		},
+		{
+			name: apiArtifact{
+				ProjectID:  "p",
+				ApiID:      "!!",
+				ArtifactID: "x",
+			},
+		},
+		{
+			name: apiArtifact{
+				ProjectID:  "p",
+				ApiID:      "a",
+				ArtifactID: "!!",
+			},
+		},
+		{
+			name: versionArtifact{
+				ProjectID:  "p",
+				ApiID:      "a",
+				VersionID:  "!!",
+				ArtifactID: "x",
+			},
+		},
+		{
+			name: versionArtifact{
+				ProjectID:  "p",
+				ApiID:      "a",
+				VersionID:  "v",
+				ArtifactID: "!!",
+			},
+		},
+		{
+			name: specArtifact{
+				ProjectID:  "p",
+				ApiID:      "a",
+				VersionID:  "v",
+				SpecID:     "!!",
+				RevisionID: "123",
+				ArtifactID: "x",
+			},
+		},
+		{
+			name: specArtifact{
+				ProjectID:  "p",
+				ApiID:      "a",
+				VersionID:  "v",
+				SpecID:     "s",
+				RevisionID: "!!!",
+				ArtifactID: "x",
+			},
+		},
+		{
+			name: specArtifact{
+				ProjectID:  "p",
+				ApiID:      "a",
+				VersionID:  "v",
+				SpecID:     "s",
+				RevisionID: "123",
+				ArtifactID: "!!",
+			},
+		},
+		{
+			name: deploymentArtifact{
+				ProjectID:    "p",
+				ApiID:        "a",
+				DeploymentID: "!!",
+				RevisionID:   "123",
+				ArtifactID:   "x",
+			},
+		},
+		{
+			name: deploymentArtifact{
+				ProjectID:    "p",
+				ApiID:        "a",
+				DeploymentID: "d",
+				RevisionID:   "!!!",
+				ArtifactID:   "x",
+			},
+		},
+		{
+			name: deploymentArtifact{
+				ProjectID:    "p",
+				ApiID:        "a",
+				DeploymentID: "d",
+				RevisionID:   "123",
+				ArtifactID:   "!!",
+			},
+		},
+	}
+	for _, name := range names {
+		err := name.Validate()
+		if err == nil {
+			t.Errorf("Validate() succeeded for %s and should have failed", name)
+		}
+	}
+}

--- a/server/registry/names/artifact_test.go
+++ b/server/registry/names/artifact_test.go
@@ -247,3 +247,31 @@ func TestInvalidArtifactNames(t *testing.T) {
 		}
 	}
 }
+
+func TestNullArtifactName(t *testing.T) {
+	name := Artifact{}
+	if name.ProjectID() != "" {
+		t.Errorf("%s has incorrect project id %s", name, name.ProjectID())
+	}
+	if name.ApiID() != "" {
+		t.Errorf("%s has incorrect api id %s", name, name.ApiID())
+	}
+	if name.VersionID() != "" {
+		t.Errorf("%s has incorrect version id %s", name, name.VersionID())
+	}
+	if name.SpecID() != "" {
+		t.Errorf("%s has incorrect spec id %s", name, name.SpecID())
+	}
+	if name.DeploymentID() != "" {
+		t.Errorf("%s has incorrect deployment id %s", name, name.DeploymentID())
+	}
+	if name.RevisionID() != "" {
+		t.Errorf("%s has incorrect revision id %s", name, name.RevisionID())
+	}
+	if name.ArtifactID() != "" {
+		t.Errorf("%s has incorrect artifact id %s", name, name.ArtifactID())
+	}
+	if name.Parent() != "" {
+		t.Errorf("%s has incorrect parent %s", name, name.Parent())
+	}
+}

--- a/server/registry/names/common.go
+++ b/server/registry/names/common.go
@@ -36,11 +36,6 @@ const (
 // User provided identifiers should be validated according to this format.
 var customIdentifier = regexp.MustCompile(`^[a-z0-9-.]+$`)
 
-// GenerateID generates a random resource ID.
-func GenerateID() string {
-	return uuid.New().String()[:8]
-}
-
 // validateID returns an error if the provided ID is invalid.
 func validateID(id string) error {
 	if "" == id {

--- a/server/registry/names/deployment_revision_test.go
+++ b/server/registry/names/deployment_revision_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestDeploymentRevisionNames(t *testing.T) {
+	name := &DeploymentRevision{
+		ProjectID:    "p",
+		ApiID:        "a",
+		DeploymentID: "d",
+		RevisionID:   "123",
+	}
+	if name.Project().String() != "projects/p" {
+		t.Errorf("%s Project() returned incorrect value %s", name, name.Project())
+	}
+	if name.Api().String() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Api())
+	}
+	if name.Deployment().String() != "projects/p/locations/global/apis/a/deployments/d" {
+		t.Errorf("%s Deployment() returned incorrect value %s", name, name.Deployment())
+	}
+	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/deployments/d@123/artifacts/x" {
+		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
+	}
+	if name.Parent() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
+	}
+}

--- a/server/registry/names/deployment_revision_test.go
+++ b/server/registry/names/deployment_revision_test.go
@@ -41,3 +41,14 @@ func TestDeploymentRevisionNames(t *testing.T) {
 		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
 	}
 }
+
+func TestImpliedDeploymentRevisionName(t *testing.T) {
+	name := &DeploymentRevision{
+		ProjectID:    "p",
+		ApiID:        "a",
+		DeploymentID: "d",
+	}
+	if name.String() != "projects/p/locations/global/apis/a/deployments/d" {
+		t.Errorf("%s has incorrect name", name)
+	}
+}

--- a/server/registry/names/deployment_test.go
+++ b/server/registry/names/deployment_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestDeploymentNames(t *testing.T) {
+	name := &Deployment{
+		ProjectID:    "p",
+		ApiID:        "a",
+		DeploymentID: "d",
+	}
+	err := name.Validate()
+	if err != nil {
+		t.Errorf("Validate() failed for name %s: %s", name, err)
+	}
+	if name.Project().String() != "projects/p" {
+		t.Errorf("%s Project() returned incorrect value %s", name, name.Project())
+	}
+	if name.Api().String() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Api())
+	}
+	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/deployments/d/artifacts/x" {
+		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
+	}
+	if name.Parent() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
+	}
+	if name.Normal().String() != "projects/p/locations/global/apis/a/deployments/d" {
+		t.Errorf("%s Normal() returned incorrect value %s", name, name.Normal())
+	}
+}
+
+func TestInvalidDeploymentNames(t *testing.T) {
+	names := []Deployment{
+		{
+			ProjectID:    "!!",
+			ApiID:        "a",
+			DeploymentID: "d",
+		},
+		{
+			ProjectID:    "p",
+			ApiID:        "!!",
+			DeploymentID: "d",
+		},
+		{
+			ProjectID:    "p",
+			ApiID:        "a",
+			DeploymentID: "!!",
+		},
+	}
+	for _, name := range names {
+		err := name.Validate()
+		if err == nil {
+			t.Errorf("Validate() succeeded for %s and should have failed", name)
+		}
+	}
+}

--- a/server/registry/names/deployment_test.go
+++ b/server/registry/names/deployment_test.go
@@ -37,6 +37,9 @@ func TestDeploymentNames(t *testing.T) {
 	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/deployments/d/artifacts/x" {
 		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
 	}
+	if name.Revision("123").String() != "projects/p/locations/global/apis/a/deployments/d@123" {
+		t.Errorf("%s Revision() returned incorrect value %s", name, name.Revision("123"))
+	}
 	if name.Parent() != "projects/p/locations/global/apis/a" {
 		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
 	}

--- a/server/registry/names/names_test.go
+++ b/server/registry/names/names_test.go
@@ -449,3 +449,21 @@ func TestExportableName(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidIDs(t *testing.T) {
+	ids := []string{
+		"",
+		"!!",
+		"3d46969a-d232-4fcc-88e3-0aa51c849e4b",
+		"012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+		"-invalid",
+		".invalid",
+		"invalid-",
+		"invalid.",
+	}
+	for _, id := range ids {
+		if validateID(id) == nil {
+			t.Errorf("id %q should be invalid, but validated", id)
+		}
+	}
+}

--- a/server/registry/names/names_test.go
+++ b/server/registry/names/names_test.go
@@ -56,6 +56,24 @@ func TestResourceNames(t *testing.T) {
 			},
 		},
 		{
+			name: "project with location",
+			check: func(name string) bool {
+				_, err := ParseProjectWithLocation(name)
+				return err == nil
+			},
+			pass: []string{
+				"projects/google/locations/global",
+				"projects/-/locations/global",
+			},
+			fail: []string{
+				"-",
+				"projects/google",
+				"projects/-",
+				"projects/google/locations/us-central1",
+				"projects/-/locations/us-central1",
+			},
+		},
+		{
 			name: "api collections",
 			check: func(name string) bool {
 				_, err := ParseApiCollection(name)

--- a/server/registry/names/names_test.go
+++ b/server/registry/names/names_test.go
@@ -467,3 +467,50 @@ func TestInvalidIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestParseValidNames(t *testing.T) {
+	names := []string{
+		"projects",
+		"projects/-",
+		"projects/p",
+		"projects/p/locations/global/apis",
+		"projects/p/locations/global/apis/-",
+		"projects/p/locations/global/apis/a",
+		"projects/p/locations/global/apis/a/versions",
+		"projects/p/locations/global/apis/a/versions/-",
+		"projects/p/locations/global/apis/a/versions/v",
+		"projects/p/locations/global/apis/a/versions/v/specs",
+		"projects/p/locations/global/apis/a/versions/v/specs/-",
+		"projects/p/locations/global/apis/a/versions/v/specs/s",
+		"projects/p/locations/global/apis/a/versions/v/specs/s@",
+		"projects/p/locations/global/apis/a/versions/v/specs/s@-",
+		"projects/p/locations/global/apis/a/versions/v/specs/s@123",
+		"projects/p/locations/global/apis/a/deployments",
+		"projects/p/locations/global/apis/a/deployments/-",
+		"projects/p/locations/global/apis/a/deployments/d",
+		"projects/p/locations/global/apis/a/deployments/d@",
+		"projects/p/locations/global/apis/a/deployments/d@-",
+		"projects/p/locations/global/apis/a/deployments/d@123",
+		"projects/p/locations/global/artifacts",
+		"projects/p/locations/global/artifacts/-",
+		"projects/p/locations/global/artifacts/x",
+	}
+	for _, name := range names {
+		_, err := Parse(name)
+		if err != nil {
+			t.Errorf("failed to parse name %s", name)
+		}
+	}
+}
+
+func TestParseInvalidNames(t *testing.T) {
+	names := []string{
+		"invalid",
+	}
+	for _, name := range names {
+		_, err := Parse(name)
+		if err == nil {
+			t.Errorf("incorrectly parsed invalid name %s", name)
+		}
+	}
+}

--- a/server/registry/names/project_test.go
+++ b/server/registry/names/project_test.go
@@ -27,7 +27,7 @@ func TestProjectNames(t *testing.T) {
 		t.Errorf("Validate() failed for name %s: %s", name, err)
 	}
 	if name.Api("a").String() != "projects/p/locations/global/apis/a" {
-		t.Errorf("%s Version() returned incorrect value %s", name, name.Api("a"))
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Api("a"))
 	}
 	if name.Artifact("x").String() != "projects/p/locations/global/artifacts/x" {
 		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))

--- a/server/registry/names/project_test.go
+++ b/server/registry/names/project_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestProjectNames(t *testing.T) {
+	name := &Project{
+		ProjectID: "p",
+	}
+	err := name.Validate()
+	if err != nil {
+		t.Errorf("Validate() failed for name %s: %s", name, err)
+	}
+	if name.Api("a").String() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Version() returned incorrect value %s", name, name.Api("a"))
+	}
+	if name.Artifact("x").String() != "projects/p/locations/global/artifacts/x" {
+		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
+	}
+}
+
+func TestInvalidProjectNames(t *testing.T) {
+	names := []Project{
+		{
+			ProjectID: "!!",
+		},
+	}
+	for _, name := range names {
+		err := name.Validate()
+		if err == nil {
+			t.Errorf("Validate() succeeded for %s and should have failed", name)
+		}
+	}
+}

--- a/server/registry/names/spec_revision_test.go
+++ b/server/registry/names/spec_revision_test.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestSpecRevisionNames(t *testing.T) {
+	name := &SpecRevision{
+		ProjectID:  "p",
+		ApiID:      "a",
+		VersionID:  "v",
+		SpecID:     "s",
+		RevisionID: "123",
+	}
+	if name.Project().String() != "projects/p" {
+		t.Errorf("%s Project() returned incorrect value %s", name, name.Project())
+	}
+	if name.Api().String() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Api())
+	}
+	if name.Version().String() != "projects/p/locations/global/apis/a/versions/v" {
+		t.Errorf("%s Version() returned incorrect value %s", name, name.Version())
+	}
+	if name.Spec().String() != "projects/p/locations/global/apis/a/versions/v/specs/s" {
+		t.Errorf("%s Spec() returned incorrect value %s", name, name.Spec())
+	}
+	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/versions/v/specs/s@123/artifacts/x" {
+		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
+	}
+	if name.Parent() != "projects/p/locations/global/apis/a/versions/v" {
+		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
+	}
+}

--- a/server/registry/names/spec_revision_test.go
+++ b/server/registry/names/spec_revision_test.go
@@ -45,3 +45,15 @@ func TestSpecRevisionNames(t *testing.T) {
 		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
 	}
 }
+
+func TestImpliedSpecRevisionName(t *testing.T) {
+	name := &SpecRevision{
+		ProjectID: "p",
+		ApiID:     "a",
+		VersionID: "v",
+		SpecID:    "s",
+	}
+	if name.String() != "projects/p/locations/global/apis/a/versions/v/specs/s" {
+		t.Errorf("%s has incorrect name", name)
+	}
+}

--- a/server/registry/names/spec_test.go
+++ b/server/registry/names/spec_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names
+
+import (
+	"testing"
+)
+
+func TestSpecNames(t *testing.T) {
+	name := &Spec{
+		ProjectID: "p",
+		ApiID:     "a",
+		VersionID: "v",
+		SpecID:    "s",
+	}
+	err := name.Validate()
+	if err != nil {
+		t.Errorf("Validate() failed for name %s: %s", name, err)
+	}
+	if name.Project().String() != "projects/p" {
+		t.Errorf("%s Project() returned incorrect value %s", name, name.Project())
+	}
+	if name.Api().String() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Api())
+	}
+	if name.Version().String() != "projects/p/locations/global/apis/a/versions/v" {
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Version())
+	}
+	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/versions/v/specs/s/artifacts/x" {
+		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
+	}
+	if name.Parent() != "projects/p/locations/global/apis/a/versions/v" {
+		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
+	}
+	if name.Normal().String() != "projects/p/locations/global/apis/a/versions/v/specs/s" {
+		t.Errorf("%s Normal() returned incorrect value %s", name, name.Normal())
+	}
+}
+
+func TestInvalidSpecNames(t *testing.T) {
+	names := []Spec{
+		{
+			ProjectID: "!!",
+			ApiID:     "a",
+			VersionID: "v",
+			SpecID:    "s",
+		},
+		{
+			ProjectID: "p",
+			ApiID:     "!!",
+			VersionID: "v",
+			SpecID:    "s",
+		},
+		{
+			ProjectID: "p",
+			ApiID:     "a",
+			VersionID: "!!",
+			SpecID:    "s",
+		},
+		{
+			ProjectID: "p",
+			ApiID:     "a",
+			VersionID: "v",
+			SpecID:    "!!",
+		},
+	}
+	for _, name := range names {
+		err := name.Validate()
+		if err == nil {
+			t.Errorf("Validate() succeeded for %s and should have failed", name)
+		}
+	}
+}

--- a/server/registry/names/spec_test.go
+++ b/server/registry/names/spec_test.go
@@ -36,7 +36,7 @@ func TestSpecNames(t *testing.T) {
 		t.Errorf("%s Api() returned incorrect value %s", name, name.Api())
 	}
 	if name.Version().String() != "projects/p/locations/global/apis/a/versions/v" {
-		t.Errorf("%s Api() returned incorrect value %s", name, name.Version())
+		t.Errorf("%s Version() returned incorrect value %s", name, name.Version())
 	}
 	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/versions/v/specs/s/artifacts/x" {
 		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))

--- a/server/registry/names/spec_test.go
+++ b/server/registry/names/spec_test.go
@@ -41,6 +41,9 @@ func TestSpecNames(t *testing.T) {
 	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/versions/v/specs/s/artifacts/x" {
 		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
 	}
+	if name.Revision("123").String() != "projects/p/locations/global/apis/a/versions/v/specs/s@123" {
+		t.Errorf("%s Revision() returned incorrect value %s", name, name.Revision("123"))
+	}
 	if name.Parent() != "projects/p/locations/global/apis/a/versions/v" {
 		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
 	}

--- a/server/registry/names/version_test.go
+++ b/server/registry/names/version_test.go
@@ -18,10 +18,11 @@ import (
 	"testing"
 )
 
-func TestApiNames(t *testing.T) {
-	name := &Api{
+func TestVersionNames(t *testing.T) {
+	name := &Version{
 		ProjectID: "p",
 		ApiID:     "a",
+		VersionID: "v",
 	}
 	err := name.Validate()
 	if err != nil {
@@ -30,29 +31,36 @@ func TestApiNames(t *testing.T) {
 	if name.Project().String() != "projects/p" {
 		t.Errorf("%s Project() returned incorrect value %s", name, name.Project())
 	}
-	if name.Version("v").String() != "projects/p/locations/global/apis/a/versions/v" {
-		t.Errorf("%s Version() returned incorrect value %s", name, name.Version("v"))
+	if name.Api().String() != "projects/p/locations/global/apis/a" {
+		t.Errorf("%s Api() returned incorrect value %s", name, name.Api())
 	}
-	if name.Deployment("d").String() != "projects/p/locations/global/apis/a/deployments/d" {
-		t.Errorf("%s Deployment() returned incorrect value %s", name, name.Deployment("d"))
+	if name.Spec("s").String() != "projects/p/locations/global/apis/a/versions/v/specs/s" {
+		t.Errorf("%s Spec() returned incorrect value %s", name, name.Spec("v"))
 	}
-	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/artifacts/x" {
+	if name.Artifact("x").String() != "projects/p/locations/global/apis/a/versions/v/artifacts/x" {
 		t.Errorf("%s Artifact() returned incorrect value %s", name, name.Artifact("x"))
 	}
-	if name.Parent() != "projects/p/locations/global" {
+	if name.Parent() != "projects/p/locations/global/apis/a" {
 		t.Errorf("%s Parent() returned incorrect value %s", name, name.Parent())
 	}
 }
 
-func TestInvalidApiNames(t *testing.T) {
-	names := []Api{
+func TestInvalidVersionNames(t *testing.T) {
+	names := []Version{
 		{
 			ProjectID: "!!",
 			ApiID:     "a",
+			VersionID: "v",
 		},
 		{
 			ProjectID: "p",
 			ApiID:     "!!",
+			VersionID: "v",
+		},
+		{
+			ProjectID: "p",
+			ApiID:     "a",
+			VersionID: "!!",
 		},
 	}
 	for _, name := range names {


### PR DESCRIPTION
I think this gets close enough to close #911.

Uncovered code appears to be unreachable.

Tests could be better (not all failures are clearly explained), but since the `names` package is so simple, I think it's better to not overinvest in this and leave further test improvement for when/if it's needed.