### PR TITLE
Allow uploads of CSV to hosted registries.

### DIFF
--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -35,7 +35,6 @@ import (
 
 func csvCommand() *cobra.Command {
 	var (
-		projectID string
 		delimiter string
 		jobs      int
 	)
@@ -44,29 +43,25 @@ func csvCommand() *cobra.Command {
 		Use:   "csv file --project-id=value [--delimiter=value]",
 		Short: "Upload API descriptions from a CSV file",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ctx := cmd.Context()
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(delimiter) != 1 {
-				log.Fatalf(ctx, "Invalid delimiter %q: must be exactly one character", delimiter)
+				return fmt.Errorf("invalid delimiter %q: must be exactly one character", delimiter)
 			}
-
+			ctx := cmd.Context()
+			parent, err := getParent(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to identify parent project (%s)", err)
+			}
+			parentName, err := names.ParseProjectWithLocation(parent)
+			if err != nil {
+				return fmt.Errorf("error parsing project name (%s)", err)
+			}
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
+				return fmt.Errorf("error getting client (%s)", err)
 			}
-
-			adminClient, err := connection.NewAdminClient(ctx)
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
-			}
-
-			if _, err := adminClient.UpdateProject(ctx, &rpc.UpdateProjectRequest{
-				Project: &rpc.Project{
-					Name: names.Project{ProjectID: projectID}.String(),
-				},
-				AllowMissing: true,
-			}); err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to ensure project exists")
+			if err := core.VerifyLocation(ctx, client, parent); err != nil {
+				return fmt.Errorf("parent does not exist (%s)", err)
 			}
 
 			taskQueue, wait := core.WorkerPool(ctx, jobs)
@@ -74,7 +69,7 @@ func csvCommand() *cobra.Command {
 
 			file, err := os.Open(args[0])
 			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to open file")
+				return fmt.Errorf("failed to open file (%s)", err)
 			}
 			defer file.Close()
 
@@ -85,23 +80,22 @@ func csvCommand() *cobra.Command {
 
 			for row, err := r.Read(); err != io.EOF; row, err = r.Read() {
 				if err != nil {
-					log.FromContext(ctx).WithError(err).Fatal("Failed to read row from file")
+					return fmt.Errorf("failed to read row from file (%s)", err)
 				}
 
 				taskQueue <- &uploadSpecTask{
-					client:    client,
-					projectID: projectID,
-					apiID:     row.ApiID,
-					versionID: row.VersionID,
-					specID:    row.SpecID,
-					filepath:  row.Filepath,
+					client:     client,
+					parentName: parentName,
+					apiID:      row.ApiID,
+					versionID:  row.VersionID,
+					specID:     row.SpecID,
+					filepath:   row.Filepath,
 				}
 			}
+			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&projectID, "project-id", "", "project ID to use for each upload")
-	_ = cmd.MarkFlagRequired("project-id")
 	cmd.Flags().StringVar(&delimiter, "delimiter", ",", "field delimiter for the CSV file")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
@@ -180,18 +174,19 @@ func (r *uploadCSVReader) buildColumnIndex(header []string) error {
 }
 
 type uploadSpecTask struct {
-	client    connection.RegistryClient
-	projectID string
-	apiID     string
-	versionID string
-	specID    string
-	filepath  string
+	client     connection.RegistryClient
+	parentName names.Project
+	apiID      string
+	versionID  string
+	specID     string
+	filepath   string
 }
 
 func (t uploadSpecTask) Run(ctx context.Context) error {
+	apiName := t.parentName.Api(t.apiID)
 	api, err := t.client.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/global", t.projectID),
-		ApiId:  t.apiID,
+		Parent: apiName.Parent(),
+		ApiId:  apiName.ApiID,
 		Api:    &rpc.Api{},
 	})
 
@@ -200,15 +195,16 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		log.Debugf(ctx, "Created API: %s", api.GetName())
 	case codes.AlreadyExists:
 		api = &rpc.Api{
-			Name: fmt.Sprintf("projects/%s/locations/global/apis/%s", t.projectID, t.apiID),
+			Name: apiName.String(),
 		}
 	default:
 		return fmt.Errorf("failed to ensure API exists: %s", err)
 	}
 
+	versionName := apiName.Version(t.versionID)
 	version, err := t.client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
-		Parent:       api.GetName(),
-		ApiVersionId: t.versionID,
+		Parent:       versionName.Parent(),
+		ApiVersionId: versionName.VersionID,
 		ApiVersion:   &rpc.ApiVersion{},
 	})
 
@@ -217,7 +213,7 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		log.Debugf(ctx, "Created API version: %s", version.GetName())
 	case codes.AlreadyExists:
 		version = &rpc.ApiVersion{
-			Name: fmt.Sprintf("projects/%s/locations/global/apis/%s/versions/%s", t.projectID, t.apiID, t.versionID),
+			Name: versionName.String(),
 		}
 	default:
 		return fmt.Errorf("failed to ensure API version exists: %s", err)
@@ -233,9 +229,10 @@ func (t uploadSpecTask) Run(ctx context.Context) error {
 		return err
 	}
 
+	specName := versionName.Spec(t.specID)
 	spec, err := t.client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
-		Parent:    version.GetName(),
-		ApiSpecId: t.specID,
+		Parent:    specName.Parent(),
+		ApiSpecId: specName.SpecID,
 		ApiSpec: &rpc.ApiSpec{
 			// TODO: How do we choose a mime type?
 			MimeType: types.OpenAPIMimeType("+gzip", "3.0.0"),

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -40,7 +40,7 @@ func csvCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "csv file --project-id=value [--delimiter=value]",
+		Use:   "csv FILE",
 		Short: "Upload API descriptions from a CSV file",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/registry/cmd/upload/csv_test.go
+++ b/cmd/registry/cmd/upload/csv_test.go
@@ -57,6 +57,7 @@ func TestUploadCSV(t *testing.T) {
 	}
 
 	const testProject = "csv-demo"
+	const testParent = "projects/" + testProject + "/locations/global"
 	tests := []struct {
 		desc string
 		args []string
@@ -66,7 +67,7 @@ func TestUploadCSV(t *testing.T) {
 			desc: "multiple spec upload",
 			args: []string{
 				filepath.Join("testdata", "csv", "multiple-specs.csv"),
-				"--project-id", testProject,
+				"--parent", testParent,
 			},
 			want: []*rpc.ApiSpec{
 				{
@@ -95,7 +96,7 @@ func TestUploadCSV(t *testing.T) {
 			desc: "out of order columns",
 			args: []string{
 				filepath.Join("testdata", "csv", "out-of-order-columns.csv"),
-				"--project-id", testProject,
+				"--parent", testParent,
 			},
 			want: []*rpc.ApiSpec{
 				{
@@ -109,7 +110,7 @@ func TestUploadCSV(t *testing.T) {
 			desc: "empty sheet",
 			args: []string{
 				filepath.Join("testdata", "csv", "empty-sheet.csv"),
-				"--project-id", testProject,
+				"--parent", testParent,
 			},
 			want: []*rpc.ApiSpec{},
 		},
@@ -133,6 +134,17 @@ func TestUploadCSV(t *testing.T) {
 			})
 			if err != nil && status.Code(err) != codes.NotFound {
 				t.Fatalf("Setup: Failed to delete test project: %s", err)
+			}
+
+			_, err = adminClient.CreateProject(ctx, &rpc.CreateProjectRequest{
+				ProjectId: testProject,
+				Project: &rpc.Project{
+					DisplayName: "Test",
+					Description: "A test catalog",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Error creating project %s", err)
 			}
 
 			args := append([]string{"csv"}, test.args...)


### PR DESCRIPTION
This addresses #971 by using [core.VerifyLocation()](https://github.com/apigee/registry/blob/989942a561d89fd1f51ec1bdca34b496899be252/cmd/registry/core/verify.go#L10) instead of the Admin service to verify that a parent project exists.

Other incidental changes:
- `upload csv` no longer creates projects on demand, as with other uploaders, destination projects must be preexisting.
- this addresses #827 by converting the `upload csv` command to use `RunE` and return errors instead of logging fatal errors.
- the `--parent` flag is used instead of `--project_id` and is processed by a common function used by other `upload` commands.
- Names are used instead of strings in the command implementation.

(new tests for error cases are coming to this PR)