### PR TITLE
refactor test setup and seeding to be reusable

### DIFF
--- a/cmd/registry/cmd/check/lint/checker.go
+++ b/cmd/registry/cmd/check/lint/checker.go
@@ -34,6 +34,13 @@ const (
 	ContextKeyRegistryClient contextKey = iota
 )
 
+func RegistryClient(ctx context.Context) connection.RegistryClient {
+	if c := ctx.Value(ContextKeyRegistryClient); c != nil {
+		return c.(connection.RegistryClient)
+	}
+	return nil
+}
+
 type Resource interface {
 	GetName() string
 }

--- a/cmd/registry/cmd/check/lint/checker_test.go
+++ b/cmd/registry/cmd/check/lint/checker_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry"
@@ -91,9 +90,8 @@ func TestChecker_run(t *testing.T) {
 			err := rules.Register(111, &ProjectRule{
 				Name: NewRuleName(111, "test-rule"),
 				ApplyToProject: func(ctx context.Context, p *rpc.Project) []Problem {
-					client := ctx.Value(ContextKeyRegistryClient)
-					if _, ok := client.(*gapic.RegistryClient); !ok {
-						t.Errorf("context does not include client: %v", ctx)
+					if c := RegistryClient(ctx); c == nil {
+						t.Errorf("RegistryClient missing in context: %v", ctx)
 					}
 					return test.problems
 				},

--- a/cmd/registry/cmd/check/lint/checker_test.go
+++ b/cmd/registry/cmd/check/lint/checker_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
 	"github.com/apigee/registry/server/registry"

--- a/cmd/registry/cmd/check/lint/checker_test.go
+++ b/cmd/registry/cmd/check/lint/checker_test.go
@@ -101,7 +101,7 @@ func TestChecker_run(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			registryClient, adminClient := grpctest.PrepRegistry(ctx, t, "checker-test", []seeder.RegistryResource{
+			registryClient, adminClient := grpctest.SetupRegistry(ctx, t, "checker-test", []seeder.RegistryResource{
 				&rpc.Project{
 					Name: "projects/checker-test",
 				},
@@ -159,7 +159,7 @@ func TestChecker_panic(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			registryClient, adminClient := grpctest.PrepRegistry(ctx, t, "checker-test", []seeder.RegistryResource{
+			registryClient, adminClient := grpctest.SetupRegistry(ctx, t, "checker-test", []seeder.RegistryResource{
 				&rpc.Project{
 					Name: "projects/checker-test",
 				},

--- a/pkg/connection/grpctest/server.go
+++ b/pkg/connection/grpctest/server.go
@@ -87,11 +87,11 @@ func TestMain(m *testing.M, rc registry.Config) {
 	os.Exit(m.Run())
 }
 
-// PrepRegistry connects to a registry instance using the default config,
+// SetupRegistry connects to a registry instance using the default config,
 // deletes the project if it exists, seeds the registry for testing, and
 // returns the connections used. It also registers cleanup handlers on the
 // test to close the connections and delete the project.
-func PrepRegistry(ctx context.Context, t *testing.T, projectID string, seeds []seeder.RegistryResource) (*gapic.RegistryClient, *gapic.AdminClient) {
+func SetupRegistry(ctx context.Context, t *testing.T, projectID string, seeds []seeder.RegistryResource) (*gapic.RegistryClient, *gapic.AdminClient) {
 	t.Helper()
 	registryClient, err := connection.NewRegistryClient(ctx)
 	if err != nil {


### PR DESCRIPTION
refactor test setup and seeding to be reusable
add accessor for registryClient
fix ioutil deprecation warning

I broke this refactor out to be more easily reviewed, I use it in my testing PR that will come next.