### PR TITLE
Add `-o raw` support to `registry get`.

### DIFF
--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -29,6 +29,8 @@ import (
 	"github.com/apigee/registry/pkg/visitor"
 	"github.com/apigee/registry/rpc"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func Command() *cobra.Command {
@@ -101,6 +103,9 @@ func (v *getVisitor) ProjectHandler() visitor.ProjectHandler {
 			v.results = append(v.results, message.Name)
 			_, err := v.writer.Write([]byte(message.Name + "\n"))
 			return err
+		case "raw":
+			v.results = append(v.results, message)
+			return nil
 		case "yaml":
 			project, err := patch.NewProject(ctx, v.registryClient, message)
 			if err != nil {
@@ -121,6 +126,9 @@ func (v *getVisitor) ApiHandler() visitor.ApiHandler {
 			v.results = append(v.results, message.Name)
 			_, err := v.writer.Write([]byte(message.Name + "\n"))
 			return err
+		case "raw":
+			v.results = append(v.results, message)
+			return nil
 		case "yaml":
 			api, err := patch.NewApi(ctx, v.registryClient, message, v.nested)
 			if err != nil {
@@ -141,6 +149,9 @@ func (v *getVisitor) VersionHandler() visitor.VersionHandler {
 			v.results = append(v.results, message.Name)
 			_, err := v.writer.Write([]byte(message.Name + "\n"))
 			return err
+		case "raw":
+			v.results = append(v.results, message)
+			return nil
 		case "yaml":
 			version, err := patch.NewApiVersion(ctx, v.registryClient, message, v.nested)
 			if err != nil {
@@ -161,6 +172,9 @@ func (v *getVisitor) DeploymentHandler() visitor.DeploymentHandler {
 			v.results = append(v.results, message.Name)
 			_, err := v.writer.Write([]byte(message.Name + "\n"))
 			return err
+		case "raw":
+			v.results = append(v.results, message)
+			return nil
 		case "yaml":
 			deployment, err := patch.NewApiDeployment(ctx, v.registryClient, message, v.nested)
 			if err != nil {
@@ -185,6 +199,9 @@ func (v *getVisitor) SpecHandler() visitor.SpecHandler {
 			v.results = append(v.results, message.Name)
 			_, err := v.writer.Write([]byte(message.Name + "\n"))
 			return err
+		case "raw":
+			v.results = append(v.results, message)
+			return nil
 		case "contents":
 			if len(v.results) > 0 {
 				return fmt.Errorf("contents can be gotten for at most one spec")
@@ -222,6 +239,9 @@ func (v *getVisitor) ArtifactHandler() visitor.ArtifactHandler {
 			v.results = append(v.results, message.Name)
 			_, err := v.writer.Write([]byte(message.Name + "\n"))
 			return err
+		case "raw":
+			v.results = append(v.results, message)
+			return nil
 		case "contents":
 			if len(v.results) > 0 {
 				return fmt.Errorf("contents can be gotten for at most one artifact")
@@ -271,6 +291,29 @@ func (v *getVisitor) write() error {
 		}
 		_, err = v.writer.Write(bytes)
 		return err
+	}
+	if v.output == "raw" {
+		if _, err := v.writer.Write([]byte("[")); err != nil {
+			return err
+		}
+		for i, r := range v.results {
+			if i > 0 {
+				if _, err := v.writer.Write([]byte(",")); err != nil {
+					return err
+				}
+			}
+			b, err := protojson.Marshal(r.(proto.Message))
+			if err != nil {
+				return err
+			}
+			if _, err := v.writer.Write(b); err != nil {
+				return err
+			}
+		}
+		if _, err := v.writer.Write([]byte("]")); err != nil {
+			return err
+		}
+		return nil
 	}
 	if v.output == "contents" {
 		if len(v.results) == 1 {

--- a/cmd/registry/cmd/get/get_test.go
+++ b/cmd/registry/cmd/get/get_test.go
@@ -17,6 +17,7 @@ package get
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/apigee/registry/cmd/registry/compress"
@@ -125,7 +126,7 @@ func TestGetValidResources(t *testing.T) {
 	}
 	// get names for each resource
 	for _, r := range resources {
-		t.Run(r, func(t *testing.T) {
+		t.Run(r+"+name", func(t *testing.T) {
 			cmd := Command()
 			args := []string{r, "-o", "name"}
 			cmd.SetArgs(args)
@@ -141,7 +142,7 @@ func TestGetValidResources(t *testing.T) {
 	}
 	// get yaml for each resource
 	for _, r := range resources {
-		t.Run(r, func(t *testing.T) {
+		t.Run(r+"+yaml", func(t *testing.T) {
 			cmd := Command()
 			args := []string{r, "-o", "yaml"}
 			cmd.SetArgs(args)
@@ -152,6 +153,23 @@ func TestGetValidResources(t *testing.T) {
 			}
 			if len(out.Bytes()) == 0 {
 				t.Errorf("Execute() with args %v failed to return expected value(s)", args)
+			}
+		})
+	}
+	// get raw output for each resource
+	for _, r := range resources {
+		t.Run(r+"+raw", func(t *testing.T) {
+			cmd := Command()
+			args := []string{r, "-o", "raw"}
+			cmd.SetArgs(args)
+			out := bytes.NewBuffer(make([]byte, 0))
+			cmd.SetOut(out)
+			if err := cmd.Execute(); err != nil {
+				t.Errorf("Execute() with args %v returned error: %s", args, err)
+			}
+			var content []interface{}
+			if err := json.Unmarshal(out.Bytes(), &content); err != nil {
+				t.Errorf("Execute() with args %v failed to return a valid JSON array", args)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1024

This adds support for `--output raw` (`-o raw`) to `registry get` and returns a JSON array of the raw message content of matching resources. Because `registry get` can return multiple values and to simplify downstream processing of the resulting JSON, results are always returned as a JSON array.

Here are some thoughts on using `raw` as the option name:
- It's a direct (JSON) representation of the API message and matches what is returned by the generated `rpc` commands.
- It is not `--output json` because I think we should save that for a JSON-equivalent of Registry YAML.
- It is not `--output message` because I think that would suggest results were the encoded protobuf messages.