### PR TITLE
Add benchmark that lists artifacts under each resource type.

### DIFF
--- a/tests/benchmark/benchmark_apis_test.go
+++ b/tests/benchmark/benchmark_apis_test.go
@@ -30,7 +30,7 @@ func apiId(i int) string {
 }
 
 func apiName(apiId string) string {
-	return fmt.Sprintf("%s/apis/%s", root(), apiId)
+	return fmt.Sprintf("%s/apis/%s", root().String()+"/locations/global", apiId)
 }
 
 func getApi(b *testing.B, ctx context.Context, client connection.RegistryClient, apiId string) error {
@@ -41,26 +41,13 @@ func getApi(b *testing.B, ctx context.Context, client connection.RegistryClient,
 
 func listApis(b *testing.B, ctx context.Context, client connection.RegistryClient) error {
 	b.Helper()
-	it := client.ListApis(ctx, &rpc.ListApisRequest{Parent: root()})
+	it := client.ListApis(ctx, &rpc.ListApisRequest{Parent: root().String() + "/locations/global"})
 	for _, err := it.Next(); err != iterator.Done; _, err = it.Next() {
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func createApi(b *testing.B, ctx context.Context, client connection.RegistryClient, apiId string) error {
-	b.Helper()
-	_, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
-		Parent: root(),
-		ApiId:  apiId,
-		Api: &rpc.Api{
-			DisplayName: apiId,
-			Description: fmt.Sprintf("Description for %s", apiId),
-		},
-	})
-	return err
 }
 
 func updateApi(b *testing.B, ctx context.Context, client connection.RegistryClient, apiId string) error {
@@ -83,7 +70,7 @@ func deleteApi(b *testing.B, ctx context.Context, client connection.RegistryClie
 
 func BenchmarkGetApi(b *testing.B) {
 	ctx, client := setup(b)
-	if err := createApi(b, ctx, client, apiId(1)); err != nil {
+	if err := createApi(b, ctx, client, root().Api(apiId(1))); err != nil {
 		b.Fatalf("%s", err)
 	}
 	b.Run("GetApi", func(b *testing.B) {
@@ -99,7 +86,7 @@ func BenchmarkGetApi(b *testing.B) {
 func BenchmarkListApis(b *testing.B) {
 	ctx, client := setup(b)
 	for i := 1; i <= 10; i++ {
-		if err := createApi(b, ctx, client, apiId(i)); err != nil {
+		if err := createApi(b, ctx, client, root().Api(apiId(i))); err != nil {
 			b.Fatalf("%s", err)
 		}
 	}
@@ -117,7 +104,7 @@ func BenchmarkCreateApi(b *testing.B) {
 	ctx, client := setup(b)
 	b.Run("CreateApi", func(b *testing.B) {
 		for i := 1; i <= b.N; i++ {
-			if err := createApi(b, ctx, client, apiId(i)); err != nil {
+			if err := createApi(b, ctx, client, root().Api(apiId(i))); err != nil {
 				b.Fatalf("%s", err)
 			}
 		}
@@ -135,7 +122,7 @@ func BenchmarkCreateApi(b *testing.B) {
 func BenchmarkUpdateApi(b *testing.B) {
 	ctx, client := setup(b)
 	for i := 1; i <= 1; i++ {
-		if err := createApi(b, ctx, client, apiId(i)); err != nil {
+		if err := createApi(b, ctx, client, root().Api(apiId(i))); err != nil {
 			b.Fatalf("%s", err)
 		}
 	}
@@ -154,7 +141,7 @@ func BenchmarkDeleteApi(b *testing.B) {
 	b.Run("DeleteApi", func(b *testing.B) {
 		b.StopTimer()
 		for i := 1; i <= b.N; i++ {
-			if err := createApi(b, ctx, client, apiId(i)); err != nil {
+			if err := createApi(b, ctx, client, root().Api(apiId(i))); err != nil {
 				b.Fatalf("%s", err)
 			}
 		}

--- a/tests/benchmark/benchmark_artifacts_test.go
+++ b/tests/benchmark/benchmark_artifacts_test.go
@@ -1,0 +1,209 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apigee/registry/cmd/registry/tasks"
+	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/names"
+	"github.com/apigee/registry/rpc"
+	"google.golang.org/api/iterator"
+)
+
+func listArtifacts(b *testing.B, ctx context.Context, client connection.RegistryClient, parent, filter string) error {
+	b.Helper()
+	count := 0
+	it := client.ListArtifacts(ctx, &rpc.ListArtifactsRequest{Parent: parent, Filter: filter})
+	for _, err := it.Next(); err != iterator.Done; _, err = it.Next() {
+		if err != nil {
+			return err
+		}
+		count++
+	}
+	return nil
+}
+
+type seedArtifactsTask struct {
+	client      connection.RegistryClient
+	b           *testing.B
+	start       int
+	count       int
+	projectName names.Project
+}
+
+func (task *seedArtifactsTask) String() string {
+	return fmt.Sprintf("seed %d-%d", task.start, task.start+task.count-1)
+}
+
+func (task *seedArtifactsTask) Run(ctx context.Context) error {
+	b := task.b
+	client := task.client
+	for i := 0; i < task.count; i++ {
+		apiName := task.projectName.Api(fmt.Sprintf("a%d", task.start+i))
+		createApi(b, ctx, client, apiName)
+		createArtifact(b, ctx, client, apiName.Artifact("a"))
+		createArtifact(b, ctx, client, apiName.Artifact("b"))
+		createArtifact(b, ctx, client, apiName.Artifact("c"))
+		versionName := apiName.Version("v")
+		createApiVersion(b, ctx, client, versionName)
+		createArtifact(b, ctx, client, versionName.Artifact("a"))
+		createArtifact(b, ctx, client, versionName.Artifact("b"))
+		createArtifact(b, ctx, client, versionName.Artifact("c"))
+		specName := versionName.Spec("s")
+		createApiSpecRevisions(b, ctx, client, specName, 3)
+		createArtifact(b, ctx, client, specName.Artifact("a"))
+		createArtifact(b, ctx, client, specName.Artifact("b"))
+		createArtifact(b, ctx, client, specName.Artifact("c"))
+		deploymentName := apiName.Deployment("d")
+		createApiDeploymentRevisions(b, ctx, client, deploymentName, 3)
+		createArtifact(b, ctx, client, deploymentName.Artifact("a"))
+		createArtifact(b, ctx, client, deploymentName.Artifact("b"))
+		createArtifact(b, ctx, client, deploymentName.Artifact("c"))
+	}
+	return nil
+}
+
+func BenchmarkListArtifacts(b *testing.B) {
+	ctx, client := setup(b)
+	// Try to speed up creation with a worker pool (this might not help much but seemed worth a try).
+	taskQueue, wait := tasks.WorkerPool(ctx, 5)
+	projectName := names.Project{ProjectID: projectID}
+	total := 100
+	step := 5
+	for i := 0; i < total; i += step {
+		taskQueue <- &seedArtifactsTask{
+			client:      client,
+			b:           b,
+			start:       i,
+			count:       step,
+			projectName: projectName,
+		}
+	}
+	wait()
+	// Tests will list one of three artifacts created under each resource for all instances of the resource.
+	filter := "artifact_id == 'b'"
+	b.Run("ListApiArtifacts", func(b *testing.B) {
+		parent := root().Api("-").String()
+		for i := 1; i <= b.N; i++ {
+			if err := listArtifacts(b, ctx, client, parent, filter); err != nil {
+				b.Fatalf("%s", err)
+			}
+		}
+	})
+	b.Run("ListVersionArtifacts", func(b *testing.B) {
+		parent := root().Api("-").Version("-").String()
+		for i := 1; i <= b.N; i++ {
+			if err := listArtifacts(b, ctx, client, parent, filter); err != nil {
+				b.Fatalf("%s", err)
+			}
+		}
+	})
+	b.Run("ListSpecArtifacts", func(b *testing.B) {
+		parent := root().Api("-").Version("-").Spec("-").String()
+		for i := 1; i <= b.N; i++ {
+			if err := listArtifacts(b, ctx, client, parent, filter); err != nil {
+				b.Fatalf("%s", err)
+			}
+		}
+	})
+	b.Run("ListDeploymentArtifacts", func(b *testing.B) {
+		parent := root().Api("-").Deployment("-").String()
+		for i := 1; i <= b.N; i++ {
+			if err := listArtifacts(b, ctx, client, parent, filter); err != nil {
+				b.Fatalf("%s", err)
+			}
+		}
+	})
+	teardown(ctx, b, client)
+}
+
+func createApi(b *testing.B, ctx context.Context, client connection.RegistryClient, api names.Api) error {
+	b.Helper()
+	_, err := client.CreateApi(ctx, &rpc.CreateApiRequest{
+		Parent: api.Parent(),
+		ApiId:  api.ApiID,
+		Api: &rpc.Api{
+			DisplayName: api.ApiID,
+			Description: fmt.Sprintf("Description for %s", api.ApiID),
+		},
+	})
+	return err
+}
+
+func createApiVersion(b *testing.B, ctx context.Context, client connection.RegistryClient, version names.Version) error {
+	b.Helper()
+	_, err := client.CreateApiVersion(ctx, &rpc.CreateApiVersionRequest{
+		Parent:       version.Parent(),
+		ApiVersionId: version.VersionID,
+		ApiVersion: &rpc.ApiVersion{
+			DisplayName: version.VersionID,
+			Description: fmt.Sprintf("Description for %s", version.VersionID),
+		},
+	})
+	return err
+}
+
+func createApiSpecRevisions(b *testing.B, ctx context.Context, client connection.RegistryClient, spec names.Spec, revisions int) error {
+	b.Helper()
+	for r := 0; r < revisions; r++ {
+		_, err := client.UpdateApiSpec(ctx, &rpc.UpdateApiSpecRequest{
+			ApiSpec: &rpc.ApiSpec{
+				Name:        spec.String(),
+				Filename:    spec.SpecID,
+				Description: fmt.Sprintf("Description for %s", spec.SpecID),
+				MimeType:    "text/plain",
+				Contents:    []byte(fmt.Sprintf("Revision %d", r)),
+			},
+			AllowMissing: true,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createApiDeploymentRevisions(b *testing.B, ctx context.Context, client connection.RegistryClient, deployment names.Deployment, revisions int) error {
+	b.Helper()
+	for r := 0; r < revisions; r++ {
+		_, err := client.UpdateApiDeployment(ctx, &rpc.UpdateApiDeploymentRequest{
+			ApiDeployment: &rpc.ApiDeployment{
+				Name:        deployment.String(),
+				DisplayName: deployment.DeploymentID,
+				Description: fmt.Sprintf("Description for %s", deployment.DeploymentID),
+				EndpointUri: fmt.Sprintf("https://r%d.example.com", r),
+			},
+			AllowMissing: true,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createArtifact(b *testing.B, ctx context.Context, client connection.RegistryClient, artifact names.Artifact) error {
+	b.Helper()
+	_, err := client.CreateArtifact(ctx, &rpc.CreateArtifactRequest{
+		Parent:     artifact.Parent(),
+		ArtifactId: artifact.ArtifactID(),
+		Artifact:   &rpc.Artifact{},
+	})
+	return err
+}

--- a/tests/benchmark/benchmark_artifacts_test.go
+++ b/tests/benchmark/benchmark_artifacts_test.go
@@ -84,7 +84,7 @@ func BenchmarkListArtifacts(b *testing.B) {
 	// Try to speed up creation with a worker pool (this might not help much but seemed worth a try).
 	taskQueue, wait := tasks.WorkerPool(ctx, 5)
 	projectName := names.Project{ProjectID: projectID}
-	total := 100
+	total := 1000
 	step := 5
 	for i := 0; i < total; i += step {
 		taskQueue <- &seedArtifactsTask{
@@ -184,10 +184,11 @@ func createApiDeploymentRevisions(b *testing.B, ctx context.Context, client conn
 	for r := 0; r < revisions; r++ {
 		_, err := client.UpdateApiDeployment(ctx, &rpc.UpdateApiDeploymentRequest{
 			ApiDeployment: &rpc.ApiDeployment{
-				Name:        deployment.String(),
-				DisplayName: deployment.DeploymentID,
-				Description: fmt.Sprintf("Description for %s", deployment.DeploymentID),
-				EndpointUri: fmt.Sprintf("https://r%d.example.com", r),
+				Name:            deployment.String(),
+				DisplayName:     deployment.DeploymentID,
+				Description:     fmt.Sprintf("Description for %s", deployment.DeploymentID),
+				EndpointUri:     fmt.Sprintf("https://r%d.example.com", r),
+				ApiSpecRevision: fmt.Sprintf(deployment.Project().String()+"/apis/a/versions/v/specs/s@%d", r),
 			},
 			AllowMissing: true,
 		})

--- a/tests/benchmark/benchmark_artifacts_test.go
+++ b/tests/benchmark/benchmark_artifacts_test.go
@@ -56,25 +56,57 @@ func (task *seedArtifactsTask) Run(ctx context.Context) error {
 	client := task.client
 	for i := 0; i < task.count; i++ {
 		apiName := task.projectName.Api(fmt.Sprintf("a%d", task.start+i))
-		createApi(b, ctx, client, apiName)
-		createArtifact(b, ctx, client, apiName.Artifact("a"))
-		createArtifact(b, ctx, client, apiName.Artifact("b"))
-		createArtifact(b, ctx, client, apiName.Artifact("c"))
+		if err := createApi(b, ctx, client, apiName); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, apiName.Artifact("a")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, apiName.Artifact("b")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, apiName.Artifact("c")); err != nil {
+			return err
+		}
 		versionName := apiName.Version("v")
-		createApiVersion(b, ctx, client, versionName)
-		createArtifact(b, ctx, client, versionName.Artifact("a"))
-		createArtifact(b, ctx, client, versionName.Artifact("b"))
-		createArtifact(b, ctx, client, versionName.Artifact("c"))
+		if err := createApiVersion(b, ctx, client, versionName); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, versionName.Artifact("a")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, versionName.Artifact("b")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, versionName.Artifact("c")); err != nil {
+			return err
+		}
 		specName := versionName.Spec("s")
-		createApiSpecRevisions(b, ctx, client, specName, 3)
-		createArtifact(b, ctx, client, specName.Artifact("a"))
-		createArtifact(b, ctx, client, specName.Artifact("b"))
-		createArtifact(b, ctx, client, specName.Artifact("c"))
+		if err := createApiSpecRevisions(b, ctx, client, specName, 3); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, specName.Artifact("a")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, specName.Artifact("b")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, specName.Artifact("c")); err != nil {
+			return err
+		}
 		deploymentName := apiName.Deployment("d")
-		createApiDeploymentRevisions(b, ctx, client, deploymentName, 3)
-		createArtifact(b, ctx, client, deploymentName.Artifact("a"))
-		createArtifact(b, ctx, client, deploymentName.Artifact("b"))
-		createArtifact(b, ctx, client, deploymentName.Artifact("c"))
+		if err := createApiDeploymentRevisions(b, ctx, client, deploymentName, 3); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, deploymentName.Artifact("a")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, deploymentName.Artifact("b")); err != nil {
+			return err
+		}
+		if err := createArtifact(b, ctx, client, deploymentName.Artifact("c")); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/tests/benchmark/benchmark_helpers.go
+++ b/tests/benchmark/benchmark_helpers.go
@@ -17,10 +17,10 @@ package benchmark
 import (
 	"context"
 	"flag"
-	"fmt"
 	"testing"
 
 	"github.com/apigee/registry/pkg/connection"
+	"github.com/apigee/registry/pkg/names"
 	"github.com/apigee/registry/pkg/wipeout"
 )
 
@@ -36,8 +36,8 @@ func init() {
 	flag.StringVar(&projectID, "project_id", "bench", "registry project ID")
 }
 
-func root() string {
-	return fmt.Sprintf("projects/%s/locations/global", projectID)
+func root() names.Project {
+	return names.Project{ProjectID: projectID}
 }
 
 func setup(b *testing.B) (context.Context, connection.RegistryClient) {


### PR DESCRIPTION
This adds a benchmark test that lists artifacts under different resource types.

I've casually observed that listing artifacts under specs takes longer than listing artifacts under APIs, and guessed that this might be related to revision support. The test here creates N=100 APIs, each with one version, spec, and deployment, and with three artifacts ("a", "b", and "c") under each resource. Three revisions of each spec and deployment are created with artifacts only associated with the last ones created. Then we list all of the "b" artifacts under each resource type.

Running locally with Postgres on my Chromebook, I don't see much difference in listing times:
```
BenchmarkListArtifacts
BenchmarkListArtifacts/ListApiArtifacts
BenchmarkListArtifacts/ListApiArtifacts-8                     75          14497073 ns/op
BenchmarkListArtifacts/ListVersionArtifacts
BenchmarkListArtifacts/ListVersionArtifacts-8                 51          20340059 ns/op
BenchmarkListArtifacts/ListSpecArtifacts
BenchmarkListArtifacts/ListSpecArtifacts-8                    50          22871343 ns/op
BenchmarkListArtifacts/ListDeploymentArtifacts
BenchmarkListArtifacts/ListDeploymentArtifacts-8              54          19693489 ns/op
```

If I increase the number of APIs to N=1000, a distinction is more clear:
```
BenchmarkListArtifacts
BenchmarkListArtifacts/ListApiArtifacts
BenchmarkListArtifacts/ListApiArtifacts-8                      3         418735575 ns/op
BenchmarkListArtifacts/ListVersionArtifacts
BenchmarkListArtifacts/ListVersionArtifacts-8                  2         551807149 ns/op
BenchmarkListArtifacts/ListSpecArtifacts
BenchmarkListArtifacts/ListSpecArtifacts-8                     2         807084090 ns/op
BenchmarkListArtifacts/ListDeploymentArtifacts
BenchmarkListArtifacts/ListDeploymentArtifacts-8               2         743311222 ns/op
```

This doesn't seem to be as severe as it subjectively seemed to me, but this is local and my observations were running with a remote database.

Setup time dominates the runtime of these tests, so this PR keeps N=100.
