### PR TITLE
Factor a "visitors" pattern out of the get/delete/export implementations.

### DIFF
--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -17,14 +17,11 @@ package delete
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/log"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/rpc"
-	"github.com/apigee/registry/server/registry/names"
 	"github.com/spf13/cobra"
 )
 
@@ -43,8 +40,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
-			args[0] = c.FQName(args[0])
-			client, err := connection.NewRegistryClientWithSettings(ctx, c)
+			pattern := c.FQName(args[0])
+			registryClient, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				return err
 			}
@@ -55,20 +52,24 @@ func Command() *cobra.Command {
 			// Initialize task queue.
 			taskQueue, wait := core.WorkerPool(ctx, jobs)
 			defer wait()
-			h := &deleteHandler{
-				ctx:         ctx,
-				client:      client,
-				adminClient: adminClient,
-				name:        args[0],
-				filter:      filter,
-				force:       force,
-				taskQueue:   taskQueue,
+			// Create the visitor that will perform deletion.
+			v := &deletionVisitor{
+				registryClient: registryClient,
+				adminClient:    adminClient,
+				force:          force,
+				taskQueue:      taskQueue,
 			}
-			err = h.traverse()
-			if err != nil {
+			// Visit the selected resources.
+			if err = core.Visit(ctx, v, core.VisitorOptions{
+				RegistryClient:   registryClient,
+				AdminClient:      adminClient,
+				Pattern:          pattern,
+				Filter:           filter,
+				AllowUnavailable: false,
+			}); err != nil {
 				return err
 			}
-			if h.count == 0 {
+			if v.count == 0 {
 				return errors.New("no resources found")
 			}
 			return nil
@@ -81,180 +82,101 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-type deleteHandler struct {
-	ctx         context.Context
-	client      connection.RegistryClient
-	adminClient connection.AdminClient
-	name        string
-	filter      string
-	force       bool
-	count       int
-	taskQueue   chan<- core.Task
+type deletionVisitor struct {
+	registryClient connection.RegistryClient
+	adminClient    connection.AdminClient
+	force          bool
+	count          int
+	taskQueue      chan<- core.Task
 }
 
-func (h *deleteHandler) traverse() error {
-	// Define aliases to simplify the subsequent code.
-	name := h.name
-	ctx := h.ctx
-	client := h.client
-	adminClient := h.adminClient
-	filter := h.filter
-
-	// First try to match collection names.
-	if project, err := names.ParseProjectCollection(name); err == nil {
-		return core.ListProjects(ctx, adminClient, project, filter, h.projectHandler())
-	} else if api, err := names.ParseApiCollection(name); err == nil {
-		return core.ListAPIs(ctx, client, api, filter, h.apiHandler())
-	} else if deployment, err := names.ParseDeploymentCollection(name); err == nil {
-		return core.ListDeployments(ctx, client, deployment, filter, h.apiDeploymentHandler())
-	} else if rev, err := names.ParseDeploymentRevisionCollection(name); err == nil {
-		return core.ListDeploymentRevisions(ctx, client, rev, filter, h.apiDeploymentRevisionHandler())
-	} else if version, err := names.ParseVersionCollection(name); err == nil {
-		return core.ListVersions(ctx, client, version, filter, h.apiVersionHandler())
-	} else if spec, err := names.ParseSpecCollection(name); err == nil {
-		return core.ListSpecs(ctx, client, spec, filter, false, h.apiSpecHandler())
-	} else if rev, err := names.ParseSpecRevisionCollection(name); err == nil {
-		return core.ListSpecRevisions(ctx, client, rev, filter, false, h.apiSpecRevisionHandler())
-	} else if artifact, err := names.ParseArtifactCollection(name); err == nil {
-		return core.ListArtifacts(ctx, client, artifact, filter, false, h.artifactHandler())
-	}
-
-	// Then try to match resource names containing wildcards, these also are treated as collections.
-	if strings.Contains(name, "/-") || strings.Contains(name, "@-") {
-		if project, err := names.ParseProject(name); err == nil {
-			return core.ListProjects(ctx, adminClient, project, filter, h.projectHandler())
-		} else if api, err := names.ParseApi(name); err == nil {
-			return core.ListAPIs(ctx, client, api, filter, h.apiHandler())
-		} else if deployment, err := names.ParseDeployment(name); err == nil {
-			return core.ListDeployments(ctx, client, deployment, filter, h.apiDeploymentHandler())
-		} else if rev, err := names.ParseDeploymentRevision(name); err == nil {
-			return core.ListDeploymentRevisions(ctx, client, rev, filter, h.apiDeploymentRevisionHandler())
-		} else if version, err := names.ParseVersion(name); err == nil {
-			return core.ListVersions(ctx, client, version, filter, h.apiVersionHandler())
-		} else if spec, err := names.ParseSpec(name); err == nil {
-			return core.ListSpecs(ctx, client, spec, filter, false, h.apiSpecHandler())
-		} else if rev, err := names.ParseSpecRevision(name); err == nil {
-			return core.ListSpecRevisions(ctx, client, rev, filter, false, h.apiSpecRevisionHandler())
-		} else if artifact, err := names.ParseArtifact(name); err == nil {
-			return core.ListArtifacts(ctx, client, artifact, filter, false, h.artifactHandler())
-		}
-		return fmt.Errorf("unsupported pattern %+v", name)
-	}
-
-	// If we get here, name designates an individual resource to be displayed.
-	// So if a filter was specified, that's an error.
-	if filter != "" {
-		return errors.New("--filter must not be specified for a non-collection resource")
-	}
-
-	if project, err := names.ParseProject(name); err == nil {
-		return core.GetProject(ctx, adminClient, project, false, h.projectHandler())
-	} else if api, err := names.ParseApi(name); err == nil {
-		return core.GetAPI(ctx, client, api, h.apiHandler())
-	} else if deployment, err := names.ParseDeployment(name); err == nil {
-		return core.GetDeployment(ctx, client, deployment, h.apiDeploymentHandler())
-	} else if deployment, err := names.ParseDeploymentRevision(name); err == nil {
-		return core.GetDeploymentRevision(ctx, client, deployment, h.apiDeploymentRevisionHandler())
-	} else if version, err := names.ParseVersion(name); err == nil {
-		return core.GetVersion(ctx, client, version, h.apiVersionHandler())
-	} else if spec, err := names.ParseSpec(name); err == nil {
-		return core.GetSpec(ctx, client, spec, false, h.apiSpecHandler())
-	} else if spec, err := names.ParseSpecRevision(name); err == nil {
-		return core.GetSpecRevision(ctx, client, spec, false, h.apiSpecRevisionHandler())
-	} else if artifact, err := names.ParseArtifact(name); err == nil {
-		return core.GetArtifact(ctx, client, artifact, false, h.artifactHandler())
-	} else {
-		return fmt.Errorf("unsupported pattern %+v", name)
-	}
+func (v *deletionVisitor) enqueue(task core.Task) {
+	v.count++
+	v.taskQueue <- task
 }
 
-func (h *deleteHandler) enqueue(task core.Task) {
-	h.count++
-	h.taskQueue <- task
-}
-
-func (h *deleteHandler) projectHandler() func(message *rpc.Project) error {
+func (v *deletionVisitor) ProjectHandler() core.ProjectHandler {
 	return func(message *rpc.Project) error {
-		h.enqueue(&deleteProjectTask{
+		v.enqueue(&deleteProjectTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.adminClient,
-			force:      h.force,
+			client:     v.adminClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) apiHandler() func(message *rpc.Api) error {
+func (v *deletionVisitor) ApiHandler() core.ApiHandler {
 	return func(message *rpc.Api) error {
-		h.enqueue(&deleteApiTask{
+		v.enqueue(&deleteApiTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
-			force:      h.force,
+			client:     v.registryClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) apiVersionHandler() func(message *rpc.ApiVersion) error {
+func (v *deletionVisitor) VersionHandler() core.VersionHandler {
 	return func(message *rpc.ApiVersion) error {
-		h.enqueue(&deleteApiVersionTask{
+		v.enqueue(&deleteApiVersionTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
-			force:      h.force,
+			client:     v.registryClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) apiDeploymentHandler() func(message *rpc.ApiDeployment) error {
+func (v *deletionVisitor) DeploymentHandler() core.DeploymentHandler {
 	return func(message *rpc.ApiDeployment) error {
-		h.enqueue(&deleteApiDeploymentTask{
+		v.enqueue(&deleteApiDeploymentTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
-			force:      h.force,
+			client:     v.registryClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) apiDeploymentRevisionHandler() func(message *rpc.ApiDeployment) error {
+func (v *deletionVisitor) DeploymentRevisionHandler() core.DeploymentHandler {
 	return func(message *rpc.ApiDeployment) error {
-		h.enqueue(&deleteApiDeploymentRevisionTask{
+		v.enqueue(&deleteApiDeploymentRevisionTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
-			force:      h.force,
+			client:     v.registryClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) apiSpecHandler() func(message *rpc.ApiSpec) error {
+func (v *deletionVisitor) SpecHandler() core.SpecHandler {
 	return func(message *rpc.ApiSpec) error {
-		h.enqueue(&deleteApiSpecTask{
+		v.enqueue(&deleteApiSpecTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
-			force:      h.force,
+			client:     v.registryClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) apiSpecRevisionHandler() func(message *rpc.ApiSpec) error {
+func (v *deletionVisitor) SpecRevisionHandler() core.SpecHandler {
 	return func(message *rpc.ApiSpec) error {
-		h.enqueue(&deleteApiSpecRevisionTask{
+		v.enqueue(&deleteApiSpecRevisionTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
-			force:      h.force,
+			client:     v.registryClient,
+			force:      v.force,
 		})
 		return nil
 	}
 }
 
-func (h *deleteHandler) artifactHandler() func(message *rpc.Artifact) error {
+func (v *deletionVisitor) ArtifactHandler() core.ArtifactHandler {
 	return func(message *rpc.Artifact) error {
-		h.enqueue(&deleteArtifactTask{
+		v.enqueue(&deleteArtifactTask{
 			deleteTask: deleteTask{resourceName: message.Name},
-			client:     h.client,
+			client:     v.registryClient,
 		})
 		return nil
 	}

--- a/cmd/registry/cmd/delete/delete.go
+++ b/cmd/registry/cmd/delete/delete.go
@@ -61,11 +61,11 @@ func Command() *cobra.Command {
 			}
 			// Visit the selected resources.
 			if err = core.Visit(ctx, v, core.VisitorOptions{
-				RegistryClient:   registryClient,
-				AdminClient:      adminClient,
-				Pattern:          pattern,
-				Filter:           filter,
-				AllowUnavailable: false,
+				RegistryClient:          registryClient,
+				AdminClient:             adminClient,
+				Pattern:                 pattern,
+				Filter:                  filter,
+				AllowUnavailableProject: false,
 			}); err != nil {
 				return err
 			}

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -17,8 +17,6 @@ package export
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/cmd/registry/patch"
@@ -44,7 +42,7 @@ func Command() *cobra.Command {
 				return err
 			}
 			pattern := c.FQName(args[0])
-			client, err := connection.NewRegistryClientWithSettings(ctx, c)
+			registryClient, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				return err
 			}
@@ -55,20 +53,26 @@ func Command() *cobra.Command {
 			// Initialize task queue.
 			taskQueue, wait := core.WorkerPool(ctx, jobs)
 			defer wait()
-			h := &exportHandler{
-				ctx:         ctx,
-				client:      client,
-				adminClient: adminClient,
-				pattern:     pattern,
-				filter:      filter,
-				recursive:   recursive,
-				root:        root,
-				taskQueue:   taskQueue,
+			// Create the visitor that will perform exports.
+			v := &exportVisitor{
+				ctx:            ctx,
+				registryClient: registryClient,
+				adminClient:    adminClient,
+				recursive:      recursive,
+				root:           root,
+				taskQueue:      taskQueue,
 			}
-			if err = h.traverse(); err != nil {
+			// Visit the selected resources.
+			if err = core.Visit(ctx, v, core.VisitorOptions{
+				RegistryClient:   registryClient,
+				AdminClient:      adminClient,
+				Pattern:          pattern,
+				Filter:           filter,
+				AllowUnavailable: true,
+			}); err != nil {
 				return err
 			}
-			if h.count == 0 {
+			if v.count == 0 {
 				return errors.New("no resources found")
 			}
 			return nil
@@ -81,156 +85,90 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-type exportHandler struct {
-	ctx         context.Context
-	client      connection.RegistryClient
-	adminClient connection.AdminClient
-	pattern     string
-	filter      string
-	recursive   bool
-	root        string
-	count       int
-	taskQueue   chan<- core.Task
+type exportVisitor struct {
+	ctx            context.Context
+	registryClient connection.RegistryClient
+	adminClient    connection.AdminClient
+	recursive      bool
+	root           string
+	count          int
+	taskQueue      chan<- core.Task
 }
 
-func (h *exportHandler) traverse() error {
-	// Define aliases to simplify the subsequent code.
-	pattern := h.pattern
-	ctx := h.ctx
-	client := h.client
-	adminClient := h.adminClient
-	filter := h.filter
-
-	// First try to match collection names.
-	if project, err := names.ParseProjectCollection(pattern); err == nil {
-		return core.ListProjects(ctx, adminClient, project, filter, h.projectHandler())
-	} else if api, err := names.ParseApiCollection(pattern); err == nil {
-		return core.ListAPIs(ctx, client, api, filter, h.apiHandler())
-	} else if deployment, err := names.ParseDeploymentCollection(pattern); err == nil {
-		return core.ListDeployments(ctx, client, deployment, filter, h.apiDeploymentHandler())
-	} else if _, err := names.ParseDeploymentRevisionCollection(pattern); err == nil {
-		return errors.New("exports of specific revisions are not supported")
-	} else if version, err := names.ParseVersionCollection(pattern); err == nil {
-		return core.ListVersions(ctx, client, version, filter, h.apiVersionHandler())
-	} else if spec, err := names.ParseSpecCollection(pattern); err == nil {
-		return core.ListSpecs(ctx, client, spec, filter, false, h.apiSpecHandler())
-	} else if _, err := names.ParseSpecRevisionCollection(pattern); err == nil {
-		return errors.New("exports of specific revisions are not supported")
-	} else if artifact, err := names.ParseArtifactCollection(pattern); err == nil {
-		return core.ListArtifacts(ctx, client, artifact, filter, false, h.artifactHandler())
-	}
-
-	// Then try to match resource names containing wildcards, these also are treated as collections.
-	if strings.Contains(pattern, "/-") || strings.Contains(pattern, "@-") {
-		if project, err := names.ParseProject(pattern); err == nil {
-			return core.ListProjects(ctx, adminClient, project, filter, h.projectHandler())
-		} else if api, err := names.ParseApi(pattern); err == nil {
-			return core.ListAPIs(ctx, client, api, filter, h.apiHandler())
-		} else if deployment, err := names.ParseDeployment(pattern); err == nil {
-			return core.ListDeployments(ctx, client, deployment, filter, h.apiDeploymentHandler())
-		} else if _, err := names.ParseDeploymentRevision(pattern); err == nil {
-			return errors.New("exports of specific revisions are not supported")
-		} else if version, err := names.ParseVersion(pattern); err == nil {
-			return core.ListVersions(ctx, client, version, filter, h.apiVersionHandler())
-		} else if spec, err := names.ParseSpec(pattern); err == nil {
-			return core.ListSpecs(ctx, client, spec, filter, false, h.apiSpecHandler())
-		} else if _, err := names.ParseSpecRevision(pattern); err == nil {
-			return errors.New("exports of specific revisions are not supported")
-		} else if artifact, err := names.ParseArtifact(pattern); err == nil {
-			return core.ListArtifacts(ctx, client, artifact, filter, false, h.artifactHandler())
-		}
-		return fmt.Errorf("unsupported pattern %+v", pattern)
-	}
-
-	// If we get here, name designates an individual resource to be displayed.
-	// So if a filter was specified, that's an error.
-	if filter != "" {
-		return errors.New("--filter must not be specified for a non-collection resource")
-	}
-
-	if project, err := names.ParseProject(pattern); err == nil {
-		return core.GetProject(ctx, adminClient, project, true, h.projectHandler())
-	} else if api, err := names.ParseApi(pattern); err == nil {
-		return core.GetAPI(ctx, client, api, h.apiHandler())
-	} else if deployment, err := names.ParseDeployment(pattern); err == nil {
-		return core.GetDeployment(ctx, client, deployment, h.apiDeploymentHandler())
-	} else if _, err := names.ParseDeploymentRevision(pattern); err == nil {
-		return errors.New("exports of specific revisions are not supported")
-	} else if version, err := names.ParseVersion(pattern); err == nil {
-		return core.GetVersion(ctx, client, version, h.apiVersionHandler())
-	} else if spec, err := names.ParseSpec(pattern); err == nil {
-		return core.GetSpec(ctx, client, spec, false, h.apiSpecHandler())
-	} else if _, err := names.ParseSpecRevision(pattern); err == nil {
-		return errors.New("exports of specific revisions are not supported")
-	} else if artifact, err := names.ParseArtifact(pattern); err == nil {
-		return core.GetArtifact(ctx, client, artifact, false, h.artifactHandler())
-	} else {
-		return fmt.Errorf("unsupported pattern %+v", pattern)
-	}
-}
-
-func (h *exportHandler) projectHandler() func(message *rpc.Project) error {
+func (h *exportVisitor) ProjectHandler() core.ProjectHandler {
 	return func(message *rpc.Project) error {
 		h.count++
 		name, err := names.ParseProject(message.Name)
 		if err != nil {
 			return err
 		}
-		return patch.ExportProject(h.ctx, h.client, name, h.root, h.taskQueue)
+		return patch.ExportProject(h.ctx, h.registryClient, name, h.root, h.taskQueue)
 	}
 }
 
-func (h *exportHandler) apiHandler() func(message *rpc.Api) error {
+func (h *exportVisitor) ApiHandler() core.ApiHandler {
 	return func(message *rpc.Api) error {
 		h.count++
 		name, err := names.ParseApi(message.Name)
 		if err != nil {
 			return err
 		}
-		return patch.ExportAPI(h.ctx, h.client, name, h.recursive, h.root, h.taskQueue)
+		return patch.ExportAPI(h.ctx, h.registryClient, name, h.recursive, h.root, h.taskQueue)
 	}
 }
 
-func (h *exportHandler) apiVersionHandler() func(message *rpc.ApiVersion) error {
+func (h *exportVisitor) VersionHandler() core.VersionHandler {
 	return func(message *rpc.ApiVersion) error {
 		h.count++
 		name, err := names.ParseVersion(message.Name)
 		if err != nil {
 			return err
 		}
-		return patch.ExportAPIVersion(h.ctx, h.client, name, h.recursive, h.root, h.taskQueue)
+		return patch.ExportAPIVersion(h.ctx, h.registryClient, name, h.recursive, h.root, h.taskQueue)
 	}
 }
 
-func (h *exportHandler) apiDeploymentHandler() func(message *rpc.ApiDeployment) error {
+func (h *exportVisitor) DeploymentHandler() core.DeploymentHandler {
 	return func(message *rpc.ApiDeployment) error {
 		h.count++
 		name, err := names.ParseDeployment(message.Name)
 		if err != nil {
 			return err
 		}
-		return patch.ExportAPIDeployment(h.ctx, h.client, name, h.recursive, h.root, h.taskQueue)
+		return patch.ExportAPIDeployment(h.ctx, h.registryClient, name, h.recursive, h.root, h.taskQueue)
 	}
 }
 
-func (h *exportHandler) apiSpecHandler() func(message *rpc.ApiSpec) error {
+func (h *exportVisitor) DeploymentRevisionHandler() core.DeploymentHandler {
+	return func(message *rpc.ApiDeployment) error {
+		return errors.New("exports of specific revisions are not supported")
+	}
+}
+
+func (h *exportVisitor) SpecHandler() core.SpecHandler {
 	return func(message *rpc.ApiSpec) error {
 		h.count++
 		name, err := names.ParseSpec(message.Name)
 		if err != nil {
 			return err
 		}
-		return patch.ExportAPISpec(h.ctx, h.client, name, h.recursive, h.root, h.taskQueue)
+		return patch.ExportAPISpec(h.ctx, h.registryClient, name, h.recursive, h.root, h.taskQueue)
 	}
 }
 
-func (h *exportHandler) artifactHandler() func(message *rpc.Artifact) error {
+func (h *exportVisitor) SpecRevisionHandler() core.SpecHandler {
+	return func(message *rpc.ApiSpec) error {
+		return errors.New("exports of specific revisions are not supported")
+	}
+}
+
+func (h *exportVisitor) ArtifactHandler() core.ArtifactHandler {
 	return func(message *rpc.Artifact) error {
 		h.count++
 		name, err := names.ParseArtifact(message.Name)
 		if err != nil {
 			return err
 		}
-		return patch.ExportArtifact(h.ctx, h.client, name, h.root, h.taskQueue)
+		return patch.ExportArtifact(h.ctx, h.registryClient, name, h.root, h.taskQueue)
 	}
 }

--- a/cmd/registry/cmd/export/export.go
+++ b/cmd/registry/cmd/export/export.go
@@ -64,11 +64,11 @@ func Command() *cobra.Command {
 			}
 			// Visit the selected resources.
 			if err = core.Visit(ctx, v, core.VisitorOptions{
-				RegistryClient:   registryClient,
-				AdminClient:      adminClient,
-				Pattern:          pattern,
-				Filter:           filter,
-				AllowUnavailable: true,
+				RegistryClient:          registryClient,
+				AdminClient:             adminClient,
+				Pattern:                 pattern,
+				Filter:                  filter,
+				AllowUnavailableProject: true,
 			}); err != nil {
 				return err
 			}

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -62,11 +62,11 @@ func Command() *cobra.Command {
 			}
 			// Visit the selected resources.
 			if err = core.Visit(ctx, v, core.VisitorOptions{
-				RegistryClient:   registryClient,
-				AdminClient:      adminClient,
-				Pattern:          pattern,
-				Filter:           filter,
-				AllowUnavailable: false,
+				RegistryClient:          registryClient,
+				AdminClient:             adminClient,
+				Pattern:                 pattern,
+				Filter:                  filter,
+				AllowUnavailableProject: false,
 			}); err != nil {
 				return err
 			}

--- a/cmd/registry/core/visitors.go
+++ b/cmd/registry/core/visitors.go
@@ -35,11 +35,11 @@ type Visitor interface {
 }
 
 type VisitorOptions struct {
-	RegistryClient   connection.RegistryClient
-	AdminClient      connection.AdminClient
-	Pattern          string
-	Filter           string
-	AllowUnavailable bool
+	RegistryClient          connection.RegistryClient
+	AdminClient             connection.AdminClient
+	Pattern                 string
+	Filter                  string
+	AllowUnavailableProject bool
 }
 
 // Visit traverses a registry, applying the Visitor to each selected resource.
@@ -95,7 +95,7 @@ func Visit(ctx context.Context, v Visitor, options VisitorOptions) error {
 	}
 	// Finally, match individual resources
 	if project, err := names.ParseProject(name); err == nil {
-		return GetProject(ctx, ac, project, options.AllowUnavailable, v.ProjectHandler())
+		return GetProject(ctx, ac, project, options.AllowUnavailableProject, v.ProjectHandler())
 	} else if api, err := names.ParseApi(name); err == nil {
 		return GetAPI(ctx, rc, api, v.ApiHandler())
 	} else if deployment, err := names.ParseDeployment(name); err == nil {

--- a/cmd/registry/core/visitors.go
+++ b/cmd/registry/core/visitors.go
@@ -1,0 +1,116 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/server/registry/names"
+)
+
+type Visitor interface {
+	ProjectHandler() ProjectHandler
+	ApiHandler() ApiHandler
+	DeploymentHandler() DeploymentHandler
+	DeploymentRevisionHandler() DeploymentHandler
+	VersionHandler() VersionHandler
+	SpecHandler() SpecHandler
+	SpecRevisionHandler() SpecHandler
+	ArtifactHandler() ArtifactHandler
+}
+
+type VisitorOptions struct {
+	RegistryClient   connection.RegistryClient
+	AdminClient      connection.AdminClient
+	Pattern          string
+	Filter           string
+	AllowUnavailable bool
+}
+
+// Visit traverses a registry, applying the Visitor to each selected resource.
+func Visit(ctx context.Context, v Visitor, options VisitorOptions) error {
+	filter := options.Filter
+	name := options.Pattern
+	ac := options.AdminClient
+	rc := options.RegistryClient
+
+	// First try to match collection names.
+	if project, err := names.ParseProjectCollection(name); err == nil {
+		return ListProjects(ctx, ac, project, filter, v.ProjectHandler())
+	} else if api, err := names.ParseApiCollection(name); err == nil {
+		return ListAPIs(ctx, rc, api, filter, v.ApiHandler())
+	} else if deployment, err := names.ParseDeploymentCollection(name); err == nil {
+		return ListDeployments(ctx, rc, deployment, filter, v.DeploymentHandler())
+	} else if rev, err := names.ParseDeploymentRevisionCollection(name); err == nil {
+		return ListDeploymentRevisions(ctx, rc, rev, filter, v.DeploymentRevisionHandler())
+	} else if version, err := names.ParseVersionCollection(name); err == nil {
+		return ListVersions(ctx, rc, version, filter, v.VersionHandler())
+	} else if spec, err := names.ParseSpecCollection(name); err == nil {
+		return ListSpecs(ctx, rc, spec, filter, false, v.SpecHandler())
+	} else if rev, err := names.ParseSpecRevisionCollection(name); err == nil {
+		return ListSpecRevisions(ctx, rc, rev, filter, false, v.SpecRevisionHandler())
+	} else if artifact, err := names.ParseArtifactCollection(name); err == nil {
+		return ListArtifacts(ctx, rc, artifact, filter, false, v.ArtifactHandler())
+	}
+	// Then try to match resource names containing wildcards, these also are treated as collections.
+	if strings.Contains(name, "/-") || strings.Contains(name, "@-") {
+		if project, err := names.ParseProject(name); err == nil {
+			return ListProjects(ctx, ac, project, filter, v.ProjectHandler())
+		} else if api, err := names.ParseApi(name); err == nil {
+			return ListAPIs(ctx, rc, api, filter, v.ApiHandler())
+		} else if deployment, err := names.ParseDeployment(name); err == nil {
+			return ListDeployments(ctx, rc, deployment, filter, v.DeploymentHandler())
+		} else if rev, err := names.ParseDeploymentRevision(name); err == nil {
+			return ListDeploymentRevisions(ctx, rc, rev, filter, v.DeploymentRevisionHandler())
+		} else if version, err := names.ParseVersion(name); err == nil {
+			return ListVersions(ctx, rc, version, filter, v.VersionHandler())
+		} else if spec, err := names.ParseSpec(name); err == nil {
+			return ListSpecs(ctx, rc, spec, filter, false, v.SpecHandler())
+		} else if rev, err := names.ParseSpecRevision(name); err == nil {
+			return ListSpecRevisions(ctx, rc, rev, filter, false, v.SpecRevisionHandler())
+		} else if artifact, err := names.ParseArtifact(name); err == nil {
+			return ListArtifacts(ctx, rc, artifact, filter, false, v.ArtifactHandler())
+		}
+		return fmt.Errorf("unsupported pattern %+v", name)
+	}
+	// If we get here, name designates an individual resource to be displayed.
+	// So if a filter was specified, that's an error.
+	if filter != "" {
+		return errors.New("--filter must not be specified for a non-collection resource")
+	}
+	// Finally, match individual resources
+	if project, err := names.ParseProject(name); err == nil {
+		return GetProject(ctx, ac, project, options.AllowUnavailable, v.ProjectHandler())
+	} else if api, err := names.ParseApi(name); err == nil {
+		return GetAPI(ctx, rc, api, v.ApiHandler())
+	} else if deployment, err := names.ParseDeployment(name); err == nil {
+		return GetDeployment(ctx, rc, deployment, v.DeploymentHandler())
+	} else if deployment, err := names.ParseDeploymentRevision(name); err == nil {
+		return GetDeploymentRevision(ctx, rc, deployment, v.DeploymentRevisionHandler())
+	} else if version, err := names.ParseVersion(name); err == nil {
+		return GetVersion(ctx, rc, version, v.VersionHandler())
+	} else if spec, err := names.ParseSpec(name); err == nil {
+		return GetSpec(ctx, rc, spec, false, v.SpecHandler())
+	} else if spec, err := names.ParseSpecRevision(name); err == nil {
+		return GetSpecRevision(ctx, rc, spec, false, v.SpecRevisionHandler())
+	} else if artifact, err := names.ParseArtifact(name); err == nil {
+		return GetArtifact(ctx, rc, artifact, false, v.ArtifactHandler())
+	} else {
+		return fmt.Errorf("unsupported pattern %+v", name)
+	}
+}


### PR DESCRIPTION
This defines a new `Visitor` interface and a `Visit` function that applies the visitor to resources matching a pattern and filter. This was factored out of the `registry get`, `registry export`, and `registry delete` commands. It builds on the `List*` and `Get*` functions in `core` without making any changes to those. The `Visitor` interface returns closures that are passed to these functions. If usage expands, I think we might consider new `List` and `Get` methods that just take `Visitor` instances and call appropriate functions in the interface - then the `Visitor` interface would just be handlers and not need to return closures. But this seems like a good incremental step forward.

Note that there are some contexts in structs pending #913.

Looking ahead to testing, I think this and related functions should move to a new package under `pkg` and be tested there. Thoughts? `pkg/visitor`?