### PR TITLE
readd nightly build for docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,8 @@
 name: Publish docker images
 
 on:
+  schedule:
+    - cron: '0 0 * * *' # each 12:00 UTC
   push:
     branches: [ main ]
     tags: [ 'v*.*.*' ] # semver release


### PR DESCRIPTION
For your consideration: perhaps we do want to keep a nightly docker build around as we might want point users to it on occasion.