### PR TITLE
Remove ".yaml" extensions from all spec ids used in tests.

### DIFF
--- a/cmd/registry/cmd/compute/conformance/conformance_test.go
+++ b/cmd/registry/cmd/compute/conformance/conformance_test.go
@@ -69,7 +69,7 @@ func TestConformance(t *testing.T) {
 		{
 			desc:            "normal case",
 			conformancePath: filepath.Join("..", "testdata", "styleguide.yaml"),
-			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest",
+			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-openapitest",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest",
 				Kind:       "ConformanceReport",
@@ -89,7 +89,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "norefsiblings",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "No $ref siblings",
 												Description: "An object exposing a $ref property cannot be further extended with additional properties.",
 												DocUri:      "https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#no-ref-siblings",
@@ -112,7 +112,7 @@ func TestConformance(t *testing.T) {
 		{
 			desc:            "default case",
 			conformancePath: filepath.Join("..", "testdata", "styleguide-default.yaml"),
-			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-default",
+			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-openapitest-default",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-default",
 				Kind:       "ConformanceReport",
@@ -129,7 +129,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "norefsiblings",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "No $ref siblings",
 												Description: "An object exposing a $ref property cannot be further extended with additional properties.",
 											},
@@ -154,7 +154,7 @@ func TestConformance(t *testing.T) {
 		{
 			desc:            "multiple severity",
 			conformancePath: filepath.Join("..", "testdata", "styleguide-multiple-severity.yaml"),
-			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-multiple-severity",
+			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-openapitest-multiple-severity",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-multiple-severity",
 				Kind:       "ConformanceReport",
@@ -174,13 +174,13 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "operationtags",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Operation tags",
 												Description: "Operation should have non-empty tags array.",
 											},
 											{
 												RuleId:      "operationtagdefined",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Operation tag defined",
 												Description: "Operation tags should be defined in global tags.",
 											},
@@ -192,13 +192,13 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "openapitags",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "OpenAPI tags",
 												Description: "OpenAPI object should have non-empty tags array.",
 											},
 											{
 												RuleId:      "openapitagsalphabetical",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "OpenAPI tags alphabetical",
 												Description: "OpenAPI object should have alphabetical tags. This will be sorted by the name property.",
 											},
@@ -218,7 +218,7 @@ func TestConformance(t *testing.T) {
 		{
 			desc:            "multiple state",
 			conformancePath: filepath.Join("..", "testdata", "styleguide-multiple-state.yaml"),
-			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-multiple-state",
+			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-openapitest-multiple-state",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-multiple-state",
 				Kind:       "ConformanceReport",
@@ -237,7 +237,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "operationtags",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Operation tags",
 												Description: "Operation should have non-empty tags array.",
 											},
@@ -249,7 +249,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "openapitags",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "OpenAPI tags",
 												Description: "OpenAPI object should have non-empty tags array.",
 											},
@@ -272,7 +272,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "norefsiblings",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "No $ref siblings",
 												Description: "An object exposing a $ref property cannot be further extended with additional properties.",
 											},
@@ -294,7 +294,7 @@ func TestConformance(t *testing.T) {
 		{
 			desc:            "multiple linter",
 			conformancePath: filepath.Join("..", "testdata", "styleguide-multiple-linter.yaml"),
-			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-openapitest-multiple-linter",
+			getPattern:      "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-openapitest-multiple-linter",
 			wantProto: &rpc.ConformanceReport{
 				Id:         "conformance-openapitest-multiple-linter",
 				Kind:       "ConformanceReport",
@@ -313,13 +313,13 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "operationdescription",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Operation description",
 												Description: "Operation should have non-empty description.",
 											},
 											{
 												RuleId:      "infodescription",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Info description",
 												Description: "OpenAPI object info description must be present and non-empty string.",
 											},
@@ -330,7 +330,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "descriptiontags",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Description tags",
 												Description: "Ensures that description fields in the OpenAPI spec contain no tags (such as HTML tags).",
 											},
@@ -341,7 +341,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "tagdescription",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "Tag description",
 												Description: "Tags alone are not very descriptive. Give folks a bit more information to work with.",
 											},
@@ -364,7 +364,7 @@ func TestConformance(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:      "norefsiblings",
-												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+												Spec:        "projects/conformance-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 												DisplayName: "No $ref siblings",
 												Description: "An object exposing a $ref property cannot be further extended with additional properties.",
 											},
@@ -451,10 +451,11 @@ func TestConformance(t *testing.T) {
 
 			req := &rpc.CreateApiSpecRequest{
 				Parent:    v1.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),
+					Filename: "openapi.yaml",
 				},
 			}
 

--- a/cmd/registry/cmd/compute/score/score_test.go
+++ b/cmd/registry/cmd/compute/score/score_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -166,20 +166,20 @@ func TestScore(t *testing.T) {
 			desc: "all spec scores",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-report",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-report",
 					MimeType: conformanceReportType,
 					Contents: protoMarshal(conformanceReport),
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/conformance-report",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/conformance-report",
 					MimeType: conformanceReportType,
 					Contents: protoMarshal(conformanceReport),
 				},
@@ -190,19 +190,19 @@ func TestScore(t *testing.T) {
 				},
 			},
 			want: []string{
-				"projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@([a-z0-9-]+)/artifacts/score-lint-error",
-				"projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml@([a-z0-9-]+)/artifacts/score-lint-error",
+				"projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi@([a-z0-9-]+)/artifacts/score-lint-error",
+				"projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi@([a-z0-9-]+)/artifacts/score-lint-error",
 			},
 		},
 		{
 			desc: "only openapi scores with single definition",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-report",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-report",
 					MimeType: conformanceReportType,
 					Contents: protoMarshal(conformanceReport),
 				},
@@ -222,18 +222,18 @@ func TestScore(t *testing.T) {
 				},
 			},
 			want: []string{
-				"projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@([a-z0-9-]+)/artifacts/score-lint-error-openapi",
+				"projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi@([a-z0-9-]+)/artifacts/score-lint-error-openapi",
 			},
 		},
 		{
 			desc: "only proto scores with single definition",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-report",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-report",
 					MimeType: conformanceReportType,
 					Contents: protoMarshal(conformanceReport),
 				},
@@ -260,11 +260,11 @@ func TestScore(t *testing.T) {
 			desc: "proto and openapi scores with both definitions",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-report",
+					Name:     "projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-report",
 					MimeType: conformanceReportType,
 					Contents: protoMarshal(conformanceReport),
 				},
@@ -290,7 +290,7 @@ func TestScore(t *testing.T) {
 				},
 			},
 			want: []string{
-				"projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@([a-z0-9-]+)/artifacts/score-lint-error-openapi",
+				"projects/score-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi@([a-z0-9-]+)/artifacts/score-lint-error-openapi",
 				"projects/score-test/locations/global/apis/petstore/versions/1.0.1/specs/proto.yaml@([a-z0-9-]+)/artifacts/score-lint-error-proto",
 			},
 		},

--- a/cmd/registry/cmd/compute/scorecard/scorecard_test.go
+++ b/cmd/registry/cmd/compute/scorecard/scorecard_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -122,20 +122,20 @@ func TestScoreCard(t *testing.T) {
 			desc: "all spec scores",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: scoreType,
 					Contents: protoMarshal(scoreLintError),
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/score-lint-error",
 					MimeType: scoreType,
 					Contents: protoMarshal(scoreLintError),
 				},
@@ -146,19 +146,19 @@ func TestScoreCard(t *testing.T) {
 				},
 			},
 			want: []string{
-				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@([a-z0-9-]+)/artifacts/scorecard-lint-summary",
-				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml@([a-z0-9-]+)/artifacts/scorecard-lint-summary",
+				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi@([a-z0-9-]+)/artifacts/scorecard-lint-summary",
+				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi@([a-z0-9-]+)/artifacts/scorecard-lint-summary",
 			},
 		},
 		{
 			desc: "only openapi scores with single definition",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: scoreType,
 					Contents: protoMarshal(scoreLintError),
 				},
@@ -178,18 +178,18 @@ func TestScoreCard(t *testing.T) {
 				},
 			},
 			want: []string{
-				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@([a-z0-9-]+)/artifacts/scorecard-lint-summary-openapi",
+				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi@([a-z0-9-]+)/artifacts/scorecard-lint-summary-openapi",
 			},
 		},
 		{
 			desc: "only proto scores with single definition",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: scoreType,
 					Contents: protoMarshal(scoreLintError),
 				},
@@ -216,11 +216,11 @@ func TestScoreCard(t *testing.T) {
 			desc: "proto and openapi scores with both definitions",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: scoreType,
 					Contents: protoMarshal(scoreLintError),
 				},
@@ -246,7 +246,7 @@ func TestScoreCard(t *testing.T) {
 				},
 			},
 			want: []string{
-				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@([a-z0-9-]+)/artifacts/scorecard-lint-summary-openapi",
+				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi@([a-z0-9-]+)/artifacts/scorecard-lint-summary-openapi",
 				"projects/scorecard-test/locations/global/apis/petstore/versions/1.0.1/specs/proto.yaml@([a-z0-9-]+)/artifacts/scorecard-lint-summary-proto",
 			},
 		},

--- a/cmd/registry/cmd/resolve/resolve_test.go
+++ b/cmd/registry/cmd/resolve/resolve_test.go
@@ -73,9 +73,9 @@ func TestResolve(t *testing.T) {
 			dryRun:       false,
 			listParent:   "projects/controller-demo/locations/global/apis/petstore/versions/-/specs/-",
 			want: []string{
-				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
-				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity",
-				"projects/controller-demo/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity",
+				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
+				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity",
+				"projects/controller-demo/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity",
 			},
 		},
 		{
@@ -84,9 +84,9 @@ func TestResolve(t *testing.T) {
 			dryRun:       false,
 			listParent:   "projects/controller-demo/locations/global/apis/petstore/versions/-/specs/-",
 			want: []string{
-				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/test-receipt-artifact",
-				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/test-receipt-artifact",
-				"projects/controller-demo/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/test-receipt-artifact",
+				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/test-receipt-artifact",
+				"projects/controller-demo/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/test-receipt-artifact",
+				"projects/controller-demo/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/test-receipt-artifact",
 			},
 		},
 		{
@@ -183,7 +183,7 @@ func TestResolve(t *testing.T) {
 
 			req := &rpc.CreateApiSpecRequest{
 				Parent:    v1.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),
@@ -191,7 +191,7 @@ func TestResolve(t *testing.T) {
 			}
 			s, err := client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
 				Parent:    v1.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),
@@ -217,7 +217,7 @@ func TestResolve(t *testing.T) {
 
 			req = &rpc.CreateApiSpecRequest{
 				Parent:    v2.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),
@@ -225,7 +225,7 @@ func TestResolve(t *testing.T) {
 			}
 			s, err = client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
 				Parent:    v2.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),
@@ -238,7 +238,7 @@ func TestResolve(t *testing.T) {
 
 			req = &rpc.CreateApiSpecRequest{
 				Parent:    v3.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),
@@ -246,7 +246,7 @@ func TestResolve(t *testing.T) {
 			}
 			s, err = client.CreateApiSpec(ctx, &rpc.CreateApiSpecRequest{
 				Parent:    v3.Name,
-				ApiSpecId: "openapi.yaml",
+				ApiSpecId: "openapi",
 				ApiSpec: &rpc.ApiSpec{
 					MimeType: "application/x.openapi+gzip;version=3.0.0",
 					Contents: buf.Bytes(),

--- a/cmd/registry/cmd/upload/csv_test.go
+++ b/cmd/registry/cmd/upload/csv_test.go
@@ -71,22 +71,22 @@ func TestUploadCSV(t *testing.T) {
 			},
 			want: []*rpc.ApiSpec{
 				{
-					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2beta2/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2beta2/specs/openapi", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: cloudtasksBeta,
 				},
 				{
-					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2/specs/openapi", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: cloudtasksGA,
 				},
 				{
-					Name:     fmt.Sprintf("projects/%s/locations/global/apis/datastore/versions/v1beta1/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/datastore/versions/v1beta1/specs/openapi", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: datastoreBeta,
 				},
 				{
-					Name:     fmt.Sprintf("projects/%s/locations/global/apis/datastore/versions/v1/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/datastore/versions/v1/specs/openapi", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: datastoreGA,
 				},
@@ -100,7 +100,7 @@ func TestUploadCSV(t *testing.T) {
 			},
 			want: []*rpc.ApiSpec{
 				{
-					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2/specs/openapi.yaml", testProject),
+					Name:     fmt.Sprintf("projects/%s/locations/global/apis/cloudtasks/versions/v2/specs/openapi", testProject),
 					MimeType: gzipOpenAPIv3,
 					Contents: cloudtasksGA,
 				},

--- a/cmd/registry/cmd/upload/testdata/csv/multiple-specs.csv
+++ b/cmd/registry/cmd/upload/testdata/csv/multiple-specs.csv
@@ -1,5 +1,5 @@
 api_id,version_id,spec_id,filepath
-cloudtasks,v2beta2,openapi.yaml,testdata/csv/cloudtasks/v2beta2/openapi.yaml
-cloudtasks,v2,openapi.yaml,testdata/csv/cloudtasks/v2/openapi.yaml
-datastore,v1beta1,openapi.yaml,testdata/csv/datastore/v1beta1/openapi.yaml
-datastore,v1,openapi.yaml,testdata/csv/datastore/v1/openapi.yaml
+cloudtasks,v2beta2,openapi,testdata/csv/cloudtasks/v2beta2/openapi.yaml
+cloudtasks,v2,openapi,testdata/csv/cloudtasks/v2/openapi.yaml
+datastore,v1beta1,openapi,testdata/csv/datastore/v1beta1/openapi.yaml
+datastore,v1,openapi,testdata/csv/datastore/v1/openapi.yaml

--- a/cmd/registry/cmd/upload/testdata/csv/out-of-order-columns.csv
+++ b/cmd/registry/cmd/upload/testdata/csv/out-of-order-columns.csv
@@ -1,2 +1,2 @@
 filepath,spec_id,version_id,api_id
-testdata/csv/cloudtasks/v2/openapi.yaml,openapi.yaml,v2,cloudtasks
+testdata/csv/cloudtasks/v2/openapi.yaml,openapi,v2,cloudtasks

--- a/cmd/registry/cmd/upload/testdata/discovery/apigeeregistry-v1.json
+++ b/cmd/registry/cmd/upload/testdata/discovery/apigeeregistry-v1.json
@@ -1141,7 +1141,7 @@
                               "location": "path",
                               "required": true,
                               "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
-                              "description": "Required. The name of the spec revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8`",
+                              "description": "Required. The name of the spec revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi@c7cfa2a8`",
                               "type": "string"
                             }
                           },

--- a/cmd/registry/cmd/upload/testdata/protos/google/cloud/apigeeregistry/v1/registry_service.proto
+++ b/cmd/registry/cmd/upload/testdata/protos/google/cloud/apigeeregistry/v1/registry_service.proto
@@ -830,7 +830,7 @@ message DeleteApiSpecRevisionRequest {
   // with a revision ID explicitly included.
   //
   // Example:
-  // `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8`
+  // `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi@c7cfa2a8`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -102,7 +102,11 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	name := filepath.Base(task.Spec.GetName())
+	filename := task.Spec.GetFilename()
+	if filename == "" {
+		return fmt.Errorf("%s does not specify a filename", task.Spec.GetName())
+	}
+	name := filepath.Base(filename)
 	defer os.RemoveAll(root)
 
 	if types.IsZipArchive(task.Spec.GetMimeType()) {

--- a/cmd/registry/conformance/conformance-task_test.go
+++ b/cmd/registry/conformance/conformance-task_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const project = "demo"
-const specName = "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"
+const specName = "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"
 const revisionId = "abcdef"
 const styleguideId = "openapi-test"
 

--- a/cmd/registry/controller/controller-error-path_test.go
+++ b/cmd/registry/controller/controller-error-path_test.go
@@ -181,15 +181,15 @@ func TestControllerErrors(t *testing.T) {
 
 			seed := []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 			}

--- a/cmd/registry/controller/controller-timestamp_test.go
+++ b/cmd/registry/controller/controller-timestamp_test.go
@@ -189,31 +189,31 @@ func TestTimestampArtifacts(t *testing.T) {
 			desc: "partially existing artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType:           gzipOpenAPIv3,
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 2)),
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 				},
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 				},
 			},
 		},
@@ -221,38 +221,38 @@ func TestTimestampArtifacts(t *testing.T) {
 			desc: "outdated artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType:           gzipOpenAPIv3,
 					RevisionUpdateTime: timestamppb.New(time.Now()),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 3)),
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 				},
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 				},
 			},
 		},
@@ -260,45 +260,45 @@ func TestTimestampArtifacts(t *testing.T) {
 			desc: "not recent enough artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType:           gzipOpenAPIv3,
 					RevisionUpdateTime: timestamppb.New(time.Now()),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType:           gzipOpenAPIv3,
 					RevisionUpdateTime: timestamppb.New(time.Now()),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					MimeType:           gzipOpenAPIv3,
 					RevisionUpdateTime: timestamppb.New(time.Now()),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 				},
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 				},
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 				},
 			},
 		},
@@ -351,15 +351,15 @@ func TestTimestampAggregateArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// test api 1
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
@@ -368,15 +368,15 @@ func TestTimestampAggregateArtifacts(t *testing.T) {
 				},
 				// test api 2
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
@@ -385,7 +385,7 @@ func TestTimestampAggregateArtifacts(t *testing.T) {
 				},
 				// Update underlying spec to make artifact outdated
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * 4)),
 				},
 			},
@@ -401,15 +401,15 @@ func TestTimestampAggregateArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// test api 1
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
@@ -418,15 +418,15 @@ func TestTimestampAggregateArtifacts(t *testing.T) {
 				},
 				// test api 2
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
@@ -494,50 +494,50 @@ func TestTimestampDerivedArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// version 1.0.0
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/summary",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/summary",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 2)),
 				},
 				// version 1.0.1
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/summary",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/summary",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 2)),
 				},
 				// version 1.1.0
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/summary",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/summary",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 2)),
 				},
 				// Make some artifacts outdated from the above setup
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 4)),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 4)),
 				},
 			},
@@ -545,16 +545,16 @@ func TestTimestampDerivedArtifacts(t *testing.T) {
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/summary",
 				},
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/summary",
 				},
 			},
 		},
@@ -563,41 +563,41 @@ func TestTimestampDerivedArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// version 1.0.0
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/summary",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/summary",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 				// version 1.0.1
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/summary",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/summary",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 				// version 1.1.0
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity",
 					UpdateTime: timestamppb.Now(),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/summary",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/summary",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 			},
@@ -605,23 +605,23 @@ func TestTimestampDerivedArtifacts(t *testing.T) {
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/summary",
 				},
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/summary",
 				},
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/summary",
 				},
 			},
 		},
@@ -674,29 +674,29 @@ func TestRefreshArtifacts(t *testing.T) {
 			desc: "non-existing artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-receipt",
+					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-receipt",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score-receipt",
+					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/score-receipt",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score-receipt",
+					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/score-receipt",
 					RequiresReceipt:   true,
 				},
 			},
@@ -705,22 +705,22 @@ func TestRefreshArtifacts(t *testing.T) {
 			desc: "existing valid artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-receipt",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-receipt",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score-receipt",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/score-receipt",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score-receipt",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/score-receipt",
 				},
 			},
 			want: nil,
@@ -729,44 +729,44 @@ func TestRefreshArtifacts(t *testing.T) {
 			desc: "existing invalid artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * -5)),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * -5)),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * -5)),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-receipt",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-receipt",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * -3)),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score-receipt",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/score-receipt",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * -3)),
 				},
 				&rpc.Artifact{
-					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score-receipt",
+					Name:       "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/score-receipt",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * -3)),
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-receipt",
+					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-receipt",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score-receipt",
+					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/score-receipt",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score-receipt",
+					Command:           "registry compute score projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/score-receipt",
 					RequiresReceipt:   true,
 				},
 			},
@@ -775,25 +775,25 @@ func TestRefreshArtifacts(t *testing.T) {
 			desc: "existing valid artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * -2)),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * -2)),
 				},
 				&rpc.ApiSpec{
-					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:               "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					RevisionUpdateTime: timestamppb.New(time.Now().Add(time.Second * -2)),
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-receipt",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-receipt",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/score-receipt",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/score-receipt",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/score-receipt",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/score-receipt",
 				},
 			},
 			want: nil,

--- a/cmd/registry/controller/controller_test.go
+++ b/cmd/registry/controller/controller_test.go
@@ -79,14 +79,14 @@ func TestArtifacts(t *testing.T) {
 			desc: "single spec",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 				},
 			},
 		},
@@ -94,30 +94,30 @@ func TestArtifacts(t *testing.T) {
 			desc: "multiple specs",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 				&rpc.ApiSpec{
-					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name:     "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 					MimeType: gzipOpenAPIv3,
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 				},
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 				},
 				{
-					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml --linter gnostic",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Command:           "registry compute lint projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi --linter gnostic",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 				},
 			},
 		},
@@ -189,23 +189,23 @@ func TestAggregateArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// test api 1
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/test-api-1/versions/1.1.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/test-api-1/versions/1.0.1/specs/openapi",
 				},
 				// test api 2
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/test-api-2/versions/1.1.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/test-api-2/versions/1.0.1/specs/openapi",
 				},
 			},
 			want: []*Action{
@@ -287,47 +287,47 @@ func TestDerivedArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// version 1.0.0
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 				},
 				// version 1.0.1
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity",
 				},
 				// version 1.1.0
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity",
 				},
 			},
 			want: []*Action{
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/summary",
 				},
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/summary",
 				},
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/summary",
 				},
 			},
 		},
@@ -336,27 +336,27 @@ func TestDerivedArtifacts(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// version 1.0.0
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 				},
 				// version 1.0.1
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity",
 				},
 				// version 1.1.0
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/complexity",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/complexity",
 				},
 			},
 			want: []*Action{
 				{
 					Command: fmt.Sprintf(
 						"registry compute summary %s %s",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/lint-gnostic",
-						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/complexity"),
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/summary",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/lint-gnostic",
+						"projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/complexity"),
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/summary",
 				},
 			},
 		},
@@ -429,29 +429,29 @@ func TestReceiptArtifacts(t *testing.T) {
 			desc: "create artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "command projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/custom-artifact",
+					Command:           "command projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/custom-artifact",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "command projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/custom-artifact",
+					Command:           "command projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/custom-artifact",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "command projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/custom-artifact",
+					Command:           "command projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/custom-artifact",
 					RequiresReceipt:   true,
 				},
 			},
@@ -523,13 +523,13 @@ func TestReceiptAggArtifacts(t *testing.T) {
 			desc: "create artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			want: []*Action{
@@ -544,17 +544,17 @@ func TestReceiptAggArtifacts(t *testing.T) {
 			desc: "updated artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.Artifact{
 					Name: "projects/controller-test/locations/global/artifacts/search-index",
 				},
 				// Add a new spec to make the artifact outdated
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			want: []*Action{
@@ -637,29 +637,29 @@ func TestMultipleEntitiesArtifacts(t *testing.T) {
 					Contents: protoMarshal(styleguide),
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 			},
@@ -668,13 +668,13 @@ func TestMultipleEntitiesArtifacts(t *testing.T) {
 			desc: "outdated spec artifacts",
 			seed: []seeder.RegistryResource{
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-registry-styleguide",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/conformance-registry-styleguide",
 				},
 				&rpc.Artifact{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/conformance-registry-styleguide",
 				},
 				//Update styleguide definition to make sure conformance artifacts are outdated
 				&rpc.Artifact{
@@ -685,18 +685,18 @@ func TestMultipleEntitiesArtifacts(t *testing.T) {
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 			},
@@ -710,24 +710,24 @@ func TestMultipleEntitiesArtifacts(t *testing.T) {
 					Contents: protoMarshal(styleguide),
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiVersion{
 					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			want: []*Action{
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 				{
-					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
-					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml/artifacts/conformance-registry-styleguide",
+					Command:           "registry compute conformance projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
+					GeneratedResource: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi/artifacts/conformance-registry-styleguide",
 					RequiresReceipt:   true,
 				},
 			},
@@ -829,13 +829,13 @@ func TestMaxActions(t *testing.T) {
 			desc: "generated more than maxActions",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			maxActions: 2,
@@ -844,13 +844,13 @@ func TestMaxActions(t *testing.T) {
 			desc: "generated less than maxActions",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.0.1/specs/openapi",
 				},
 				&rpc.ApiSpec{
-					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi.yaml",
+					Name: "projects/controller-test/locations/global/apis/petstore/versions/1.1.0/specs/openapi",
 				},
 			},
 			maxActions: 4,

--- a/cmd/registry/controller/parser_test.go
+++ b/cmd/registry/controller/parser_test.go
@@ -44,22 +44,22 @@ func TestGenerateCommand(t *testing.T) {
 		{
 			desc:         "spec reference",
 			action:       "compute lint $resource.spec --linter=gnostic",
-			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
-			want:         "compute lint projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml --linter=gnostic",
+			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
+			want:         "compute lint projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi --linter=gnostic",
 		},
 		{
 			desc:         "multiple args",
 			action:       "compute score $resource.spec/artifacts/complexity $resource.spec/artifacts/vocabulary",
-			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score",
+			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score",
 			want: fmt.Sprintf("compute score %s %s",
-				"projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
-				"projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/vocabulary"),
+				"projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
+				"projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/vocabulary"),
 		},
 		{
 			desc:         "extended reference",
 			action:       "compute score $resource.spec/artifacts/complexity",
-			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-			want:         "compute score projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+			want:         "compute score projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 		},
 	}
 
@@ -85,17 +85,17 @@ func TestGenerateCommandError(t *testing.T) {
 		{
 			desc:         "incorrect reference",
 			action:       "compute lintstats $resource.apispec",
-			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc:         "incorrect format",
 			action:       "compute lintstats $resourceversion",
-			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc:         "invalid reference",
 			action:       "compute lintstats $resource.artifact",
-			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			resourceName: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 	}
 
@@ -227,7 +227,7 @@ func TestValidateGeneratedResourceEntryError(t *testing.T) {
 		{
 			desc: "no target resource name",
 			generatedResource: &rpc.GeneratedResource{
-				Pattern: "apis/-/versions/-/specs/-", // Correct pattern: apis/-/versions/-/specs/openapi.yaml
+				Pattern: "apis/-/versions/-/specs/-", // Correct pattern: apis/-/versions/-/specs/openapi
 				Dependencies: []*rpc.Dependency{
 					{
 						Pattern: "$resource.spec",

--- a/cmd/registry/patch/patch_test.go
+++ b/cmd/registry/patch/patch_test.go
@@ -604,7 +604,7 @@ func TestMessageArtifactPatches(t *testing.T) {
 										RuleReports: []*rpc.RuleReport{
 											{
 												RuleId:     "no-ref-siblings",
-												Spec:       "projects/demo/locations/global/apis/petstore/versions/v1/specs/openapi.yaml",
+												Spec:       "projects/demo/locations/global/apis/petstore/versions/v1/specs/openapi",
 												File:       "openapi.yaml",
 												Suggestion: "",
 												Location: &rpc.LintLocation{

--- a/cmd/registry/patch/testdata/artifacts/conformancereport.yaml
+++ b/cmd/registry/patch/testdata/artifacts/conformancereport.yaml
@@ -12,7 +12,7 @@ data:
             - severity: ERROR
               ruleReports:
                 - ruleId: no-ref-siblings
-                  spec: projects/demo/locations/global/apis/petstore/versions/v1/specs/openapi.yaml
+                  spec: projects/demo/locations/global/apis/petstore/versions/v1/specs/openapi
                   file: openapi.yaml
                   suggestion: ""
                   location:

--- a/cmd/registry/patterns/parser.go
+++ b/cmd/registry/patterns/parser.go
@@ -146,7 +146,7 @@ func GetReferenceEntityValue(resourcePattern string, referred ResourceName) (str
 	// Reads the sourcePattern and returns the entity value for the $resource reference
 	// Example:
 	// pattern: $resource.api/versions/-/specs/-
-	// resource: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"
+	// resource: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"
 	// returns "projects/demo/locations/global/apis/petstore"
 
 	_, entityType, err := GetReferenceEntityType(resourcePattern)
@@ -189,12 +189,12 @@ func GetReferenceEntityValue(resourcePattern string, referred ResourceName) (str
 func FullResourceNameFromParent(resourcePattern string, parent string) (ResourceName, error) {
 	// Derives the resource name from the provided resourcePattern and it's parent.
 	// Example:
-	// 1) resourcePattern: projects/demo/locations/global/apis/-/versions/-/specs/openapi.yaml
+	// 1) resourcePattern: projects/demo/locations/global/apis/-/versions/-/specs/openapi
 	//    parent: projects/demo/locations/global/apis/petstore/versions/1.0.0
-	//    returns projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml
+	//    returns projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi
 	// 2) resourcePattern: projects/demo/locations/global/apis/petstore/versions/-/specs/-/artifacts/custom-artifact
-	//    parent: projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml
-	//    returns projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/custom-artifact
+	//    parent: projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi
+	//    returns projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/custom-artifact
 
 	parsedResourcePattern, err := ParseResourcePattern(resourcePattern)
 	if err != nil {

--- a/cmd/registry/patterns/parser_test.go
+++ b/cmd/registry/patterns/parser_test.go
@@ -166,22 +166,22 @@ func TestFullResourceNameFromParent(t *testing.T) {
 		},
 		{
 			desc:            "spec pattern",
-			resourcePattern: "projects/demo/locations/global/apis/-/versions/-/specs/openapi.yaml",
+			resourcePattern: "projects/demo/locations/global/apis/-/versions/-/specs/openapi",
 			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0",
-			want:            generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
+			want:            generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
 		},
 		{
 			desc:            "specrev pattern",
-			resourcePattern: "projects/demo/locations/global/apis/-/versions/-/specs/openapi.yaml@rev",
+			resourcePattern: "projects/demo/locations/global/apis/-/versions/-/specs/openapi@rev",
 			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0",
-			want:            generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@rev"),
+			want:            generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@rev"),
 		},
 		{
 			desc:            "artifact pattern",
 			resourcePattern: "projects/demo/locations/global/apis/-/versions/-/specs/-/artifacts/complexity",
-			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 			want: ArtifactName{
-				Name: generateArtifact(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity"),
+				Name: generateArtifact(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity"),
 			},
 		},
 	}
@@ -208,12 +208,12 @@ func TestFullResourceNameFromParentError(t *testing.T) {
 		{
 			desc:            "incorrect keywords",
 			resourcePattern: "projects/demo/locations/global/apis/-/versions/-/apispecs/-",
-			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc:            "incorrect pattern",
 			resourcePattern: "projects/demo/locations/global/apis/-/specs/-",
-			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			parent:          "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 	}
 
@@ -237,37 +237,37 @@ func TestGetReferenceEntityValue(t *testing.T) {
 		{
 			desc:            "api group",
 			resourcePattern: "$resource.api/versions/-/specs/-",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
 			want:            "projects/demo/locations/global/apis/petstore",
 		},
 		{
 			desc:            "version group",
 			resourcePattern: "$resource.version/specs/-",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
 			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0",
 		},
 		{
 			desc:            "spec group",
 			resourcePattern: "$resource.spec",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
-			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
+			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc:            "spec revision group",
 			resourcePattern: "$resource.spec",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@rev"),
-			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@rev",
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@rev"),
+			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@rev",
 		},
 		{
 			desc:            "artifact group",
 			resourcePattern: "$resource.artifact",
-			referred:        ArtifactName{Name: generateArtifact(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")},
-			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic",
+			referred:        ArtifactName{Name: generateArtifact(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic")},
+			want:            "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic",
 		},
 		{
 			desc:            "no group",
 			resourcePattern: "apis/-/versions/-/specs/-",
-			referred:        ArtifactName{Name: generateArtifact(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-gnostic")},
+			referred:        ArtifactName{Name: generateArtifact(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-gnostic")},
 			want:            "default",
 		},
 	}
@@ -294,17 +294,17 @@ func TestGetReferenceEntityValueError(t *testing.T) {
 		{
 			desc:            "typo",
 			resourcePattern: "$resource.apis/versions/-/specs/-",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
 		},
 		{
 			desc:            "incorrect reference",
 			resourcePattern: "$resource.name/versions/-/specs/-",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
 		},
 		{
 			desc:            "incorrect resourceKW",
 			resourcePattern: "$resources.api/versions/-/specs/-",
-			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml"),
+			referred:        generateSpecName(t, "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi"),
 		},
 	}
 

--- a/cmd/registry/patterns/resources.go
+++ b/cmd/registry/patterns/resources.go
@@ -28,7 +28,7 @@ const ResourceUpdateThreshold = time.Second * 2
 
 // This interface is used to describe generic resource names
 // Example:
-// projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml
+// projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi
 // projects/demo/locations/global/apis/-/versions/-/specs/-/artifacts/-
 type ResourceName interface {
 	Artifact() string

--- a/cmd/registry/scoring/parser_test.go
+++ b/cmd/registry/scoring/parser_test.go
@@ -1736,8 +1736,8 @@ func TestGenerateCombinedPattern(t *testing.T) {
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/-/versions/-/specs/-",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc: "spec pattern collection input",
@@ -1752,8 +1752,8 @@ func TestGenerateCombinedPattern(t *testing.T) {
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/petstore/versions/-/specs/-",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc: "specific api match collection input",
@@ -1768,7 +1768,7 @@ func TestGenerateCombinedPattern(t *testing.T) {
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/test/versions/-/specs/-",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 			wantErr:      true,
 		},
 		{
@@ -1776,8 +1776,8 @@ func TestGenerateCombinedPattern(t *testing.T) {
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/-/versions/1.0.0/specs/-",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc: "specific version match collection input",
@@ -1792,31 +1792,31 @@ func TestGenerateCombinedPattern(t *testing.T) {
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/-/versions/2.0.0/specs/-",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 			wantErr:      true,
 		},
 		{
 			desc: "specific spec match spec input",
 			targetPattern: &rpc.ResourcePattern{
-				Pattern: "apis/-/versions/-/specs/openapi.yaml",
+				Pattern: "apis/-/versions/-/specs/openapi",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
-			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
+			wantPattern:  "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 		{
 			desc: "specific spec match collection input",
 			targetPattern: &rpc.ResourcePattern{
-				Pattern: "apis/-/versions/-/specs/openapi.yaml",
+				Pattern: "apis/-/versions/-/specs/openapi",
 			},
 			inputPattern: "projects/pattern-test/locations/global/apis/-/versions/-/specs/-",
-			wantPattern:  "projects/pattern-test/locations/global/apis/-/versions/-/specs/openapi.yaml",
+			wantPattern:  "projects/pattern-test/locations/global/apis/-/versions/-/specs/openapi",
 		},
 		{
 			desc: "specific spec no match",
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/-/versions/-/specs/swagger.yaml",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 			wantErr:      true,
 		},
 		{
@@ -1824,7 +1824,7 @@ func TestGenerateCombinedPattern(t *testing.T) {
 			targetPattern: &rpc.ResourcePattern{
 				Pattern: "apis/-/versions/-/specs/-/artifacts/lint-spectral",
 			},
-			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			inputPattern: "projects/pattern-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 			wantErr:      true,
 		},
 		{

--- a/cmd/registry/scoring/score_test.go
+++ b/cmd/registry/scoring/score_test.go
@@ -140,7 +140,7 @@ func TestCalculateScore(t *testing.T) {
 			desc: "nonexistent score ScoreArtifact",
 			seed: []seeder.RegistryResource{
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -200,7 +200,7 @@ func TestCalculateScore(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -218,7 +218,7 @@ func TestCalculateScore(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: []byte{},
 				},
@@ -292,13 +292,13 @@ func TestCalculateScore(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: []byte{},
 				},
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -334,7 +334,7 @@ func TestCalculateScore(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: []byte{},
 				},
@@ -365,7 +365,7 @@ func TestCalculateScore(t *testing.T) {
 				},
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -427,7 +427,7 @@ func TestCalculateScore(t *testing.T) {
 
 			resource := patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			}
 
@@ -447,7 +447,7 @@ func TestCalculateScore(t *testing.T) {
 			//fetch score artifact and check the value
 			scoreArtifact, err := getArtifact(
 				ctx, artifactClient,
-				"projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error", true)
+				"projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error", true)
 			if err != nil {
 				t.Errorf("failed to get the result scoreArtifact from registry")
 			}
@@ -490,7 +490,7 @@ func TestProcessScoreFormula(t *testing.T) {
 
 	seed := []seeder.RegistryResource{
 		&rpc.Artifact{
-			Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+			Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 			MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 			Contents: protoMarshal(&rpc.Lint{
 				Name: "openapi.yaml",
@@ -521,7 +521,7 @@ func TestProcessScoreFormula(t *testing.T) {
 	}
 	resource := patterns.SpecResource{
 		Spec: &rpc.ApiSpec{
-			Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 	}
 
@@ -553,7 +553,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			desc: "invalid reference",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			formula: &rpc.ScoreFormula{
@@ -564,7 +564,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -572,7 +572,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			desc: "invalid extended pattern",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			formula: &rpc.ScoreFormula{
@@ -583,7 +583,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -591,7 +591,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			desc: "missing artifact",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			formula: &rpc.ScoreFormula{
@@ -602,7 +602,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -610,7 +610,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			desc: "unsupported artifact type",
 			seed: []seeder.RegistryResource{
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-definition",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-definition",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.applications.v1alpha1.ScoreDefinition",
 					Contents: protoMarshal(&rpc.ScoreDefinition{
 						Id:             "dummy-score-definition",
@@ -623,7 +623,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			formula: &rpc.ScoreFormula{},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -631,7 +631,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			desc: "invalid expression",
 			seed: []seeder.RegistryResource{
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -656,7 +656,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -664,7 +664,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			desc: "missing expression",
 			seed: []seeder.RegistryResource{
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -688,7 +688,7 @@ func TestProcessScoreFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -756,7 +756,7 @@ func TestProcessRollUpFormula(t *testing.T) {
 	seed := []seeder.RegistryResource{
 		// lint artifact
 		&rpc.Artifact{
-			Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+			Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 			MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 			Contents: protoMarshal(&rpc.Lint{
 				Name: "openapi.yaml",
@@ -777,7 +777,7 @@ func TestProcessRollUpFormula(t *testing.T) {
 		},
 		// complexity artifact
 		&rpc.Artifact{
-			Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+			Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 			MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 			Contents: protoMarshal(&metrics.Complexity{
 				GetCount:    1,
@@ -814,7 +814,7 @@ func TestProcessRollUpFormula(t *testing.T) {
 	}
 	resource := patterns.SpecResource{
 		Spec: &rpc.ApiSpec{
-			Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		},
 	}
 
@@ -845,7 +845,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			desc: "missing score_formulas",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			formula: &rpc.RollUpFormula{
@@ -853,7 +853,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -861,7 +861,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			desc: "missing rollup_expression",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			formula: &rpc.RollUpFormula{
@@ -884,7 +884,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -893,7 +893,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -914,7 +914,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -945,7 +945,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -954,7 +954,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -975,7 +975,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -1006,7 +1006,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},
@@ -1014,7 +1014,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			desc: "invalid reference_id",
 			seed: []seeder.RegistryResource{
 				&rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			formula: &rpc.RollUpFormula{
@@ -1038,7 +1038,7 @@ func TestProcessRollUpFormulaError(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 		},

--- a/cmd/registry/scoring/scorecard_test.go
+++ b/cmd/registry/scoring/scorecard_test.go
@@ -57,7 +57,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -73,7 +73,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -125,7 +125,7 @@ func TestCalculateScoreCard(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -141,7 +141,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -157,7 +157,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -265,7 +265,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -301,7 +301,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -317,7 +317,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -369,7 +369,7 @@ func TestCalculateScoreCard(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -405,7 +405,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -421,7 +421,7 @@ func TestCalculateScoreCard(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -517,7 +517,7 @@ func TestCalculateScoreCard(t *testing.T) {
 
 			resource := patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			}
 
@@ -537,7 +537,7 @@ func TestCalculateScoreCard(t *testing.T) {
 			//fetch score artifact and check the value
 			scoreCardArtifact, err := getArtifact(
 				ctx, artifactClient,
-				"projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality", true)
+				"projects/score-card-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality", true)
 			if err != nil {
 				t.Errorf("failed to get the result scoreCardArtifact from registry")
 			}
@@ -572,7 +572,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -588,7 +588,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -604,7 +604,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -641,7 +641,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -686,7 +686,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -722,7 +722,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -738,7 +738,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -755,7 +755,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -800,7 +800,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -836,7 +836,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -852,7 +852,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -869,7 +869,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -914,7 +914,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -930,7 +930,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -966,7 +966,7 @@ func TestProcessScorePatterns(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -983,7 +983,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -1069,7 +1069,7 @@ func TestProcessScorePatterns(t *testing.T) {
 			artifactClient := &RegistryArtifactClient{RegistryClient: registryClient}
 
 			//fetch the ScoreCard artifact
-			scoreCardArtifact, err := getArtifact(ctx, artifactClient, "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality", false)
+			scoreCardArtifact, err := getArtifact(ctx, artifactClient, "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality", false)
 			if err != nil {
 				t.Errorf("failed to fetch the scoreCardArtifact from setup: %s", err)
 			}
@@ -1119,7 +1119,7 @@ func TestProcessScorePatternsError(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -1154,7 +1154,7 @@ func TestProcessScorePatternsError(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -1215,7 +1215,7 @@ func TestProcessScorePatternsError(t *testing.T) {
 
 			resource := patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			}
 

--- a/cmd/registry/scoring/scoring-timestamp_test.go
+++ b/cmd/registry/scoring/scoring-timestamp_test.go
@@ -145,7 +145,7 @@ func TestTimestampCalculateScore(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -190,7 +190,7 @@ func TestTimestampCalculateScore(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents:   []byte{},
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 3)),
@@ -203,7 +203,7 @@ func TestTimestampCalculateScore(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -248,7 +248,7 @@ func TestTimestampCalculateScore(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents:   []byte{},
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
@@ -281,7 +281,7 @@ func TestTimestampCalculateScore(t *testing.T) {
 
 			resource := patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			}
 
@@ -299,7 +299,7 @@ func TestTimestampCalculateScore(t *testing.T) {
 			//fetch score artifact and check the value
 			scoreArtifact, err := getArtifact(
 				ctx, client,
-				"projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error", true)
+				"projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error", true)
 			if err != nil {
 				t.Errorf("failed to get the result scoreArtifact from registry")
 			}
@@ -332,13 +332,13 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: []byte{},
 				},
 				// score  formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -357,7 +357,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -373,7 +373,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -392,7 +392,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents:   []byte{},
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 3)),
@@ -400,7 +400,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -415,12 +415,12 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 				},
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -439,7 +439,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -454,7 +454,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -473,14 +473,14 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 3)),
 				},
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -495,7 +495,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -514,14 +514,14 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -536,7 +536,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score formula artifact
 				&rpc.Artifact{
-					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -555,14 +555,14 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -584,7 +584,7 @@ func TestProcessScoreFormulaTimestamp(t *testing.T) {
 			}
 
 			//fetch score artifact
-			scoreArtifact, err := getArtifact(ctx, client, "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error", false)
+			scoreArtifact, err := getArtifact(ctx, client, "projects/score-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error", false)
 			if err != nil {
 				t.Errorf("failed to fetch the scoreArtifact from setup: %s", err)
 			}
@@ -619,12 +619,12 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 				},
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -645,7 +645,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				//  complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -657,7 +657,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -672,7 +672,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -693,12 +693,12 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -710,7 +710,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -725,7 +725,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -747,7 +747,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -759,14 +759,14 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 3)),
 				},
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: true,
@@ -781,12 +781,12 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 				},
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -807,7 +807,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -819,7 +819,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -834,7 +834,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -855,12 +855,12 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -872,7 +872,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -887,7 +887,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -909,7 +909,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -921,14 +921,14 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 3)),
 				},
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -943,7 +943,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// lint artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/lint-spectral",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/lint-spectral",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint",
 					Contents: protoMarshal(&rpc.Lint{
 						Name: "openapi.yaml",
@@ -965,7 +965,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// complexity artifact
 				&rpc.Artifact{
-					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/complexity",
+					Name:     "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/complexity",
 					MimeType: "application/octet-stream;type=gnostic.metrics.Complexity",
 					Contents: protoMarshal(&metrics.Complexity{
 						GetCount:    1,
@@ -977,14 +977,14 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 				},
 				// score artifact
 				&rpc.Artifact{
-					Name:       "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:       "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType:   "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					UpdateTime: timestamppb.New(time.Now().Add(time.Second * 1)),
 				},
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -1006,7 +1006,7 @@ func TestProcessRollUpFormulaTimestamp(t *testing.T) {
 			}
 
 			//fetch score artifact
-			scoreArtifact, err := getArtifact(ctx, client, "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error", false)
+			scoreArtifact, err := getArtifact(ctx, client, "projects/rollup-formula-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error", false)
 			if err != nil {
 				t.Errorf("failed to fetch the scoreArtifact from setup: %s", err)
 			}
@@ -1054,7 +1054,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -1071,7 +1071,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -1088,7 +1088,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 				},
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -1126,7 +1126,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -1141,7 +1141,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 			seed: []seeder.RegistryResource{
 				// Score lint-error
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lint-error",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lint-error",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lint-error",
@@ -1158,7 +1158,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 				},
 				// Score lang-reuse
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/score-lang-reuse",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/score-lang-reuse",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.Score",
 					Contents: protoMarshal(&rpc.Score{
 						Id:             "score-lang-reuse",
@@ -1175,7 +1175,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 				},
 				// ScoreCard artifact
 				&rpc.Artifact{
-					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality",
+					Name:     "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality",
 					MimeType: "application/octet-stream;type=google.cloud.apigeeregistry.v1.ScoreCard",
 					Contents: protoMarshal(&rpc.ScoreCard{
 						Id:             "scorecard-quality",
@@ -1213,7 +1213,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 			},
 			resource: patterns.SpecResource{
 				Spec: &rpc.ApiSpec{
-					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+					Name: "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				},
 			},
 			takeAction: false,
@@ -1279,7 +1279,7 @@ func TestProcessScorePatternsTimestamp(t *testing.T) {
 			}
 
 			//fetch the ScoreCard artifact
-			scoreCardArtifact, err := getArtifact(ctx, client, "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml/artifacts/scorecard-quality", false)
+			scoreCardArtifact, err := getArtifact(ctx, client, "projects/score-patterns-test/locations/global/apis/petstore/versions/1.0.0/specs/openapi/artifacts/scorecard-quality", false)
 			if err != nil {
 				t.Errorf("failed to fetch the scoreCardArtifact from setup: %s", err)
 			}

--- a/google/cloud/apigeeregistry/v1/registry_service.proto
+++ b/google/cloud/apigeeregistry/v1/registry_service.proto
@@ -842,7 +842,7 @@ message DeleteApiSpecRevisionRequest {
   // with a revision ID explicitly included.
   //
   // Example:
-  // projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8
+  // projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi@c7cfa2a8
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -164,7 +164,7 @@ func TestResourceNames(t *testing.T) {
 				return err == nil
 			},
 			pass: []string{
-				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi.yaml",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi",
 				"projects/-/locations/global/apis/-/versions/-/specs/-",
 				"projects/123/locations/global/apis/abc/versions/123/specs/abc",
 				"projects/1-2-3/locations/global/apis/abc/versions/123/specs/abc",
@@ -176,7 +176,7 @@ func TestResourceNames(t *testing.T) {
 				"projects/123/locations/global/apis/",
 				"projects/123/locations/global/invalid/123",
 				"projects/123/locations/global/apis/ 123",
-				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi.yaml@1234567890abcdef",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi@1234567890abcdef",
 			},
 		},
 		{
@@ -202,8 +202,8 @@ func TestResourceNames(t *testing.T) {
 				return err == nil
 			},
 			pass: []string{
-				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi.yaml@1234567890abcdef",
-				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi.yaml",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi@1234567890abcdef",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi",
 				"projects/-/locations/global/apis/-/versions/-/specs/-",
 				"projects/123/locations/global/apis/abc/versions/123/specs/abc",
 				"projects/1-2-3/locations/global/apis/abc/versions/123/specs/abc",
@@ -299,7 +299,7 @@ func TestResourceNames(t *testing.T) {
 				"projects/google/locations/global/artifacts",
 				"projects/google/locations/global/apis/sample/artifacts",
 				"projects/google/locations/global/apis/sample/versions/v1/artifacts",
-				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi.yaml/artifacts",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi/artifacts",
 				"projects/google/locations/global/apis/sample/deployments/prod/artifacts",
 			},
 			fail: []string{
@@ -316,7 +316,7 @@ func TestResourceNames(t *testing.T) {
 				"projects/google/locations/global/artifacts/test-artifact",
 				"projects/google/locations/global/apis/sample/artifacts/test-artifact",
 				"projects/google/locations/global/apis/sample/versions/v1/artifacts/test-artifact",
-				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi.yaml/artifacts/test-artifact",
+				"projects/google/locations/global/apis/sample/versions/v1/specs/openapi/artifacts/test-artifact",
 				"projects/google/locations/global/apis/sample/deployments/prod/artifacts/test-artifact",
 			},
 			fail: []string{

--- a/rpc/registry_service.pb.go
+++ b/rpc/registry_service.pb.go
@@ -1591,7 +1591,7 @@ type DeleteApiSpecRevisionRequest struct {
 	// with a revision ID explicitly included.
 	//
 	// Example:
-	// projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8
+	// projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi@c7cfa2a8
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 }
 

--- a/tests/crud/crud_test.go
+++ b/tests/crud/crud_test.go
@@ -154,7 +154,7 @@ func TestCRUD(t *testing.T) {
 		check(t, "error reading spec", err)
 		req := &rpc.CreateApiSpecRequest{
 			Parent:    "projects/test/locations/global/apis/sample/versions/1.0.0",
-			ApiSpecId: "openapi.yaml",
+			ApiSpecId: "openapi",
 			ApiSpec: &rpc.ApiSpec{
 				MimeType:    "application/x.openapi+gzip;version=3.0.0",
 				Contents:    buf.Bytes(),
@@ -197,7 +197,7 @@ func TestCRUD(t *testing.T) {
 	var revision string
 	{
 		req := &rpc.GetApiSpecRequest{
-			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi",
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)
@@ -217,7 +217,7 @@ func TestCRUD(t *testing.T) {
 	// Check the contents of the created spec.
 	{
 		req := &rpc.GetApiSpecContentsRequest{
-			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi",
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
@@ -234,7 +234,7 @@ func TestCRUD(t *testing.T) {
 	// Check the contents of the created revision.
 	{
 		req := &rpc.GetApiSpecContentsRequest{
-			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision,
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi@" + revision,
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
@@ -252,7 +252,7 @@ func TestCRUD(t *testing.T) {
 	revisionTag := "prod"
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
-			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revision,
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi@" + revision,
 			Tag:  revisionTag,
 		}
 		_, err := registryClient.TagApiSpecRevision(ctx, req)
@@ -261,7 +261,7 @@ func TestCRUD(t *testing.T) {
 	// Check the contents of the tagged revision.
 	{
 		req := &rpc.GetApiSpecContentsRequest{
-			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml@" + revisionTag,
+			Name: "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi@" + revisionTag,
 		}
 		response, err := registryClient.GetApiSpecContents(ctx, req)
 		check(t, "error getting spec contents %s", err)
@@ -278,7 +278,7 @@ func TestCRUD(t *testing.T) {
 	testArtifacts(ctx, registryClient, t, "projects/test/locations/global")
 	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample")
 	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample/versions/1.0.0")
-	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi.yaml")
+	testArtifacts(ctx, registryClient, t, "projects/test/locations/global/apis/sample/versions/1.0.0/specs/openapi")
 	// Delete the test project.
 	{
 		req := &rpc.DeleteProjectRequest{

--- a/tests/demo/demo_test.go
+++ b/tests/demo/demo_test.go
@@ -101,7 +101,7 @@ func listAllSpecs(ctx context.Context, registryClient connection.RegistryClient)
 func listAllSpecRevisionIDs(ctx context.Context, registryClient connection.RegistryClient) []string {
 	revisionIDs := make([]string, 0)
 	req := &rpc.ListApiSpecRevisionsRequest{
-		Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@-",
+		Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@-",
 	}
 	it := registryClient.ListApiSpecRevisions(ctx, req)
 	for {
@@ -225,7 +225,7 @@ func TestDemo(t *testing.T) {
 		check(t, "error reading spec", err)
 		req := &rpc.CreateApiSpecRequest{
 			Parent:    "projects/demo/locations/global/apis/petstore/versions/1.0.0",
-			ApiSpecId: "openapi.yaml",
+			ApiSpecId: "openapi",
 			ApiSpec: &rpc.ApiSpec{
 				MimeType: "application/x.openapi+gzip;version=3.0.0",
 				Contents: buf.Bytes(),
@@ -246,7 +246,7 @@ func TestDemo(t *testing.T) {
 		check(t, "error reading spec", err)
 		req := &rpc.UpdateApiSpecRequest{
 			ApiSpec: &rpc.ApiSpec{
-				Name:     "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+				Name:     "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 				Contents: buf.Bytes(),
 			},
 		}
@@ -263,7 +263,7 @@ func TestDemo(t *testing.T) {
 	// check the size and hash of each spec revision
 	for i, revisionID := range revisionIDs {
 		req := &rpc.GetApiSpecRequest{
-			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + revisionID,
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi" + "@" + revisionID,
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)
@@ -289,12 +289,12 @@ func TestDemo(t *testing.T) {
 	// tag a spec revision
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
-			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml" + "@" + originalRevisionID,
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi" + "@" + originalRevisionID,
 			Tag:  "og",
 		}
 		taggedSpec, err := registryClient.TagApiSpecRevision(ctx, req)
 		check(t, "error tagging spec", err)
-		if taggedSpec.Name != "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og" {
+		if taggedSpec.Name != "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@og" {
 			t.Errorf("Incorrect name of tagged spec: %s", taggedSpec.Name)
 		}
 		if taggedSpec.Hash != originalHash {
@@ -304,12 +304,12 @@ func TestDemo(t *testing.T) {
 	// tag the tagged revision
 	{
 		req := &rpc.TagApiSpecRevisionRequest{
-			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@og",
 			Tag:  "first",
 		}
 		taggedSpec, err := registryClient.TagApiSpecRevision(ctx, req)
 		check(t, "error tagging spec", err)
-		if taggedSpec.Name != "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@first" {
+		if taggedSpec.Name != "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@first" {
 			t.Errorf("Incorrect name of tagged spec: %s", taggedSpec.Name)
 		}
 		if taggedSpec.Hash != originalHash {
@@ -319,7 +319,7 @@ func TestDemo(t *testing.T) {
 	// get a spec by its tag
 	{
 		req := &rpc.GetApiSpecRequest{
-			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@first",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@first",
 		}
 		spec, err := registryClient.GetApiSpec(ctx, req)
 		check(t, "error getting spec %s", err)
@@ -330,7 +330,7 @@ func TestDemo(t *testing.T) {
 	// rollback a spec revision (this creates a new revision that's a copy)
 	{
 		req := &rpc.RollbackApiSpecRequest{
-			Name:       "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			Name:       "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 			RevisionId: "og",
 		}
 		spec, err := registryClient.RollbackApiSpec(ctx, req)
@@ -356,7 +356,7 @@ func TestDemo(t *testing.T) {
 	// delete a spec revision
 	{
 		req := &rpc.DeleteApiSpecRevisionRequest{
-			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi@og",
 		}
 		spec, err := registryClient.DeleteApiSpecRevision(ctx, req)
 		check(t, "error deleting spec revision %s", err)
@@ -381,7 +381,7 @@ func TestDemo(t *testing.T) {
 	// delete the spec
 	{
 		req := &rpc.DeleteApiSpecRequest{
-			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml",
+			Name: "projects/demo/locations/global/apis/petstore/versions/1.0.0/specs/openapi",
 		}
 		err := registryClient.DeleteApiSpec(ctx, req)
 		check(t, "error deleting spec %s", err)

--- a/tests/demo/walkthrough.sh
+++ b/tests/demo/walkthrough.sh
@@ -55,20 +55,20 @@ echo
 echo Add a spec for the API version that we just added to the registry.
 registry rpc create-api-spec \
     --parent projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0 \
-    --api_spec_id openapi.yaml \
+    --api_spec_id openapi \
     --api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r0` \
     --json
 
 echo
 echo Get the API spec.
 registry rpc get-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json
 
 echo
 echo Get the contents of the API spec.
 registry rpc get-api-spec-contents \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.data' -r | \
     registry-decode-spec
@@ -76,76 +76,76 @@ registry rpc get-api-spec-contents \
 echo
 echo Update an attribute of the spec.
 registry rpc update-api-spec \
-	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
 	--api_spec.mime_type "application/x.openapi+gzip;version=3" \
     --json
 
 echo
 echo Get the modified API spec.
 registry rpc get-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json
 
 echo
 echo Update the spec to new contents.
 registry rpc update-api-spec \
-	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
 	--api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r1` \
     --json
 
 echo
 echo Again update the spec to new contents.
 registry rpc update-api-spec \
-	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
 	--api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r2` \
     --json
 
 echo
 echo Make a third update of the spec contents.
 registry rpc update-api-spec \
-	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+	--api_spec.name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
 	--api_spec.contents `registry-encode-spec < testdata/openapi.yaml@r3`
 
 echo
 echo Get the API spec.
 registry rpc get-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json
 
 echo
 echo List the revisions of the spec.
 registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json
 
 echo
 echo List just the names of the revisions of the spec.
 registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.apiSpecs[].name' -r 
 
 echo
 echo Get the latest revision of the spec.
 registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.apiSpecs[0].name' -r 
 
 echo
 echo Get the oldest revision of the spec.
 registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.apiSpecs[-1].name' -r 
 
 ORIGINAL=`registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.apiSpecs[-1].name' -r`
 
 ORIGINAL_HASH=`registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.apiSpecs[-1].hash' -r`
 
@@ -156,27 +156,27 @@ registry rpc tag-api-spec-revision --name $ORIGINAL --tag og --json
 echo
 echo Get a spec by its tag.
 registry rpc get-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@og \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi@og \
     --json
 
 echo
 echo Print the hash of the current spec revision.
 registry rpc get-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.hash' -r
 
 echo
 echo Rollback to a prior spec revision.
 registry rpc rollback-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --revision_id og \
     --json
 
 echo
 echo Print the hash of the current spec revision after the rollback.
 registry rpc get-api-spec \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.hash' -r
 
@@ -189,7 +189,7 @@ echo Delete a spec revision.
 registry rpc delete-api-spec-revision --name $ORIGINAL
 
 ORIGINAL2=`registry rpc list-api-spec-revisions \
-    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml \
+    --name projects/$PROJECT/locations/global/apis/petstore/versions/1.0.0/specs/openapi \
     --json | \
     jq '.specs[-1].name' -r`
 


### PR DESCRIPTION
Fixes #883 by replacing "openapi.yaml" spec IDs with "openapi" in all tests. This follows #882 which removed extensions from IDs created by the bulk importers. Generally we want to discourage the use of extensions in resource ids so that YAML exports can use resource ids as names of directories; these directories contain resource details and children.

This change exposed #1023 by breaking the `registry compute conformance` tests. The problem was that the conformance task-runner was writing specs into files named by their spec id, and lint runners were expecting linted files to have ".yaml" extensions, so the linting skipped them. This PR doesn't change the lint runners (they still expect ".yaml" extensions), but changes the task-runner to name spec files using their specified `filename` values. If specs don't have a specified filename, that is treated as an error. This PR fixes #1023.
