### PR TITLE
Replace wildcards with specific file names in download script.

### DIFF
--- a/downloadLatest.sh
+++ b/downloadLatest.sh
@@ -84,10 +84,12 @@ printf "\n"
 cd "$HOME" || exit
 mkdir -p "$HOME/.registry/bin"
 mv "${tmp}/registry" "$HOME/.registry/bin"
-mv "${tmp}/registry-lint-*" "$HOME/.registry/bin"
+mv "${tmp}/registry-lint-api-linter" "$HOME/.registry/bin"
+mv "${tmp}/registry-lint-spectral" "$HOME/.registry/bin"
 printf "Copied registry into the $HOME/.registry/bin folder.\n"
 chmod +x "$HOME/.registry/bin/registry"
-chmod +x "$HOME/.registry/bin/registry-lint-*"
+chmod +x "$HOME/.registry/bin/registry-lint-api-linter"
+chmod +x "$HOME/.registry/bin/registry-lint-spectral"
 
 # Print message
 printf "\n"


### PR DESCRIPTION
Running the latest download script with `v0.6.6`, I get the following error on Linux:
```
$ sh downloadLatest.sh 
https://github.com/apigee/registry/releases/download/v0.6.6/registry_0.6.6_linux_amd64.tar.gz

Downloading registry_v0.6.6 from https://github.com/apigee/registry/releases/download/v0.6.6/registry_0.6.6_linux_amd64.tar.gz ...

registry v0.6.6 Download Complete!

mv: cannot stat '/tmp/registry.PaMH31/registry-lint-*': No such file or directory
```
It appears that the globbing is not being expanded properly. This replaces the * with the specific filenames that we want to install.
