### PR TITLE
Add improved error reporting to `registry apply`.

### DIFF
--- a/cmd/registry/cmd/apply/apply.go
+++ b/cmd/registry/cmd/apply/apply.go
@@ -55,7 +55,7 @@ func Command() *cobra.Command {
 			if err := visitor.VerifyLocation(ctx, client, project); err != nil {
 				return fmt.Errorf("parent project %q does not exist: %s", project, err)
 			}
-			return patch.Apply(ctx, client, fileName, project, recursive, jobs)
+			return patch.Apply(ctx, client, cmd.InOrStdin(), fileName, project, recursive, jobs)
 		},
 	}
 	cmd.Flags().StringVarP(&fileName, "file", "f", "", "file or directory containing the patch(es) to apply. Use '-' to read from standard input")

--- a/cmd/registry/cmd/apply/apply_test.go
+++ b/cmd/registry/cmd/apply/apply_test.go
@@ -230,7 +230,7 @@ func TestApply_Stdin(t *testing.T) {
 			cmd.SetArgs(test.args)
 			cmd.SetIn(r)
 			if err := cmd.Execute(); err != nil {
-				t.Fatalf("Execute() with args %+v returned error: %s", cmd.Args, err)
+				t.Fatalf("Execute() with args %+v returned error: %s", test.args, err)
 			}
 		})
 	}

--- a/cmd/registry/patch/apply.go
+++ b/cmd/registry/patch/apply.go
@@ -31,10 +31,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func Apply(ctx context.Context, client connection.RegistryClient, path, project string, recursive bool, jobs int) error {
+func Apply(ctx context.Context, client connection.RegistryClient, in io.Reader, path, project string, recursive bool, jobs int) error {
 	patches := &patchGroup{}
 	if path == "-" {
-		bytes, err := io.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(in)
 		if err != nil {
 			return err
 		}

--- a/cmd/registry/patch/export_test.go
+++ b/cmd/registry/patch/export_test.go
@@ -73,7 +73,7 @@ func TestExport(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Setup: Failed to create registry client: %s", err)
 		}
-		if err := Apply(ctx, registryClient, test.root, project.String()+"/locations/global", true, 1); err != nil {
+		if err := Apply(ctx, registryClient, nil, test.root, project.String()+"/locations/global", true, 1); err != nil {
 			t.Fatalf("Apply() returned error: %s", err)
 		}
 

--- a/cmd/registry/patch/patch_lists_test.go
+++ b/cmd/registry/patch/patch_lists_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -78,7 +78,7 @@ func TestArtifactLists(t *testing.T) {
 			}
 			defer registryClient.Close()
 
-			if err := Apply(ctx, registryClient, test.root, project.String()+"/locations/global", true, 10); err != nil {
+			if err := Apply(ctx, registryClient, nil, test.root, project.String()+"/locations/global", true, 10); err != nil {
 				t.Fatalf("Apply() returned error: %s", err)
 			}
 

--- a/cmd/registry/patch/patch_project_test.go
+++ b/cmd/registry/patch/patch_project_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -86,7 +86,7 @@ func TestProjectImports(t *testing.T) {
 			}
 			defer registryClient.Close()
 
-			if err := Apply(ctx, registryClient, test.root, project.String()+"/locations/global", true, 10); err != nil {
+			if err := Apply(ctx, registryClient, nil, test.root, project.String()+"/locations/global", true, 10); err != nil {
 				t.Fatalf("Apply() returned error: %s", err)
 			}
 

--- a/cmd/registry/patch/patch_test.go
+++ b/cmd/registry/patch/patch_test.go
@@ -1214,7 +1214,8 @@ func TestInvalidArtifactPatches(t *testing.T) {
 		},
 		{
 			artifactID: "lifecycle-invalid-parent",
-		}, {
+		},
+		{
 			artifactID: "references-no-data",
 		},
 		{
@@ -1273,4 +1274,33 @@ func unmarshal(value []byte, message proto.Message) (proto.Message, error) {
 		return nil, err
 	}
 	return message, nil
+}
+
+func TestEmptyArtifactPatches(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "empty directory",
+			path: "testdata/empty",
+		},
+		{
+			name: "unrecognized yaml",
+			path: "testdata/sample-hierarchical/apis/registry/versions/v1/specs/openapi/openapi.yaml",
+		},
+	}
+	ctx := context.Background()
+	registryClient, _ := grpctest.SetupRegistry(ctx, t, "patch-empty-test", []seeder.RegistryResource{
+		&rpc.Project{
+			Name: "projects/patch-empty-test",
+		},
+	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Apply(ctx, registryClient, nil, test.path, "projects/patch-empty-test/locations/global", true, 10); err == nil {
+				t.Errorf("Apply() succeeded and should have failed")
+			}
+		})
+	}
 }

--- a/cmd/registry/patch/testdata/empty/README.md
+++ b/cmd/registry/patch/testdata/empty/README.md
@@ -1,0 +1,1 @@
+This directory is intentionally empty (no YAML files).


### PR DESCRIPTION
Fixes #889 

`registry apply` now reports the number of files read and applied. 

For a moderate-sized input, the final log message looks like this:
```
  INFO[0002] 44 YAML file(s) applied (87 found, 44 with 'apiVersion: apigeeregistry/v1') uid=79eb00e5
```
For a single file input, the log message looks like this:
```
  INFO[0000] 1 YAML file(s) applied (1 found, 1 with 'apiVersion: apigeeregistry/v1') uid=f7bc2216
```
Errors are reported if a directory is specified that contains no YAML files:
```
Error: no YAML files found
```
Errors are also reported if none of the YAML files found are valid Registry YAML:
```
Error: no YAML files applied (1 found, none with 'apiVersion: apigeeregistry/v1')
```