### PR TITLE
Pass filenames of patch files to all patch helpers.

### DIFF
--- a/cmd/registry/patch/api.go
+++ b/cmd/registry/patch/api.go
@@ -189,7 +189,7 @@ func optionalDeploymentName(apiName names.Api, deploymentID string) string {
 	return apiName.Deployment(deploymentID).String()
 }
 
-func applyApiPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, parent string) error {
+func applyApiPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, parent string, filename string) error {
 	var api models.Api
 	err := yaml.Unmarshal(bytes, &api)
 	if err != nil {
@@ -218,19 +218,19 @@ func applyApiPatchBytes(ctx context.Context, client connection.RegistryClient, b
 		return fmt.Errorf("UpdateApi: %s", err)
 	}
 	for _, versionPatch := range api.Data.ApiVersions {
-		err := applyApiVersionPatch(ctx, client, versionPatch, apiName.String())
+		err := applyApiVersionPatch(ctx, client, versionPatch, apiName.String(), filename)
 		if err != nil {
 			return err
 		}
 	}
 	for _, deploymentPatch := range api.Data.ApiDeployments {
-		err := applyApiDeploymentPatch(ctx, client, deploymentPatch, apiName.String())
+		err := applyApiDeploymentPatch(ctx, client, deploymentPatch, apiName.String(), filename)
 		if err != nil {
 			return err
 		}
 	}
 	for _, artifactPatch := range api.Data.Artifacts {
-		err = applyArtifactPatch(ctx, client, artifactPatch, apiName.String())
+		err = applyArtifactPatch(ctx, client, artifactPatch, apiName.String(), filename)
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/patch/apply.go
+++ b/cmd/registry/patch/apply.go
@@ -207,14 +207,14 @@ func (task *applyBytesTask) Run(ctx context.Context) error {
 	log.FromContext(ctx).Infof("Applying %s", task.resource())
 	switch header.Kind {
 	case "API":
-		return applyApiPatchBytes(ctx, task.client, task.bytes, task.project)
+		return applyApiPatchBytes(ctx, task.client, task.bytes, task.project, task.path)
 	case "Version":
-		return applyApiVersionPatchBytes(ctx, task.client, task.bytes, task.project)
+		return applyApiVersionPatchBytes(ctx, task.client, task.bytes, task.project, task.path)
 	case "Spec":
 		return applyApiSpecPatchBytes(ctx, task.client, task.bytes, task.project, task.path)
 	case "Deployment":
-		return applyApiDeploymentPatchBytes(ctx, task.client, task.bytes, task.project)
+		return applyApiDeploymentPatchBytes(ctx, task.client, task.bytes, task.project, task.path)
 	default: // for everything else, try an artifact type
-		return applyArtifactPatchBytes(ctx, task.client, task.bytes, task.project)
+		return applyArtifactPatchBytes(ctx, task.client, task.bytes, task.project, task.path)
 	}
 }

--- a/cmd/registry/patch/artifact.go
+++ b/cmd/registry/patch/artifact.go
@@ -150,13 +150,13 @@ func NewArtifact(ctx context.Context, client *gapic.RegistryClient, message *rpc
 	}, nil
 }
 
-func applyArtifactPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, project string) error {
+func applyArtifactPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, project string, filename string) error {
 	var artifact models.Artifact
 	err := yaml.Unmarshal(bytes, &artifact)
 	if err != nil {
 		return err
 	}
-	return applyArtifactPatch(ctx, client, &artifact, project)
+	return applyArtifactPatch(ctx, client, &artifact, project, filename)
 }
 
 func artifactName(parent string, metadata models.Metadata) (names.Artifact, error) {
@@ -166,7 +166,7 @@ func artifactName(parent string, metadata models.Metadata) (names.Artifact, erro
 	return names.ParseArtifact(parent + "/artifacts/" + metadata.Name)
 }
 
-func applyArtifactPatch(ctx context.Context, client connection.RegistryClient, content *models.Artifact, parent string) error {
+func applyArtifactPatch(ctx context.Context, client connection.RegistryClient, content *models.Artifact, parent string, filename string) error {
 	// Restyle the YAML representation so that yaml.Marshal will marshal it as JSON.
 	styleForJSON(&content.Data)
 	// Marshal the YAML representation into the JSON serialization.

--- a/cmd/registry/patch/deployment.go
+++ b/cmd/registry/patch/deployment.go
@@ -84,13 +84,13 @@ func NewApiDeployment(ctx context.Context, client *gapic.RegistryClient, message
 	}, nil
 }
 
-func applyApiDeploymentPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, project string) error {
+func applyApiDeploymentPatchBytes(ctx context.Context, client connection.RegistryClient, bytes []byte, project string, filename string) error {
 	var deployment models.ApiDeployment
 	err := yaml.Unmarshal(bytes, &deployment)
 	if err != nil {
 		return err
 	}
-	return applyApiDeploymentPatch(ctx, client, &deployment, project)
+	return applyApiDeploymentPatch(ctx, client, &deployment, project, filename)
 }
 
 func deploymentName(parent string, metadata models.Metadata) (names.Deployment, error) {
@@ -108,7 +108,8 @@ func applyApiDeploymentPatch(
 	ctx context.Context,
 	client connection.RegistryClient,
 	deployment *models.ApiDeployment,
-	parent string) error {
+	parent string,
+	filename string) error {
 	name, err := deploymentName(parent, deployment.Metadata)
 	if err != nil {
 		return err
@@ -136,7 +137,7 @@ func applyApiDeploymentPatch(
 		return fmt.Errorf("UpdateApiDeployment: %s", err)
 	}
 	for _, artifactPatch := range deployment.Data.Artifacts {
-		err = applyArtifactPatch(ctx, client, artifactPatch, name.String())
+		err = applyArtifactPatch(ctx, client, artifactPatch, name.String(), filename)
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/patch/patch_test.go
+++ b/cmd/registry/patch/patch_test.go
@@ -200,7 +200,7 @@ func TestApiPatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
-			err = applyApiPatchBytes(ctx, registryClient, b, root)
+			err = applyApiPatchBytes(ctx, registryClient, b, root, "patch.yaml")
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
@@ -303,7 +303,7 @@ func TestVersionPatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
-			err = applyApiVersionPatchBytes(ctx, registryClient, b, root)
+			err = applyApiVersionPatchBytes(ctx, registryClient, b, root, "patch.yaml")
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
@@ -512,7 +512,7 @@ func TestDeploymentPatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
-			err = applyApiDeploymentPatchBytes(ctx, registryClient, b, root)
+			err = applyApiDeploymentPatchBytes(ctx, registryClient, b, root, "patch.yaml")
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
@@ -1056,7 +1056,7 @@ func TestMessageArtifactPatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
-			err = applyArtifactPatchBytes(ctx, registryClient, b, root)
+			err = applyArtifactPatchBytes(ctx, registryClient, b, root, "patch.yaml")
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
@@ -1154,7 +1154,7 @@ func TestYamlArtifactPatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
-			err = applyArtifactPatchBytes(ctx, registryClient, b, root)
+			err = applyArtifactPatchBytes(ctx, registryClient, b, root, "patch.yaml")
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
@@ -1247,7 +1247,7 @@ func TestInvalidArtifactPatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s", err)
 			}
-			err = applyArtifactPatchBytes(ctx, registryClient, b, root)
+			err = applyArtifactPatchBytes(ctx, registryClient, b, root, "patch.yaml")
 			if err == nil {
 				t.Fatalf("expected error, received none")
 			}

--- a/cmd/registry/patch/spec.go
+++ b/cmd/registry/patch/spec.go
@@ -194,7 +194,7 @@ func applyApiSpecPatch(
 		return fmt.Errorf("UpdateApiSpec: %s", err)
 	}
 	for _, artifactPatch := range spec.Data.Artifacts {
-		err = applyArtifactPatch(ctx, client, artifactPatch, name.String())
+		err = applyArtifactPatch(ctx, client, artifactPatch, name.String(), filename)
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/patch/version.go
+++ b/cmd/registry/patch/version.go
@@ -83,13 +83,14 @@ func applyApiVersionPatchBytes(
 	ctx context.Context,
 	client connection.RegistryClient,
 	bytes []byte,
-	project string) error {
+	project string,
+	filename string) error {
 	var version models.ApiVersion
 	err := yaml.Unmarshal(bytes, &version)
 	if err != nil {
 		return err
 	}
-	return applyApiVersionPatch(ctx, client, &version, project)
+	return applyApiVersionPatch(ctx, client, &version, project, filename)
 }
 
 func versionName(parent string, metadata models.Metadata) (names.Version, error) {
@@ -107,7 +108,8 @@ func applyApiVersionPatch(
 	ctx context.Context,
 	client connection.RegistryClient,
 	version *models.ApiVersion,
-	parent string) error {
+	parent string,
+	filename string) error {
 	name, err := versionName(parent, version.Metadata)
 	if err != nil {
 		return err
@@ -129,13 +131,13 @@ func applyApiVersionPatch(
 		return fmt.Errorf("UpdateApiVersion: %s", err)
 	}
 	for _, specPatch := range version.Data.ApiSpecs {
-		err := applyApiSpecPatch(ctx, client, specPatch, name.String(), "")
+		err := applyApiSpecPatch(ctx, client, specPatch, name.String(), filename)
 		if err != nil {
 			return err
 		}
 	}
 	for _, artifactPatch := range version.Data.Artifacts {
-		err = applyArtifactPatch(ctx, client, artifactPatch, name.String())
+		err = applyArtifactPatch(ctx, client, artifactPatch, name.String(), filename)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When `registry apply` uploads spec files, it looks for them in the same directory as the YAML file that referenced them, i.e. the specs should be alongside the YAML. This requires us to pass the path to the containing YAML file all the way down to the spec handler. Previously YAML representations of specs were getting the path name, but higher-level nested representations (APIs and versions) did not have their filenames passed down during processing. This fixes that and passes the containing filename down to all handlers, including artifact handlers, which don't need them now but would use them if/when we support importing external (binary?) files as artifact contents. 