### PR TITLE
Add support for exporting, getting, and applying receipts in YAML.

### DIFF
--- a/cmd/registry/patch/patch_test.go
+++ b/cmd/registry/patch/patch_test.go
@@ -719,6 +719,19 @@ func TestMessageArtifactPatches(t *testing.T) {
 			},
 		},
 		{
+			artifactID: "receipt",
+			parent:     "apis/a/versions/v/specs/s",
+			yamlFile:   "testdata/artifacts/receipt.yaml",
+			message: &rpc.Receipt{
+				Id:          "receipt", // deprecated field
+				Kind:        "Receipt", // deprecated field
+				DisplayName: "Sample Receipt",
+				Action:      "registry compute scorecard RESOURCE",
+				Description: "Description",
+				ResultUri:   "https://example.com",
+			},
+		},
+		{
 			artifactID: "references",
 			parent:     "apis/a",
 			yamlFile:   "testdata/artifacts/references.yaml",

--- a/cmd/registry/patch/testdata/artifacts/receipt.yaml
+++ b/cmd/registry/patch/testdata/artifacts/receipt.yaml
@@ -1,0 +1,10 @@
+apiVersion: apigeeregistry/v1
+kind: Receipt
+metadata:
+  name: receipt
+  parent: apis/a/versions/v/specs/s
+data:
+  displayName: Sample Receipt
+  description: Description
+  action: registry compute scorecard RESOURCE
+  resultUri: https://example.com

--- a/cmd/registry/types/types.go
+++ b/cmd/registry/types/types.go
@@ -153,6 +153,7 @@ var artifactMessageTypes map[string]messageFactory = map[string]messageFactory{
 	"google.cloud.apigeeregistry.v1.apihub.ReferenceList":        func() proto.Message { return new(rpc.ReferenceList) },
 	"google.cloud.apigeeregistry.v1.apihub.TaxonomyList":         func() proto.Message { return new(rpc.TaxonomyList) },
 	"google.cloud.apigeeregistry.v1.controller.Manifest":         func() proto.Message { return new(rpc.Manifest) },
+	"google.cloud.apigeeregistry.v1.controller.Receipt":          func() proto.Message { return new(rpc.Receipt) },
 	"google.cloud.apigeeregistry.v1.scoring.Score":               func() proto.Message { return new(rpc.Score) },
 	"google.cloud.apigeeregistry.v1.scoring.ScoreDefinition":     func() proto.Message { return new(rpc.ScoreDefinition) },
 	"google.cloud.apigeeregistry.v1.scoring.ScoreCard":           func() proto.Message { return new(rpc.ScoreCard) },

--- a/cmd/registry/types/types_test.go
+++ b/cmd/registry/types/types_test.go
@@ -199,6 +199,11 @@ func TestProtobufMessageTypes(t *testing.T) {
 			mimeType:    "application/octet-stream;type=google.cloud.apigeeregistry.v1.controller.Manifest",
 		},
 		{
+			kind:        "Receipt",
+			messageType: "google.cloud.apigeeregistry.v1.controller.Receipt",
+			mimeType:    "application/octet-stream;type=google.cloud.apigeeregistry.v1.controller.Receipt",
+		},
+		{
 			kind:        "Score",
 			messageType: "google.cloud.apigeeregistry.v1.scoring.Score",
 			mimeType:    "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.Score",


### PR DESCRIPTION
While running `registry export` on a project with a manifest, I noticed that we were logging warnings because receipts couldn't be exported. This registers the receipt type with the `registry` tool to allow it to be handled like other artifacts.