### PR TITLE
optimize db: add index, rewrite query

### DIFF
--- a/server/registry/internal/storage/models/artifact.go
+++ b/server/registry/internal/storage/models/artifact.go
@@ -30,7 +30,7 @@ import (
 type Artifact struct {
 	Key          string    `gorm:"primaryKey"`
 	ProjectID    string    // Project associated with artifact (required).
-	ApiID        string    // Api associated with artifact (if appropriate).
+	ApiID        string    `gorm:"index"` // Api associated with artifact (if appropriate).
 	VersionID    string    // Version associated with artifact (if appropriate).
 	SpecID       string    // Spec associated with artifact (if appropriate).
 	RevisionID   string    // Revision associated with parent (if appropriate).


### PR DESCRIPTION
Fixes 1069

After using EXPLAIN, ANALYZE and doing additional research, I added an index and simplified our latest revision queries. Once done, I ran the benchmark with 100 iterations in a database that also held another project that held about 3500 APIs in it. The results are good all around, but are an especially significant improvement for artifacts.

Benchmark before:
```
BenchmarkGetApi/GetApi-10    	     100	    460169 ns/op
BenchmarkListApis/ListApis-10         	     100	   1497588 ns/op
BenchmarkCreateApi/CreateApi-10       	     100	    699478 ns/op
BenchmarkUpdateApi/UpdateApi-10       	     100	    847783 ns/op
BenchmarkDeleteApi/DeleteApi-10       	     100	   2851318 ns/op
BenchmarkListArtifacts/ListApiArtifacts-10         	     100	 155312918 ns/op
BenchmarkListArtifacts/ListVersionArtifacts-10     	     100	 178454175 ns/op
BenchmarkListArtifacts/ListSpecArtifacts-10        	     100	 443777684 ns/op
BenchmarkListArtifacts/ListDeploymentArtifacts-10  	     100	 304121872 ns/op
PASS
ok  	github.com/apigee/registry/tests/benchmark	130.127s
```

Benchmark after:
```
BenchmarkGetApi/GetApi-10    	     100	    468882 ns/op
BenchmarkListApis/ListApis-10         	     100	   1340474 ns/op
BenchmarkCreateApi/CreateApi-10       	     100	    674730 ns/op
BenchmarkUpdateApi/UpdateApi-10       	     100	    982301 ns/op
BenchmarkDeleteApi/DeleteApi-10       	     100	   2652655 ns/op
BenchmarkListArtifacts/ListApiArtifacts-10         	     100	 154785002 ns/op
BenchmarkListArtifacts/ListVersionArtifacts-10     	     100	 178868755 ns/op
BenchmarkListArtifacts/ListSpecArtifacts-10        	     100	 261795871 ns/op
BenchmarkListArtifacts/ListDeploymentArtifacts-10  	     100	 221990710 ns/op
PASS
ok  	github.com/apigee/registry/tests/benchmark	100.744s
```
