### PR TITLE
emit wiki link when user gets an error in the CLI

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -33,6 +33,9 @@ func main() {
 
 	cmd := cmd.Command()
 	if err := cmd.ExecuteContext(ctx); err != nil {
+		fmt.Println("----")
+		fmt.Println("Need more help?")
+		fmt.Println("https://github.com/apigee/registry/wiki")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Example:

```
➜  registry git:(main) ✗ registry get apis -x
Error: unknown shorthand flag: 'x' in -x
Usage:
  registry get PATTERN [flags]

Flags:
      --filter string   filter selected resources
  -h, --help            help for get
  -o, --output string   output type (name|yaml|contents) (default "name")

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry

----
Need more help?
https://github.com/apigee/registry/wiki
```

Fixes #964