### PR TITLE
Push subcommands of `registry compute` into separate directories.

### DIFF
--- a/cmd/registry/cmd/compute/complexity/complexity-discovery.go
+++ b/cmd/registry/cmd/compute/complexity/complexity-discovery.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package complexity
 
 import (
 	discovery "github.com/google/gnostic/discovery"

--- a/cmd/registry/cmd/compute/complexity/complexity-openapi.go
+++ b/cmd/registry/cmd/compute/complexity/complexity-openapi.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package complexity
 
 import (
 	metrics "github.com/google/gnostic/metrics"

--- a/cmd/registry/cmd/compute/complexity/complexity-proto.go
+++ b/cmd/registry/cmd/compute/complexity/complexity-proto.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package complexity
 
 import (
 	"archive/zip"

--- a/cmd/registry/cmd/compute/complexity/complexity.go
+++ b/cmd/registry/cmd/compute/complexity/complexity.go
@@ -98,9 +98,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().String("filter", "", "Filter selected resources")
+	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/complexity/complexity.go
+++ b/cmd/registry/cmd/compute/complexity/complexity.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package complexity
 
 import (
 	"context"
@@ -34,8 +34,8 @@ import (
 	oas3 "github.com/google/gnostic/openapiv3"
 )
 
-func complexityCommand() *cobra.Command {
-	return &cobra.Command{
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "complexity",
 		Short: "Compute complexity metrics of API specs",
 		Args:  cobra.ExactArgs(1),
@@ -98,6 +98,10 @@ func complexityCommand() *cobra.Command {
 			}
 		},
 	}
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	return cmd
 }
 
 type computeComplexityTask struct {

--- a/cmd/registry/cmd/compute/complexity/complexity_test.go
+++ b/cmd/registry/cmd/compute/complexity/complexity_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package complexity
 
 import (
 	"bytes"
@@ -23,7 +23,9 @@ import (
 	"testing"
 
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
 	"github.com/apigee/registry/server/registry/names"
 	metrics "github.com/google/gnostic/metrics"
 	"github.com/google/go-cmp/cmp"
@@ -32,6 +34,13 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
 
 func readAndGZipFile(t *testing.T, filename string) (*bytes.Buffer, error) {
 	t.Helper()
@@ -124,7 +133,7 @@ func TestComplexity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create version %s: %s", test.versionId, err.Error())
 			}
-			buf, err := readAndGZipFile(t, filepath.Join("testdata", test.specFile))
+			buf, err := readAndGZipFile(t, filepath.Join("..", "testdata", test.specFile))
 			if err != nil {
 				t.Fatalf("Failed reading spec contents: %s", err.Error())
 			}
@@ -141,7 +150,7 @@ func TestComplexity(t *testing.T) {
 				t.Fatalf("Failed CreateApiSpec(%v): %s", req, err.Error())
 			}
 			complexityCommand := Command()
-			args := []string{"complexity", spec.Name}
+			args := []string{spec.Name}
 			complexityCommand.SetArgs(args)
 			if err = complexityCommand.Execute(); err != nil {
 				t.Fatalf("Execute() with args %v returned error: %s", args, err)

--- a/cmd/registry/cmd/compute/complexity_test.go
+++ b/cmd/registry/cmd/compute/complexity_test.go
@@ -15,7 +15,10 @@
 package compute
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +33,20 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
+func readAndGZipFile(t *testing.T, filename string) (*bytes.Buffer, error) {
+	t.Helper()
+	fileBytes, _ := os.ReadFile(filename)
+	var buf bytes.Buffer
+	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	_, err := zw.Write(fileBytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return &buf, nil
+}
 func TestComplexity(t *testing.T) {
 	tests := []struct {
 		desc       string

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apigee/registry/cmd/registry/cmd/compute/lintstats"
 	"github.com/apigee/registry/cmd/registry/cmd/compute/score"
 	"github.com/apigee/registry/cmd/registry/cmd/compute/scorecard"
+	"github.com/apigee/registry/cmd/registry/cmd/vocabulary"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +37,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(lintstats.Command())
 	cmd.AddCommand(score.Command())
 	cmd.AddCommand(scorecard.Command())
-	cmd.AddCommand(vocabularyCommand())
+	cmd.AddCommand(vocabulary.Command())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
 	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -17,6 +17,8 @@ package compute
 import (
 	"github.com/apigee/registry/cmd/registry/cmd/compute/complexity"
 	"github.com/apigee/registry/cmd/registry/cmd/compute/conformance"
+	"github.com/apigee/registry/cmd/registry/cmd/compute/lint"
+	"github.com/apigee/registry/cmd/registry/cmd/compute/lintstats"
 	"github.com/spf13/cobra"
 )
 
@@ -28,8 +30,8 @@ func Command() *cobra.Command {
 
 	cmd.AddCommand(conformance.Command())
 	cmd.AddCommand(complexity.Command())
-	cmd.AddCommand(lintCommand())
-	cmd.AddCommand(lintStatsCommand())
+	cmd.AddCommand(lint.Command())
+	cmd.AddCommand(lintstats.Command())
 	cmd.AddCommand(scoreCommand())
 	cmd.AddCommand(scoreCardCommand())
 	cmd.AddCommand(vocabularyCommand())

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -19,6 +19,8 @@ import (
 	"github.com/apigee/registry/cmd/registry/cmd/compute/conformance"
 	"github.com/apigee/registry/cmd/registry/cmd/compute/lint"
 	"github.com/apigee/registry/cmd/registry/cmd/compute/lintstats"
+	"github.com/apigee/registry/cmd/registry/cmd/compute/score"
+	"github.com/apigee/registry/cmd/registry/cmd/compute/scorecard"
 	"github.com/spf13/cobra"
 )
 
@@ -32,8 +34,8 @@ func Command() *cobra.Command {
 	cmd.AddCommand(complexity.Command())
 	cmd.AddCommand(lint.Command())
 	cmd.AddCommand(lintstats.Command())
-	cmd.AddCommand(scoreCommand())
-	cmd.AddCommand(scoreCardCommand())
+	cmd.AddCommand(score.Command())
+	cmd.AddCommand(scorecard.Command())
 	cmd.AddCommand(vocabularyCommand())
 
 	cmd.PersistentFlags().String("filter", "", "Filter selected resources")

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -15,6 +15,7 @@
 package compute
 
 import (
+	"github.com/apigee/registry/cmd/registry/cmd/compute/complexity"
 	"github.com/apigee/registry/cmd/registry/cmd/compute/conformance"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +27,7 @@ func Command() *cobra.Command {
 	}
 
 	cmd.AddCommand(conformance.Command())
-	cmd.AddCommand(complexityCommand())
+	cmd.AddCommand(complexity.Command())
 	cmd.AddCommand(lintCommand())
 	cmd.AddCommand(lintStatsCommand())
 	cmd.AddCommand(scoreCommand())

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -15,6 +15,7 @@
 package compute
 
 import (
+	"github.com/apigee/registry/cmd/registry/cmd/compute/conformance"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +25,7 @@ func Command() *cobra.Command {
 		Short: "Compute properties of resources in the API Registry",
 	}
 
-	cmd.AddCommand(conformanceCommand())
+	cmd.AddCommand(conformance.Command())
 	cmd.AddCommand(complexityCommand())
 	cmd.AddCommand(lintCommand())
 	cmd.AddCommand(lintStatsCommand())

--- a/cmd/registry/cmd/compute/compute_test.go
+++ b/cmd/registry/cmd/compute/compute_test.go
@@ -16,14 +16,10 @@ package compute
 
 import (
 	"testing"
-
-	"github.com/apigee/registry/pkg/connection/grpctest"
-	"github.com/apigee/registry/server/registry"
 )
 
-// TestMain will set up a local RegistryServer and grpc.Server for all
-// tests in this package if APG_REGISTRY_ADDRESS env var is not set
-// for the client.
-func TestMain(m *testing.M) {
-	grpctest.TestMain(m, registry.Config{})
+func TestCommand(t *testing.T) {
+	if Command() == nil {
+		t.Fatalf("Command() failed to return a value")
+	}
 }

--- a/cmd/registry/cmd/compute/conformance/conformance.go
+++ b/cmd/registry/cmd/compute/conformance/conformance.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package conformance
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 
 var styleguideFilter = fmt.Sprintf("mime_type.contains('%s')", types.MimeTypeForKind("StyleGuide"))
 
-func conformanceCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conformance",
 		Short: "Compute lint results for API specs",
@@ -102,6 +102,9 @@ func conformanceCommand() *cobra.Command {
 			}
 		},
 	}
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
 
 	return cmd
 }

--- a/cmd/registry/cmd/compute/conformance/conformance.go
+++ b/cmd/registry/cmd/compute/conformance/conformance.go
@@ -102,10 +102,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
-
+	cmd.Flags().String("filter", "", "Filter selected resources")
+	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/conformance/conformance_test.go
+++ b/cmd/registry/cmd/compute/conformance/conformance_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package conformance
 
 import (
 	"bytes"
@@ -25,7 +25,9 @@ import (
 
 	"github.com/apigee/registry/cmd/registry/cmd/apply"
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/codes"
@@ -33,6 +35,13 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
 
 func readAndGZipFile(t *testing.T, filename string) (*bytes.Buffer, error) {
 	t.Helper()
@@ -59,7 +68,7 @@ func TestConformance(t *testing.T) {
 		//Tests the normal use case with one guideline defined with state: ACTIVE and one Rule defined with severity:ERROR
 		{
 			desc:            "normal case",
-			conformancePath: filepath.Join("testdata", "styleguide.yaml"),
+			conformancePath: filepath.Join("..", "testdata", "styleguide.yaml"),
 			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest",
@@ -102,7 +111,7 @@ func TestConformance(t *testing.T) {
 		//Tests if default state and severity values are assigned properly in the absence of defined values
 		{
 			desc:            "default case",
-			conformancePath: filepath.Join("testdata", "styleguide-default.yaml"),
+			conformancePath: filepath.Join("..", "testdata", "styleguide-default.yaml"),
 			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-default",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-default",
@@ -144,7 +153,7 @@ func TestConformance(t *testing.T) {
 		//Tests if multiple severity levels are populated correctly in severity report
 		{
 			desc:            "multiple severity",
-			conformancePath: filepath.Join("testdata", "styleguide-multiple-severity.yaml"),
+			conformancePath: filepath.Join("..", "testdata", "styleguide-multiple-severity.yaml"),
 			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-multiple-severity",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-multiple-severity",
@@ -208,7 +217,7 @@ func TestConformance(t *testing.T) {
 		//Tests if multiple state entries are populated correctly in severity report
 		{
 			desc:            "multiple state",
-			conformancePath: filepath.Join("testdata", "styleguide-multiple-state.yaml"),
+			conformancePath: filepath.Join("..", "testdata", "styleguide-multiple-state.yaml"),
 			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-multiple-state",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-multiple-state",
@@ -284,7 +293,7 @@ func TestConformance(t *testing.T) {
 		//Tests a guideline which defines rules from multiple linters
 		{
 			desc:            "multiple linter",
-			conformancePath: filepath.Join("testdata", "styleguide-multiple-linter.yaml"),
+			conformancePath: filepath.Join("..", "testdata", "styleguide-multiple-linter.yaml"),
 			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-multiple-linter",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-multiple-linter",
@@ -435,7 +444,7 @@ func TestConformance(t *testing.T) {
 			}
 
 			// Create Spec in each of the versions
-			buf, err := readAndGZipFile(t, filepath.Join("testdata", "openapi.yaml"))
+			buf, err := readAndGZipFile(t, filepath.Join("..", "testdata", "openapi.yaml"))
 			if err != nil {
 				t.Fatalf("Failed reading API contents: %s", err.Error())
 			}
@@ -464,7 +473,7 @@ func TestConformance(t *testing.T) {
 
 			// setup the command
 			conformanceCmd := Command()
-			args = []string{"conformance", spec.Name}
+			args = []string{spec.Name}
 			conformanceCmd.SetArgs(args)
 
 			if err = conformanceCmd.Execute(); err != nil {

--- a/cmd/registry/cmd/compute/lint/lint-openapi-gnostic.go
+++ b/cmd/registry/cmd/compute/lint/lint-openapi-gnostic.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package lint
 
 import (
 	"os"

--- a/cmd/registry/cmd/compute/lint/lint-openapi-spectral.go
+++ b/cmd/registry/cmd/compute/lint/lint-openapi-spectral.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package lint
 
 import (
 	"encoding/json"

--- a/cmd/registry/cmd/compute/lint/lint-openapi.go
+++ b/cmd/registry/cmd/compute/lint/lint-openapi.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package lint
 
 import (
 	"errors"

--- a/cmd/registry/cmd/compute/lint/lint-proto.go
+++ b/cmd/registry/cmd/compute/lint/lint-proto.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package lint
 
 import (
 	"os"

--- a/cmd/registry/cmd/compute/lint/lint.go
+++ b/cmd/registry/cmd/compute/lint/lint.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package lint
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func lintCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var linter string
 	cmd := &cobra.Command{
 		Use:   "lint",

--- a/cmd/registry/cmd/compute/lint/lint_test.go
+++ b/cmd/registry/cmd/compute/lint/lint_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lint
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection/grpctest"
+	"github.com/apigee/registry/server/registry"
+)
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
+
+func TestLint(t *testing.T) {
+	command := Command()
+	if err := command.Execute(); err == nil {
+		t.Fatalf("Execute() with no args succeeded and should have failed")
+	}
+}

--- a/cmd/registry/cmd/compute/lintstats/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats/lintstats.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package lintstats
 
 import (
 	"context"
@@ -32,11 +32,15 @@ import (
 	metrics "github.com/google/gnostic/metrics"
 )
 
+func lintRelation(linter string) string {
+	return "lint-" + linter
+}
+
 func lintStatsRelation(linter string) string {
 	return "lintstats-" + linter
 }
 
-func lintStatsCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var linter string
 	cmd := &cobra.Command{
 		Use:   "lintstats",

--- a/cmd/registry/cmd/compute/lintstats/lintstats_test.go
+++ b/cmd/registry/cmd/compute/lintstats/lintstats_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lintstats
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection/grpctest"
+	"github.com/apigee/registry/server/registry"
+)
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
+
+func TestLintStats(t *testing.T) {
+	command := Command()
+	if err := command.Execute(); err == nil {
+		t.Fatalf("Execute() with no args succeeded and should have failed")
+	}
+}

--- a/cmd/registry/cmd/compute/score/score.go
+++ b/cmd/registry/cmd/compute/score/score.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package score
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func scoreCommand() *cobra.Command {
-	return &cobra.Command{
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "score",
 		Short: "Compute scores for APIs and API specs",
 		Args:  cobra.ExactArgs(1),
@@ -99,6 +99,10 @@ func scoreCommand() *cobra.Command {
 			}
 		},
 	}
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	return cmd
 }
 
 type computeScoreTask struct {

--- a/cmd/registry/cmd/compute/score/score.go
+++ b/cmd/registry/cmd/compute/score/score.go
@@ -99,9 +99,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().String("filter", "", "Filter selected resources")
+	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/score/score_test.go
+++ b/cmd/registry/cmd/compute/score/score_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package score
 
 import (

--- a/cmd/registry/cmd/compute/score/score_test.go
+++ b/cmd/registry/cmd/compute/score/score_test.go
@@ -1,4 +1,4 @@
-package compute
+package score
 
 import (
 	"context"
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/connection/grpctest"
 	"github.com/apigee/registry/rpc"
+	"github.com/apigee/registry/server/registry"
 	"github.com/apigee/registry/server/registry/test/seeder"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/iterator"
@@ -14,6 +16,13 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
 
 const gzipOpenAPIv3 = "application/x.openapi+gzip;version=3.0.0"
 const gzipProtobuf = "application/x.protobuf+gzip"
@@ -303,7 +312,7 @@ func TestScore(t *testing.T) {
 
 			// setup the score command
 			scoreCmd := Command()
-			args := []string{"score", "projects/score-test/locations/global/apis/-/versions/-/specs/-"}
+			args := []string{"projects/score-test/locations/global/apis/-/versions/-/specs/-"}
 			scoreCmd.SetArgs(args)
 
 			if err = scoreCmd.Execute(); err != nil {

--- a/cmd/registry/cmd/compute/scorecard/scorecard.go
+++ b/cmd/registry/cmd/compute/scorecard/scorecard.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package scorecard
 
 import (
 	"context"
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func scoreCardCommand() *cobra.Command {
-	return &cobra.Command{
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "scorecard",
 		Short: "Compute score cards for APIs and API specs",
 		Args:  cobra.ExactArgs(1),
@@ -98,6 +98,10 @@ func scoreCardCommand() *cobra.Command {
 			}
 		},
 	}
+	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
+	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	return cmd
 }
 
 type computeScoreCardTask struct {

--- a/cmd/registry/cmd/compute/scorecard/scorecard.go
+++ b/cmd/registry/cmd/compute/scorecard/scorecard.go
@@ -98,9 +98,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().String("filter", "", "Filter selected resources")
+	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/scorecard/scorecard_test.go
+++ b/cmd/registry/cmd/compute/scorecard/scorecard_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package scorecard
 
 import (

--- a/cmd/registry/cmd/compute/vocabulary/vocabulary-proto.go
+++ b/cmd/registry/cmd/compute/vocabulary/vocabulary-proto.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package vocabulary
 
 import (
 	"archive/zip"

--- a/cmd/registry/cmd/compute/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary/vocabulary.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package vocabulary
 
 import (
 	"context"
@@ -34,7 +34,7 @@ import (
 	oas3 "github.com/google/gnostic/openapiv3"
 )
 
-func vocabularyCommand() *cobra.Command {
+func Command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "vocabulary",
 		Short: "Compute vocabularies of API specs",

--- a/cmd/registry/cmd/compute/vocabulary/vocabulary_test.go
+++ b/cmd/registry/cmd/compute/vocabulary/vocabulary_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vocabulary
+
+import (
+	"testing"
+
+	"github.com/apigee/registry/pkg/connection/grpctest"
+	"github.com/apigee/registry/server/registry"
+)
+
+// TestMain will set up a local RegistryServer and grpc.Server for all
+// tests in this package if APG_REGISTRY_ADDRESS env var is not set
+// for the client.
+func TestMain(m *testing.M) {
+	grpctest.TestMain(m, registry.Config{})
+}
+
+func TestVocabulary(t *testing.T) {
+	command := Command()
+	if err := command.Execute(); err == nil {
+		t.Fatalf("Execute() with no args succeeded and should have failed")
+	}
+}


### PR DESCRIPTION
Addresses #944 by pushing `registry compute` subcommand implementations into separate directories that can be independently prioritized for test coverage. Three subcommands were untested, so to keep them in our coverage stats, I added stub tests in each three that just verify that a command that is run without arguments returns an error.

The division causes some code to be duplicated that was previously shared in the `compute` package. I don't think it's significant, and would like to leave it to be addressed in any future refactoring of the tests that aims to reduce duplication (I don't think this is currently a priority). Also, flag declarations are pushed down to the leaf level because they are needed in leaf-level tests (and including the `compute` package creates an import cycle).

`testdata` remains shared across the `compute` package - I think reorganization of that would be best left to PRs focused on testing individual commands.