### PR TITLE
Allow hosted projects to be exported with `registry export`

### DIFF
--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -148,7 +148,7 @@ func (h *deleteHandler) traverse() error {
 	}
 
 	if project, err := names.ParseProject(name); err == nil {
-		return core.GetProject(ctx, adminClient, project, h.projectHandler())
+		return core.GetProject(ctx, adminClient, project, false, h.projectHandler())
 	} else if api, err := names.ParseApi(name); err == nil {
 		return core.GetAPI(ctx, client, api, h.apiHandler())
 	} else if deployment, err := names.ParseDeployment(name); err == nil {

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -149,7 +149,7 @@ func (h *exportHandler) traverse() error {
 	}
 
 	if project, err := names.ParseProject(pattern); err == nil {
-		return core.GetProject(ctx, adminClient, project, h.projectHandler())
+		return core.GetProject(ctx, adminClient, project, true, h.projectHandler())
 	} else if api, err := names.ParseApi(pattern); err == nil {
 		return core.GetAPI(ctx, client, api, h.apiHandler())
 	} else if deployment, err := names.ParseDeployment(pattern); err == nil {

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -143,7 +143,7 @@ func (h *getHandler) traverse() error {
 	}
 
 	if project, err := names.ParseProject(name); err == nil {
-		return core.GetProject(ctx, adminClient, project, h.projectHandler())
+		return core.GetProject(ctx, adminClient, project, false, h.projectHandler())
 	} else if api, err := names.ParseApi(name); err == nil {
 		return core.GetAPI(ctx, client, api, h.apiHandler())
 	} else if deployment, err := names.ParseDeployment(name); err == nil {

--- a/cmd/registry/patch/patch_test.go
+++ b/cmd/registry/patch/patch_test.go
@@ -89,7 +89,7 @@ func TestProjectPatches(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(new(rpc.Project), "create_time", "update_time"),
 			}
-			err = core.GetProject(ctx, adminClient, projectName,
+			err = core.GetProject(ctx, adminClient, projectName, false,
 				func(project *rpc.Project) error {
 					if !cmp.Equal(test.message, project, opts) {
 						t.Errorf("GetDiff returned unexpected diff (-want +got):\n%s", cmp.Diff(test.message, project, opts))


### PR DESCRIPTION
We've observed that `registry export projects/PROJECT` fails to export hosted PROJECT instances, because these lack the Admin service. This modifies the `core.GetProject()` helper to optionally provide dummy projects when the Admin service is unavailable. This is limited to `registry export`, which will fail subsequently if a nonexistent project is provided. `registry get` and `registry delete` will continue to fail for hosted project because these operations don't make sense for hosted projects (deleting an entire project is conceivable but is not something that we should support in this way).

Exporting an existing project now just works:
```
$ registry export projects/timburks-test
  INFO[0001] Exported projects/timburks-test/locations/global/apis/apigeeregistry uid=916c601f
  INFO[0001] Exported projects/timburks-test/locations/global/apis/artifactregistry uid=916c601f
  INFO[0001] Exported projects/timburks-test/locations/global/apis/helloworld uid=916c601f
```

Exporting a non-existent project fails soon enough, I think:
```
timburks@penguin:~/Desktop/exports$ registry export projects/timburks-nonexistent
Error: rpc error: code = PermissionDenied desc = Permission denied on resource project timburks-nonexistent.
error details: name = ErrorInfo reason = CONSUMER_INVALID domain = googleapis.com metadata = map[consumer:projects/timburks-nonexistent service:apigeeregistry.googleapis.com]
error details: name = DebugInfo detail = Project 'project:timburks-nonexistent' not found or deleted. stack = 
error details: name = Help desc = Google developer console API key url = https://console.developers.google.com/project/timburks-nonexistent/apiui/credential
Usage:
  registry export PATTERN [flags]

Flags:
      --filter string   filter selected resources
  -h, --help            help for export
  -j, --jobs int        number of actions to perform concurrently (default 10)
  -r, --recursive       include child resources in export
      --root string     root directory for export

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry

----
Need more help?
https://github.com/apigee/registry/wiki
```

Getting and deleting hosted projects continues to fail:
```
$ registry get projects/timburks-nonexistent
Error: rpc error: code = Unimplemented desc = The GRPC target is not implemented on the server, host: apigeeregistry.googleapis.com, method: /google.cloud.apigeeregistry.v1.Admin/GetProject.
Usage:
  registry get PATTERN [flags]

Flags:
      --filter string   filter selected resources
  -h, --help            help for get
  -o, --output string   output type (name|yaml|contents) (default "name")

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry

----
Need more help?
https://github.com/apigee/registry/wiki
$ registry delete projects/timburks-nonexistent
Error: rpc error: code = Unimplemented desc = The GRPC target is not implemented on the server, host: apigeeregistry.googleapis.com, method: /google.cloud.apigeeregistry.v1.Admin/GetProject.
Usage:
  registry delete PATTERN [flags]

Flags:
      --filter string   filter selected resources
  -f, --force           force deletion of child resources
  -h, --help            help for delete
  -j, --jobs int        number of actions to perform concurrently (default 10)

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry

----
Need more help?
https://github.com/apigee/registry/wiki
```