### PR TITLE
Additional usage information for `registry apply`

### DIFF
--- a/cmd/registry/README.md
+++ b/cmd/registry/README.md
@@ -110,9 +110,9 @@ that is likely to become a recommended way to populate an API registry.
   As above, `$PROJECT_ID` should be set to your registry project id.
 
 - `registry apply` reads API information from YAML files using a mechanism
-  similar to `kubectl apply`. For details, see
-  [this GitHub issue](https://github.com/apigee/registry/issues/450). To try
-  it, run the following from the root of the `registry` repo:
+  similar to `kubectl apply`. For details,
+  [check the wiki entry](https://github.com/apigee/registry/wiki/registry-apply)
+  To try it, run the following from the root of the `registry` repo:
 
   ```
   registry apply -f cmd/registry/cmd/apply/testdata/registry.yaml --parent projects/$PROJECT_ID/locations/global

--- a/cmd/registry/cmd/apply/apply.go
+++ b/cmd/registry/cmd/apply/apply.go
@@ -15,8 +15,8 @@
 package apply
 
 import (
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/apigee/registry/cmd/registry/core"
 	"github.com/apigee/registry/cmd/registry/patch"
@@ -26,39 +26,42 @@ import (
 
 func Command() *cobra.Command {
 	var fileName string
-	var parent string
+	var project string
 	var recursive bool
 	var jobs int
 	cmd := &cobra.Command{
-		Use:   "apply",
-		Short: "Apply patches that add content to the API Registry",
-		Args:  cobra.ExactArgs(0),
+		Use:   "apply (-f FILENAME | -f -)",
+		Short: "Apply an object to the API Registry",
+		Long:  "Apply an object to the API Registry by file name or stdin. Resources will be created if they don't exist yet.\n\nMore info and example usage at https://github.com/apigee/registry/wiki/registry-apply",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if parent == "" {
+			if project == "" {
 				c, err := connection.ActiveConfig()
 				if err != nil {
-					return errors.New("Unable to identify parent: please use --parent or registry configuration")
+					return err
 				}
-				parent, err = c.ProjectWithLocation()
+				project, err = c.ProjectWithLocation()
 				if err != nil {
-					return errors.New("Unable to identify parent: please use --parent or set registry.project in configuration")
+					return fmt.Errorf("%s: please use --project or set registry.project in configuration", err)
 				}
+			} else if !strings.Contains(project, "/locations/") {
+				project += "/locations/global"
 			}
 			client, err := connection.NewRegistryClient(ctx)
 			if err != nil {
 				return err
 			}
-			if err := core.VerifyLocation(ctx, client, parent); err != nil {
-				return fmt.Errorf("parent does not exist (%s)", err)
+			if err := core.VerifyLocation(ctx, client, project); err != nil {
+				return fmt.Errorf("parent project %q does not exist: %s", project, err)
 			}
-			return patch.Apply(ctx, client, fileName, parent, recursive, jobs)
+			return patch.Apply(ctx, client, fileName, project, recursive, jobs)
 		},
 	}
-	cmd.Flags().StringVarP(&fileName, "file", "f", "", "file or directory containing the patch(es) to apply")
-	cmd.Flags().StringVar(&parent, "parent", "", "parent resource for the patch")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "R", false,
-		"process the directory used in -f, --file recursively")
+	cmd.Flags().StringVarP(&fileName, "file", "f", "", "file or directory containing the patch(es) to apply. Use '-' to read from standard input")
+	_ = cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVar(&project, "project", "", "GCP project containing the API registry")
+	cmd.Flags().BoolVarP(&recursive, "recursive", "R", false, "process the directory used in -f, --file recursively")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }

--- a/cmd/registry/cmd/apply/apply.go
+++ b/cmd/registry/cmd/apply/apply.go
@@ -43,7 +43,7 @@ func Command() *cobra.Command {
 				}
 				project, err = c.ProjectWithLocation()
 				if err != nil {
-					return fmt.Errorf("%s: please use --project or set registry.project in configuration", err)
+					return fmt.Errorf("%s: please use --parent or set registry.project in configuration", err)
 				}
 			} else if !strings.Contains(project, "/locations/") {
 				project += "/locations/global"
@@ -60,7 +60,7 @@ func Command() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&fileName, "file", "f", "", "file or directory containing the patch(es) to apply. Use '-' to read from standard input")
 	_ = cmd.MarkFlagRequired("file")
-	cmd.Flags().StringVar(&project, "project", "", "GCP project containing the API registry")
+	cmd.Flags().StringVar(&project, "parent", "", "GCP project containing the API registry")
 	cmd.Flags().BoolVarP(&recursive, "recursive", "R", false, "process the directory used in -f, --file recursively")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd

--- a/cmd/registry/cmd/root_test.go
+++ b/cmd/registry/cmd/root_test.go
@@ -93,8 +93,8 @@ func checkCommand(t *testing.T, cmd *cobra.Command, prefix string) {
 				if f.Usage == "" {
 					t.Errorf("%q %q flag usage must not be empty.", name, f.Name)
 				} else {
-					first := []rune(f.Usage)[0]
-					if unicode.IsUpper(first) {
+					// Check if the first word is uppercase and not an initialism.
+					if words := strings.Split(f.Usage, " "); unicode.IsUpper([]rune(f.Usage)[0]) && strings.ToUpper(words[0]) != words[0] {
 						t.Errorf("%q %q flag usage must not begin with an upper case letter.", name, f.Name)
 					}
 					if strings.HasSuffix(f.Usage, ".") {

--- a/cmd/registry/patch/api.go
+++ b/cmd/registry/patch/api.go
@@ -16,6 +16,7 @@ package patch
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/log"
@@ -214,7 +215,7 @@ func applyApiPatchBytes(ctx context.Context, client connection.RegistryClient, b
 	}
 	_, err = client.UpdateApi(ctx, req)
 	if err != nil {
-		return err
+		return fmt.Errorf("UpdateApi: %s", err)
 	}
 	for _, versionPatch := range api.Data.ApiVersions {
 		err := applyApiVersionPatch(ctx, client, versionPatch, apiName.String())

--- a/cmd/registry/patch/apply.go
+++ b/cmd/registry/patch/apply.go
@@ -184,10 +184,6 @@ func (task *applyBytesTask) Run(ctx context.Context) error {
 		if header.Metadata.Parent == "" {
 			return errors.New("metadata.parent should be set to the project-local parent path")
 		}
-	case "API":
-		if header.Metadata.Parent != "" {
-			return errors.New("metadata.parent should not be set for top-level resources")
-		}
 	}
 
 	log.FromContext(ctx).Infof("Applying %s", task.resource())

--- a/cmd/registry/patch/apply.go
+++ b/cmd/registry/patch/apply.go
@@ -153,17 +153,21 @@ func (task *applyBytesTask) resource() string {
 	var collection string
 	switch task.kind {
 	case "API":
-		collection = "/apis/"
+		collection = "apis/"
 	case "Version":
-		collection = "/versions/"
+		collection = "versions/"
 	case "Spec":
-		collection = "/specs/"
+		collection = "specs/"
 	case "Deployment":
-		collection = "/deployments/"
+		collection = "deployments/"
 	default:
-		collection = "/artifacts/"
+		collection = "artifacts/"
 	}
-	return task.parent + collection + task.name
+
+	if task.parent == "" {
+		return collection + task.name
+	}
+	return task.parent + "/" + collection + task.name
 }
 
 func (task *applyBytesTask) Run(ctx context.Context) error {

--- a/cmd/registry/patch/artifact.go
+++ b/cmd/registry/patch/artifact.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -149,13 +150,13 @@ func NewArtifact(ctx context.Context, client *gapic.RegistryClient, message *rpc
 	}, nil
 }
 
-func applyArtifactPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, parent string) error {
+func applyArtifactPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, project string) error {
 	var artifact models.Artifact
 	err := yaml.Unmarshal(bytes, &artifact)
 	if err != nil {
 		return err
 	}
-	return applyArtifactPatch(ctx, client, &artifact, parent)
+	return applyArtifactPatch(ctx, client, &artifact, project)
 }
 
 func artifactName(parent string, metadata models.Metadata) (names.Artifact, error) {
@@ -227,9 +228,11 @@ func applyArtifactPatch(ctx context.Context, client connection.RegistryClient, c
 		req := &rpc.ReplaceArtifactRequest{
 			Artifact: artifact,
 		}
-		_, err = client.ReplaceArtifact(ctx, req)
+		if _, err := client.ReplaceArtifact(ctx, req); err != nil {
+			return fmt.Errorf("ReplaceArtifact: %s", err)
+		}
 	}
-	return err
+	return nil
 }
 
 // populateIdAndKind inserts the "id" and "kind" fields in the supplied json bytes.

--- a/cmd/registry/patch/deployment.go
+++ b/cmd/registry/patch/deployment.go
@@ -16,6 +16,7 @@ package patch
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/apigee/registry/gapic"
@@ -83,13 +84,13 @@ func NewApiDeployment(ctx context.Context, client *gapic.RegistryClient, message
 	}, nil
 }
 
-func applyApiDeploymentPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, parent string) error {
+func applyApiDeploymentPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, project string) error {
 	var deployment models.ApiDeployment
 	err := yaml.Unmarshal(bytes, &deployment)
 	if err != nil {
 		return err
 	}
-	return applyApiDeploymentPatch(ctx, client, &deployment, parent)
+	return applyApiDeploymentPatch(ctx, client, &deployment, project)
 }
 
 func deploymentName(parent string, metadata models.Metadata) (names.Deployment, error) {
@@ -132,7 +133,7 @@ func applyApiDeploymentPatch(
 	}
 	_, err = client.UpdateApiDeployment(ctx, req)
 	if err != nil {
-		return err
+		return fmt.Errorf("UpdateApiDeployment: %s", err)
 	}
 	for _, artifactPatch := range deployment.Data.Artifacts {
 		err = applyArtifactPatch(ctx, client, artifactPatch, name.String())

--- a/cmd/registry/patch/spec.go
+++ b/cmd/registry/patch/spec.go
@@ -16,6 +16,7 @@ package patch
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -71,14 +72,14 @@ func applyApiSpecPatchBytes(
 	ctx context.Context,
 	client connection.RegistryClient,
 	bytes []byte,
-	parent string,
+	project string,
 	filename string) error {
 	var spec models.ApiSpec
 	err := yaml.Unmarshal(bytes, &spec)
 	if err != nil {
 		return err
 	}
-	return applyApiSpecPatch(ctx, client, &spec, parent, filename)
+	return applyApiSpecPatch(ctx, client, &spec, project, filename)
 }
 
 func specName(parent string, metadata models.Metadata) (names.Spec, error) {
@@ -190,7 +191,7 @@ func applyApiSpecPatch(
 	}
 	_, err = client.UpdateApiSpec(ctx, req)
 	if err != nil {
-		return err
+		return fmt.Errorf("UpdateApiSpec: %s", err)
 	}
 	for _, artifactPatch := range spec.Data.Artifacts {
 		err = applyArtifactPatch(ctx, client, artifactPatch, name.String())

--- a/cmd/registry/patch/version.go
+++ b/cmd/registry/patch/version.go
@@ -16,6 +16,7 @@ package patch
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apigee/registry/gapic"
 	"github.com/apigee/registry/pkg/connection"
@@ -82,13 +83,13 @@ func applyApiVersionPatchBytes(
 	ctx context.Context,
 	client connection.RegistryClient,
 	bytes []byte,
-	parent string) error {
+	project string) error {
 	var version models.ApiVersion
 	err := yaml.Unmarshal(bytes, &version)
 	if err != nil {
 		return err
 	}
-	return applyApiVersionPatch(ctx, client, &version, parent)
+	return applyApiVersionPatch(ctx, client, &version, project)
 }
 
 func versionName(parent string, metadata models.Metadata) (names.Version, error) {
@@ -125,7 +126,7 @@ func applyApiVersionPatch(
 	}
 	_, err = client.UpdateApiVersion(ctx, req)
 	if err != nil {
-		return err
+		return fmt.Errorf("UpdateApiVersion: %s", err)
 	}
 	for _, specPatch := range version.Data.ApiSpecs {
 		err := applyApiSpecPatch(ctx, client, specPatch, name.String(), "")


### PR DESCRIPTION
This PR adds information to docs, error messages, info logs, and other sources of information for users of `registry apply`. It addresses some of the issues/confusion that led to #984.

Although it adds validation checks that return errors, those errors should only be returned in situations where an error would have occurred anyway. Anything that worked before should still work now. For example, when the `-f` flag isn't provided, or when `metadata.parent` isn't provided for a resource that isn't top-level, we return a more informative error.

Similarly, anything that returned an error before, should still return an error now. The only exception is the `--parent` flag can now accept project names without a location, e.g. `projects/my-project` will default to the global location `projects/my-project/locations/global`. This aligns with the behavior of the configuration value: if location isn't set it defaults to global.

## Command output samples

### Applying an API object
```
$ go run ./cmd/registry apply --parent projects/my-project -f cmd/registry/patch/testdata/resources/apis-registry.yaml
  INFO[0000] Applying apis/registry    uid=6392ee30
```

### Applying a Spec object
```
$ go run ./cmd/registry apply --parent projects/my-project -f cmd/registry/patch/testdata/resources/apis-registry-versions-v1-specs-openapi.yaml
  INFO[0000] Applying apis/registry/versions/v1/specs/openapi uid=d692383f
```
#### Invalid parent
```
$ go run ./cmd/registry apply --parent projects/my-project -f cmd/registry/patch/testdata/resources/apis-registry-versions-v1-specs-openapi.yaml
  INFO[0000] Applying apis/registry/specs/openapi uid=00afb330
 FATAL[0000] Task failed: apply apis/registry/specs/openapi (from path: cmd/registry/patch/testdata/resources/apis-registry-versions-v1-specs-openapi.yaml) error=invalid version name "projects/my-project/locations/global/apis/registry": must match "^projects/([A-Za-z0-9-.]+)/locations/global/apis/([A-Za-z0-9-.]+)/versions/([A-Za-z0-9-.]+)$" uid=00afb330
exit status 1
```
#### Missing parent
```
$ go run ./cmd/registry apply --parent projects/my-project -f cmd/registry/patch/testdata/resources/apis-registry-versions-v1-specs-openapi.yaml
 FATAL[0000] Task failed: apply specs/openapi (from path: cmd/registry/patch/testdata/resources/apis-registry-versions-v1-specs-openapi.yaml) error=metadata.parent should be set to the project-local parent path uid=d475f13d
exit status 1
```

### Applying a Manifest (project artifact) object
```
$ go run ./cmd/registry apply --parent projects/my-project -f cmd/registry/patch/testdata/artifacts/manifest.yaml
  INFO[0000] Applying artifacts/manifest uid=6604578d
```

### Applying a Complexity (spec artifact) object
```
$ go run ./cmd/registry apply --parent projects/my-project -f cmd/registry/patch/testdata/artifacts/complexity.yaml
  INFO[0000] Applying apis/registry/versions/v1/specs/openapi/artifacts/complexity uid=a7522e7d
```

### Missing `-f` flag
```
$ go run ./cmd/registry apply
Error: required flag(s) "file" not set
Usage:
  registry apply (-f FILENAME | -f -) [flags]

Flags:
  -f, --file string     file or directory containing the patch(es) to apply. Use '-' to read from standard input
  -h, --help            help for apply
  -j, --jobs int        number of actions to perform concurrently (default 10)
      --parent string   GCP project containing the API registry
  -R, --recursive       process the directory used in -f, --file recursively

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry

----
Need more help?
https://github.com/apigee/registry/wiki
exit status 1
```

### Missing `--parent` and `registry.project` configuration:
```
$ go run ./cmd/registry apply -f cmd/registry/patch/testdata/resources/apis-registry.yaml
Error: registry.project is not specified: please use --parent or set registry.project in configuration
Usage:
  registry apply (-f FILENAME | -f -) [flags]

Flags:
  -f, --file string     file or directory containing the patch(es) to apply. Use '-' to read from standard input
  -h, --help            help for apply
  -j, --jobs int        number of actions to perform concurrently (default 10)
      --parent string   GCP project containing the API registry
  -R, --recursive       process the directory used in -f, --file recursively

Global Flags:
  -c, --config string              name of a configuration profile or path to config file
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry

----
Need more help?
https://github.com/apigee/registry/wiki
exit status 1
```