### PR TITLE
Add indexes to specs and deployments.

### DIFF
--- a/server/registry/internal/storage/models/deployment.go
+++ b/server/registry/internal/storage/models/deployment.go
@@ -27,9 +27,9 @@ import (
 // Deployment is the storage-side representation of a deployment.
 type Deployment struct {
 	Key                string    `gorm:"primaryKey"`
-	ProjectID          string    // Uniquely identifies a project.
-	ApiID              string    // Uniquely identifies an api within a project.
-	DeploymentID       string    // Uniquely identifies a deployment within an api.
+	ProjectID          string    `gorm:"index:deployment"` // Uniquely identifies a project.
+	ApiID              string    `gorm:"index:deployment"` // Uniquely identifies an api within a project.
+	DeploymentID       string    `gorm:"index:deployment"` // Uniquely identifies a deployment within an api.
 	RevisionID         string    // Uniquely identifies a revision of a deployment.
 	DisplayName        string    // A human-friendly name.
 	Description        string    // A detailed description.

--- a/server/registry/internal/storage/models/deployment.go
+++ b/server/registry/internal/storage/models/deployment.go
@@ -27,9 +27,9 @@ import (
 // Deployment is the storage-side representation of a deployment.
 type Deployment struct {
 	Key                string    `gorm:"primaryKey"`
-	ProjectID          string    `gorm:"index:deployment"` // Uniquely identifies a project.
-	ApiID              string    `gorm:"index:deployment"` // Uniquely identifies an api within a project.
-	DeploymentID       string    `gorm:"index:deployment"` // Uniquely identifies a deployment within an api.
+	ProjectID          string    // Uniquely identifies a project.
+	ApiID              string    `gorm:"index"` // Uniquely identifies an api within a project.
+	DeploymentID       string    // Uniquely identifies a deployment within an api.
 	RevisionID         string    // Uniquely identifies a revision of a deployment.
 	DisplayName        string    // A human-friendly name.
 	Description        string    // A detailed description.

--- a/server/registry/internal/storage/models/spec.go
+++ b/server/registry/internal/storage/models/spec.go
@@ -32,10 +32,10 @@ import (
 // Spec is the storage-side representation of a spec.
 type Spec struct {
 	Key                string    `gorm:"primaryKey"`
-	ProjectID          string    // Uniquely identifies a project.
-	ApiID              string    // Uniquely identifies an api within a project.
-	VersionID          string    // Uniquely identifies a version within an api.
-	SpecID             string    // Uniquely identifies a spec within a version.
+	ProjectID          string    `gorm:"index:spec"` // Uniquely identifies a project.
+	ApiID              string    `gorm:"index:spec"` // Uniquely identifies an api within a project.
+	VersionID          string    `gorm:"index:spec"` // Uniquely identifies a version within an api.
+	SpecID             string    `gorm:"index:spec"` // Uniquely identifies a spec within a version.
 	RevisionID         string    // Uniquely identifies a revision of a spec.
 	Description        string    // A detailed description.
 	CreateTime         time.Time // Creation time.

--- a/server/registry/internal/storage/models/spec.go
+++ b/server/registry/internal/storage/models/spec.go
@@ -32,10 +32,10 @@ import (
 // Spec is the storage-side representation of a spec.
 type Spec struct {
 	Key                string    `gorm:"primaryKey"`
-	ProjectID          string    `gorm:"index:spec"` // Uniquely identifies a project.
-	ApiID              string    `gorm:"index:spec"` // Uniquely identifies an api within a project.
-	VersionID          string    `gorm:"index:spec"` // Uniquely identifies a version within an api.
-	SpecID             string    `gorm:"index:spec"` // Uniquely identifies a spec within a version.
+	ProjectID          string    // Uniquely identifies a project.
+	ApiID              string    `gorm:"index"` // Uniquely identifies an api within a project.
+	VersionID          string    // Uniquely identifies a version within an api.
+	SpecID             string    // Uniquely identifies a spec within a version.
 	RevisionID         string    // Uniquely identifies a revision of a spec.
 	Description        string    // A detailed description.
 	CreateTime         time.Time // Creation time.


### PR DESCRIPTION
Based on discussion in #1069, this adds indexes on the `ApiID` fields of specs and deployments.

