### PR TITLE
Bugfix for getting current user email

### DIFF
--- a/auth/HOSTED.sh
+++ b/auth/HOSTED.sh
@@ -36,7 +36,7 @@ APG_REGISTRY_INSECURE="false"
 
 APG_REGISTRY_PROJECT="$(gcloud config get project)"
 APG_REGISTRY_LOCATION="global"
-APG_REGISTRY_CLIENT_EMAIL="$(gcloud config list account --format "value(core.account)")"
+APG_REGISTRY_CLIENT_EMAIL="$(gcloud auth list --filter=status:ACTIVE --format="value(account)")"
 APG_REGISTRY_TOKEN_SOURCE="gcloud auth print-access-token ${APG_REGISTRY_CLIENT_EMAIL}"
 
 registry config configurations create hosted \

--- a/auth/HOSTED.sh
+++ b/auth/HOSTED.sh
@@ -36,7 +36,7 @@ APG_REGISTRY_INSECURE="false"
 
 APG_REGISTRY_PROJECT="$(gcloud config get project)"
 APG_REGISTRY_LOCATION="global"
-CLIENT_EMAIL="$(gcloud config get account)"
+APG_REGISTRY_CLIENT_EMAIL="$(gcloud config list account --format "value(core.account)")"
 APG_REGISTRY_TOKEN_SOURCE="gcloud auth print-access-token ${APG_REGISTRY_CLIENT_EMAIL}"
 
 registry config configurations create hosted \


### PR DESCRIPTION
Closed original #967  due to not having signed the CLA.

The existing way had two different env variables and `gcloud config get account` doesn't just print the email it also includes the project:

```
$ gcloud config get account                                                                                                                                                           ─╯
$ Your active configuration is: [api-registry]
$ john@smith.com
```

```
$ gcloud config list account --format "value(core.account)"
$ john@smith.com
```

I believe you want the latter?!