### PR TITLE
openapi and discovery-format tests for `registry compute vocabulary`

### DIFF
--- a/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/discovery/discovery.json
+++ b/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/discovery/discovery.json
@@ -1,0 +1,4100 @@
+{
+  "ownerDomain": "google.com",
+  "schemas": {
+    "ApiVersion": {
+      "id": "ApiVersion",
+      "description": "Describes a particular version of an API. ApiVersions are what consumers actually use.",
+      "properties": {
+        "primarySpec": {
+          "type": "string",
+          "description": "The primary spec for this version. Format: projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object"
+        },
+        "description": {
+          "description": "A detailed description.",
+          "type": "string"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. Last update timestamp."
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "description": "A user-definable description of the lifecycle phase of this API version. Format: free-form, but we expect single words that describe API maturity, e.g., \"CONCEPT\", \"DESIGN\", \"DEVELOPMENT\", \"STAGING\", \"PRODUCTION\", \"DEPRECATED\", \"RETIRED\"."
+        },
+        "createTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Creation timestamp.",
+          "format": "google-datetime"
+        }
+      },
+      "type": "object"
+    },
+    "Instance": {
+      "properties": {
+        "createTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "description": "Output only. Creation timestamp.",
+          "type": "string"
+        },
+        "stateMessage": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Extra information of Instance.State if the state is `FAILED`."
+        },
+        "updateTime": {
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime",
+          "description": "Output only. Last update timestamp."
+        },
+        "config": {
+          "description": "Required. Config of the Instance.",
+          "$ref": "Config"
+        },
+        "state": {
+          "description": "Output only. The current state of the Instance.",
+          "readOnly": true,
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "The Instance has not been initialized or has been deleted.",
+            "The Instance is being created.",
+            "The Instance has been created and is ready for use.",
+            "The Instance is being updated.",
+            "The Instance is being deleted.",
+            "The Instance encountered an error during a state change."
+          ],
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "INACTIVE",
+            "CREATING",
+            "ACTIVE",
+            "UPDATING",
+            "DELETING",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "build": {
+          "$ref": "Build",
+          "description": "Output only. Build info of the Instance if it's in `ACTIVE` state.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Format: `projects/*/locations/*/instance`. Currently only `locations/global` is supported."
+        }
+      },
+      "id": "Instance",
+      "type": "object",
+      "description": "An Instance represents the instance resources of the Registry. Currently, only one instance is allowed for each project."
+    },
+    "Config": {
+      "properties": {
+        "cmekKeyName": {
+          "type": "string",
+          "description": "Required. The Customer Managed Encryption Key (CMEK) used for data encryption. The CMEK name should follow the format of `projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)`, where the `location` must match InstanceConfig.location."
+        },
+        "location": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The GCP location where the Instance resides."
+        }
+      },
+      "id": "Config",
+      "type": "object",
+      "description": "Available configurations to provision an Instance."
+    },
+    "Status": {
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            }
+          }
+        }
+      },
+      "type": "object",
+      "id": "Status",
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
+    },
+    "ListApisResponse": {
+      "id": "ListApisResponse",
+      "properties": {
+        "apis": {
+          "type": "array",
+          "items": {
+            "$ref": "Api"
+          },
+          "description": "The APIs from the specified publisher."
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        }
+      },
+      "description": "Response message for ListApis.",
+      "type": "object"
+    },
+    "Empty": {
+      "id": "Empty",
+      "type": "object",
+      "properties": {},
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }"
+    },
+    "TagApiSpecRevisionRequest": {
+      "description": "Request message for TagApiSpecRevision.",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Required. The tag to apply. The tag should be at most 40 characters, and match `a-z{3,39}`.",
+          "type": "string"
+        }
+      },
+      "id": "TagApiSpecRevisionRequest"
+    },
+    "OperationMetadata": {
+      "id": "OperationMetadata",
+      "type": "object",
+      "properties": {
+        "createTime": {
+          "description": "The time the operation was created.",
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "verb": {
+          "type": "string",
+          "description": "Name of the verb executed by the operation."
+        },
+        "statusMessage": {
+          "type": "string",
+          "description": "Human-readable status of the operation, if any."
+        },
+        "endTime": {
+          "format": "google-datetime",
+          "description": "The time the operation finished running.",
+          "type": "string"
+        },
+        "cancellationRequested": {
+          "description": "Identifies whether the user has requested cancellation of the operation. Operations that have successfully been cancelled have Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`.",
+          "type": "boolean"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "API version used to start the operation."
+        },
+        "target": {
+          "type": "string",
+          "description": "Server-defined resource path for the target of the operation."
+        }
+      },
+      "description": "Represents the metadata of the long-running operation."
+    },
+    "ApiSpec": {
+      "properties": {
+        "filename": {
+          "description": "A possibly-hierarchical name used to refer to the spec from other specs.",
+          "type": "string"
+        },
+        "hash": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. A SHA-256 hash of the spec's contents. If the spec is gzipped, this is the hash of the uncompressed spec."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "A style (format) descriptor for this spec that is specified as a Media Type (https://en.wikipedia.org/wiki/Media_type). Possible values include `application/vnd.apigee.proto`, `application/vnd.apigee.openapi`, and `application/vnd.apigee.graphql`, with possible suffixes representing compression types. These hypothetical names are defined in the vendor tree defined in RFC6838 (https://tools.ietf.org/html/rfc6838) and are not final. Content types can specify compression. Currently only GZip compression is supported (indicated with \"+gzip\")."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object"
+        },
+        "revisionUpdateTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Last update timestamp: when the represented revision was last modified.",
+          "format": "google-datetime"
+        },
+        "createTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "description": "Output only. Creation timestamp; when the spec resource was created.",
+          "type": "string"
+        },
+        "sourceUri": {
+          "description": "The original source URI of the spec (if one exists). This is an external location that can be used for reference purposes but which may not be authoritative since this external resource may change after the spec is retrieved.",
+          "type": "string"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true,
+          "description": "Output only. The size of the spec file in bytes. If the spec is gzipped, this is the size of the uncompressed spec."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "revisionCreateTime": {
+          "description": "Output only. Revision creation timestamp; when the represented revision was created.",
+          "type": "string",
+          "readOnly": true,
+          "format": "google-datetime"
+        },
+        "revisionId": {
+          "description": "Output only. Immutable. The revision ID of the spec. A new revision is committed whenever the spec contents are changed. The format is an 8-character hexadecimal string.",
+          "type": "string",
+          "readOnly": true
+        },
+        "description": {
+          "description": "A detailed description.",
+          "type": "string"
+        },
+        "contents": {
+          "description": "Input only. The contents of the spec. Provided by API callers when specs are created or updated. To access the contents of a spec, use GetApiSpecContents.",
+          "format": "byte",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        }
+      },
+      "type": "object",
+      "description": "Describes a version of an API in a structured way. ApiSpecs provide formal descriptions that consumers can use to use a version. ApiSpec resources are intended to be fully-resolved descriptions of an ApiVersion. When specs consist of multiple files, these should be bundled together (e.g., in a zip archive) and stored as a unit. Multiple specs can exist to provide representations in different API description formats. Synchronization of these representations would be provided by tooling and background services.",
+      "id": "ApiSpec"
+    },
+    "Api": {
+      "description": "A top-level description of an API. Produced by producers and are commitments to provide services.",
+      "type": "object",
+      "id": "Api",
+      "properties": {
+        "updateTime": {
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. Last update timestamp.",
+          "type": "string"
+        },
+        "availability": {
+          "type": "string",
+          "description": "A user-definable description of the availability of this service. Format: free-form, but we expect single words that describe availability, e.g., \"NONE\", \"TESTING\", \"PREVIEW\", \"GENERAL\", \"DEPRECATED\", \"SHUTDOWN\"."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        },
+        "annotations": {
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "createTime": {
+          "description": "Output only. Creation timestamp.",
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "recommendedDeployment": {
+          "description": "The recommended deployment of the API. Format: `projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}`",
+          "type": "string"
+        },
+        "recommendedVersion": {
+          "type": "string",
+          "description": "The recommended version of the API. Format: `projects/{project}/locations/{location}/apis/{api}/versions/{version}`"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores, and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "type": "object"
+        }
+      }
+    },
+    "RollbackApiDeploymentRequest": {
+      "properties": {
+        "revisionId": {
+          "description": "Required. The revision ID to roll back to. It must be a revision of the same deployment. Example: `c7cfa2a8`",
+          "type": "string"
+        }
+      },
+      "description": "Request message for RollbackApiDeployment.",
+      "type": "object",
+      "id": "RollbackApiDeploymentRequest"
+    },
+    "Build": {
+      "type": "object",
+      "id": "Build",
+      "properties": {
+        "repo": {
+          "description": "Output only. Path of the open source repository: github.com/apigee/registry.",
+          "type": "string",
+          "readOnly": true
+        },
+        "commitTime": {
+          "format": "google-datetime",
+          "description": "Output only. Commit time of the latest commit in the build.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "commitId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Commit ID of the latest commit in the build."
+        }
+      },
+      "description": "Build information of the Instance if it's in `ACTIVE` state."
+    },
+    "ListApiSpecsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "apiSpecs": {
+          "type": "array",
+          "items": {
+            "$ref": "ApiSpec"
+          },
+          "description": "The specs from the specified publisher."
+        }
+      },
+      "description": "Response message for ListApiSpecs.",
+      "id": "ListApiSpecsResponse",
+      "type": "object"
+    },
+    "ListArtifactsResponse": {
+      "type": "object",
+      "id": "ListArtifactsResponse",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "artifacts": {
+          "description": "The artifacts from the specified publisher.",
+          "type": "array",
+          "items": {
+            "$ref": "Artifact"
+          }
+        }
+      },
+      "description": "Response message for ListArtifacts."
+    },
+    "ListApiDeploymentRevisionsResponse": {
+      "properties": {
+        "apiDeployments": {
+          "description": "The revisions of the deployment.",
+          "items": {
+            "$ref": "ApiDeployment"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        }
+      },
+      "description": "Response message for ListApiDeploymentRevisionsResponse.",
+      "type": "object",
+      "id": "ListApiDeploymentRevisionsResponse"
+    },
+    "ListApiVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "apiVersions": {
+          "items": {
+            "$ref": "ApiVersion"
+          },
+          "description": "The versions from the specified publisher.",
+          "type": "array"
+        }
+      },
+      "description": "Response message for ListApiVersions.",
+      "id": "ListApiVersionsResponse"
+    },
+    "ApiDeployment": {
+      "type": "object",
+      "description": "Describes a service running at particular address that provides a particular version of an API. ApiDeployments have revisions which correspond to different configurations of a single deployment in time. Revision identifiers should be updated whenever the served API spec or endpoint address changes.",
+      "id": "ApiDeployment",
+      "properties": {
+        "revisionCreateTime": {
+          "type": "string",
+          "description": "Output only. Revision creation timestamp; when the represented revision was created.",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "revisionUpdateTime": {
+          "description": "Output only. Last update timestamp: when the represented revision was last modified.",
+          "type": "string",
+          "readOnly": true,
+          "format": "google-datetime"
+        },
+        "intendedAudience": {
+          "description": "Text briefly identifying the intended audience of the API. Changes to this value will not affect the revision.",
+          "type": "string"
+        },
+        "externalChannelUri": {
+          "type": "string",
+          "description": "The address of the external channel of the API (e.g., the Developer Portal). Changes to this value will not affect the revision."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed."
+        },
+        "createTime": {
+          "type": "string",
+          "description": "Output only. Creation timestamp; when the deployment resource was created.",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "revisionId": {
+          "type": "string",
+          "description": "Output only. Immutable. The revision ID of the deployment. A new revision is committed whenever the deployment contents are changed. The format is an 8-character hexadecimal string.",
+          "readOnly": true
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "accessGuidance": {
+          "type": "string",
+          "description": "Text briefly describing how to access the endpoint. Changes to this value will not affect the revision."
+        },
+        "apiSpecRevision": {
+          "description": "The full resource name (including revision ID) of the spec of the API being served by the deployment. Changes to this value will update the revision. Format: `projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec@revision}`",
+          "type": "string"
+        },
+        "endpointUri": {
+          "type": "string",
+          "description": "The address where the deployment is serving. Changes to this value will update the revision."
+        }
+      }
+    },
+    "RollbackApiSpecRequest": {
+      "id": "RollbackApiSpecRequest",
+      "description": "Request message for RollbackApiSpec.",
+      "properties": {
+        "revisionId": {
+          "type": "string",
+          "description": "Required. The revision ID to roll back to. It must be a revision of the same spec. Example: `c7cfa2a8`"
+        }
+      },
+      "type": "object"
+    },
+    "TagApiDeploymentRevisionRequest": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Required. The tag to apply. The tag should be at most 40 characters, and match `a-z{3,39}`.",
+          "type": "string"
+        }
+      },
+      "id": "TagApiDeploymentRevisionRequest",
+      "description": "Request message for TagApiDeploymentRevision."
+    },
+    "HttpBody": {
+      "id": "HttpBody",
+      "properties": {
+        "extensions": {
+          "description": "Application specific response metadata. Must be set in the first response for streaming APIs.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "any",
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          }
+        },
+        "data": {
+          "description": "The HTTP request/response body as raw binary.",
+          "format": "byte",
+          "type": "string"
+        },
+        "contentType": {
+          "description": "The HTTP Content-Type header value specifying the content type of the body.",
+          "type": "string"
+        }
+      },
+      "description": "Message that represents an arbitrary HTTP body. It should only be used for payload formats that can't be represented as JSON, such as raw binary or an HTML page. This message can be used both in streaming and non-streaming API methods in the request as well as the response. It can be used as a top-level request field, which is convenient if one wants to extract parameters from either the URL or HTTP template into the request fields and also want access to the raw HTTP body. Example: message GetResourceRequest { // A unique request id. string request_id = 1; // The raw HTTP body is bound to this field. google.api.HttpBody http_body = 2; } service ResourceService { rpc GetResource(GetResourceRequest) returns (google.api.HttpBody); rpc UpdateResource(google.api.HttpBody) returns (google.protobuf.Empty); } Example with streaming methods: service CaldavService { rpc GetCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); rpc UpdateCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); } Use of this type only changes how the request and response bodies are handled, all other features will continue to work unchanged.",
+      "type": "object"
+    },
+    "Binding": {
+      "id": "Binding",
+      "type": "object",
+      "description": "Associates `members`, or principals, with a `role`.",
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`."
+        },
+        "condition": {
+          "$ref": "Expr",
+          "description": "The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding."
+        }
+      }
+    },
+    "ListLocationsResponse": {
+      "id": "ListLocationsResponse",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "A list of locations that matches the specified filter in the request.",
+          "items": {
+            "$ref": "Location"
+          }
+        },
+        "nextPageToken": {
+          "description": "The standard List next-page token.",
+          "type": "string"
+        }
+      },
+      "description": "The response message for Locations.ListLocations.",
+      "type": "object"
+    },
+    "Artifact": {
+      "type": "object",
+      "id": "Artifact",
+      "description": "Artifacts of resources. Artifacts are unique (single-value) per resource and are used to store metadata that is too large or numerous to be stored directly on the resource. Since artifacts are stored separately from parent resources, they should generally be used for metadata that is needed infrequently, i.e., not for display in primary views of the resource but perhaps displayed or downloaded upon request. The `ListArtifacts` method allows artifacts to be quickly enumerated and checked for presence without downloading their (potentially-large) contents.",
+      "properties": {
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "A content type specifier for the artifact. Content type specifiers are Media Types (https://en.wikipedia.org/wiki/Media_type) with a possible \"schema\" parameter that specifies a schema for the stored information. Content types can specify compression. Currently only GZip compression is supported (indicated with \"+gzip\")."
+        },
+        "hash": {
+          "description": "Output only. A SHA-256 hash of the artifact's contents. If the artifact is gzipped, this is the hash of the uncompressed artifact.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "createTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. Creation timestamp."
+        },
+        "contents": {
+          "description": "Input only. The contents of the artifact. Provided by API callers when artifacts are created or replaced. To access the contents of an artifact, use GetArtifactContents.",
+          "type": "string",
+          "format": "byte"
+        },
+        "updateTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. Last update timestamp."
+        },
+        "labels": {
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with \"registry.googleapis.com/\" and cannot be changed.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sizeBytes": {
+          "format": "int32",
+          "description": "Output only. The size of the artifact in bytes. If the artifact is gzipped, this is the size of the uncompressed artifact.",
+          "readOnly": true,
+          "type": "integer"
+        }
+      }
+    },
+    "SetIamPolicyRequest": {
+      "description": "Request message for `SetIamPolicy` method.",
+      "properties": {
+        "policy": {
+          "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them.",
+          "$ref": "Policy"
+        }
+      },
+      "id": "SetIamPolicyRequest",
+      "type": "object"
+    },
+    "Operation": {
+      "type": "object",
+      "id": "Operation",
+      "description": "This resource represents a long-running operation that is the result of a network API call.",
+      "properties": {
+        "error": {
+          "description": "The error result of the operation in case of failure or cancellation.",
+          "$ref": "Status"
+        },
+        "response": {
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "description": "The normal response of the operation in case of success. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "type": "object"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          }
+        },
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
+          "type": "string"
+        },
+        "done": {
+          "type": "boolean",
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+        }
+      }
+    },
+    "Location": {
+      "id": "Location",
+      "description": "A resource that represents Google Cloud Platform location.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Resource name for the location, which may vary between implementations. For example: `\"projects/example-project/locations/us-east1\"`"
+        },
+        "locationId": {
+          "description": "The canonical id for this location. For example: `\"us-east1\"`.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The friendly name for this location, typically a nearby city name. For example, \"Tokyo\".",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "description": "Service-specific metadata. For example the available capacity at the given location.",
+          "type": "object"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Cross-service attributes for the location. For example {\"cloud.googleapis.com/region\": \"us-east1\"}"
+        }
+      },
+      "type": "object"
+    },
+    "ListOperationsResponse": {
+      "properties": {
+        "operations": {
+          "description": "A list of operations that matches the specified filter in the request.",
+          "items": {
+            "$ref": "Operation"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The standard List next-page token."
+        }
+      },
+      "id": "ListOperationsResponse",
+      "description": "The response message for Operations.ListOperations.",
+      "type": "object"
+    },
+    "TestIamPermissionsResponse": {
+      "properties": {
+        "permissions": {
+          "items": {
+            "type": "string"
+          },
+          "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed.",
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "TestIamPermissionsResponse",
+      "description": "Response message for `TestIamPermissions` method."
+    },
+    "Expr": {
+      "description": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() \u003c 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.",
+      "properties": {
+        "location": {
+          "description": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "description": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
+        },
+        "expression": {
+          "description": "Textual representation of an expression in Common Expression Language syntax.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "id": "Expr"
+    },
+    "TestIamPermissionsRequest": {
+      "id": "TestIamPermissionsRequest",
+      "properties": {
+        "permissions": {
+          "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "Request message for `TestIamPermissions` method."
+    },
+    "CancelOperationRequest": {
+      "id": "CancelOperationRequest",
+      "properties": {},
+      "description": "The request message for Operations.CancelOperation.",
+      "type": "object"
+    },
+    "ListApiSpecRevisionsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "description": "A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "apiSpecs": {
+          "description": "The revisions of the spec.",
+          "type": "array",
+          "items": {
+            "$ref": "ApiSpec"
+          }
+        }
+      },
+      "type": "object",
+      "description": "Response message for ListApiSpecRevisionsResponse.",
+      "id": "ListApiSpecRevisionsResponse"
+    },
+    "Policy": {
+      "description": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time \u003c timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).",
+      "type": "object",
+      "properties": {
+        "etag": {
+          "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost.",
+          "type": "string",
+          "format": "byte"
+        },
+        "version": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+        },
+        "bindings": {
+          "type": "array",
+          "description": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`.",
+          "items": {
+            "$ref": "Binding"
+          }
+        }
+      },
+      "id": "Policy"
+    },
+    "ListApiDeploymentsResponse": {
+      "properties": {
+        "apiDeployments": {
+          "type": "array",
+          "items": {
+            "$ref": "ApiDeployment"
+          },
+          "description": "The deployments from the specified publisher."
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        }
+      },
+      "id": "ListApiDeploymentsResponse",
+      "description": "Response message for ListApiDeployments.",
+      "type": "object"
+    }
+  },
+  "description": "",
+  "baseUrl": "https://apigeeregistry.googleapis.com/",
+  "batchPath": "batch",
+  "name": "apigeeregistry",
+  "canonicalName": "Apigee Registry",
+  "parameters": {
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true"
+    },
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "type": "string",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query"
+    },
+    "uploadType": {
+      "location": "query",
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string"
+    },
+    "oauth_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user."
+    },
+    "quotaUser": {
+      "type": "string",
+      "location": "query",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+    },
+    "upload_protocol": {
+      "location": "query",
+      "type": "string",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
+    },
+    "alt": {
+      "default": "json",
+      "description": "Data format for response.",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "access_token": {
+      "type": "string",
+      "location": "query",
+      "description": "OAuth access token."
+    },
+    "callback": {
+      "type": "string",
+      "location": "query",
+      "description": "JSONP"
+    }
+  },
+  "documentationLink": "https://cloud.google.com/apigee/docs/api-hub/what-is-api-hub",
+  "icons": {
+    "x32": "http://www.google.com/images/icons/product/search-32.gif",
+    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+  },
+  "discoveryVersion": "v1",
+  "ownerName": "Google",
+  "servicePath": "",
+  "kind": "discovery#restDescription",
+  "id": "apigeeregistry:v1",
+  "version_module": true,
+  "mtlsRootUrl": "https://apigeeregistry.mtls.googleapis.com/",
+  "resources": {
+    "projects": {
+      "resources": {
+        "locations": {
+          "resources": {
+            "apis": {
+              "resources": {
+                "artifacts": {
+                  "methods": {
+                    "getIamPolicy": {
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:getIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.getIamPolicy",
+                      "parameters": {
+                        "resource": {
+                          "type": "string",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true
+                        },
+                        "options.requestedPolicyVersion": {
+                          "location": "query",
+                          "type": "integer",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                          "format": "int32"
+                        }
+                      },
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "Policy"
+                      }
+                    },
+                    "get": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "description": "Returns a specified artifact.",
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "type": "string",
+                          "location": "path"
+                        }
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.get",
+                      "httpMethod": "GET",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "getContents": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                          "type": "string"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.getContents",
+                      "httpMethod": "GET",
+                      "path": "v1/{+name}:getContents",
+                      "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:getContents",
+                      "response": {
+                        "$ref": "HttpBody"
+                      }
+                    },
+                    "replaceArtifact": {
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "type": "string",
+                          "required": true,
+                          "description": "Resource name.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$"
+                        }
+                      },
+                      "httpMethod": "PUT",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "request": {
+                        "$ref": "Artifact"
+                      },
+                      "description": "Used to replace a specified artifact.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.replaceArtifact",
+                      "path": "v1/{+name}"
+                    },
+                    "setIamPolicy": {
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "type": "string",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:setIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.setIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "httpMethod": "POST"
+                    },
+                    "testIamPermissions": {
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true,
+                          "location": "path",
+                          "type": "string"
+                        }
+                      },
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:testIamPermissions",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.testIamPermissions",
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "httpMethod": "POST"
+                    },
+                    "create": {
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "parameters": {
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "location": "path",
+                          "required": true
+                        },
+                        "artifactId": {
+                          "type": "string",
+                          "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                          "location": "query"
+                        }
+                      },
+                      "path": "v1/{+parent}/artifacts",
+                      "request": {
+                        "$ref": "Artifact"
+                      },
+                      "description": "Creates a specified artifact.",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.create",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts",
+                      "httpMethod": "POST"
+                    },
+                    "list": {
+                      "path": "v1/{+parent}/artifacts",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "parameters": {
+                        "pageSize": {
+                          "location": "query",
+                          "format": "int32",
+                          "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "type": "integer"
+                        },
+                        "orderBy": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\""
+                        },
+                        "pageToken": {
+                          "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                          "type": "string"
+                        },
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "type": "string",
+                          "location": "path"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.list",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "description": "Returns matching artifacts.",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts",
+                      "response": {
+                        "$ref": "ListArtifactsResponse"
+                      }
+                    },
+                    "delete": {
+                      "description": "Removes a specified artifact.",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.delete",
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "path": "v1/{+name}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "DELETE",
+                      "response": {
+                        "$ref": "Empty"
+                      }
+                    }
+                  }
+                },
+                "versions": {
+                  "methods": {
+                    "setIamPolicy": {
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "id": "apigeeregistry.projects.locations.apis.versions.setIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:setIamPolicy",
+                      "response": {
+                        "$ref": "Policy"
+                      }
+                    },
+                    "get": {
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "description": "Returns a specified version.",
+                      "httpMethod": "GET",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "description": "Required. The name of the version to retrieve. Format: `projects/*/locations/*/apis/*/versions/*`",
+                          "location": "path",
+                          "required": true,
+                          "type": "string"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.versions.get"
+                    },
+                    "testIamPermissions": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "location": "path",
+                          "required": true
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.versions.testIamPermissions",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:testIamPermissions",
+                      "httpMethod": "POST"
+                    },
+                    "create": {
+                      "parameters": {
+                        "apiVersionId": {
+                          "location": "query",
+                          "description": "Required. The ID to use for the version, which will become the final component of the version's resource name. This value should be 1-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                          "type": "string"
+                        },
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of versions. Format: `projects/*/locations/*/apis/*`",
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.versions.create",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "request": {
+                        "$ref": "ApiVersion"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "description": "Creates a specified version.",
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "path": "v1/{+parent}/versions",
+                      "httpMethod": "POST"
+                    },
+                    "getIamPolicy": {
+                      "parameters": {
+                        "resource": {
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$"
+                        },
+                        "options.requestedPolicyVersion": {
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                          "location": "query",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      },
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:getIamPolicy",
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.versions.getIamPolicy",
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "path": "v1/{+resource}:getIamPolicy"
+                    },
+                    "list": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "path": "v1/{+parent}/versions",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions",
+                      "id": "apigeeregistry.projects.locations.apis.versions.list",
+                      "parameters": {
+                        "pageSize": {
+                          "location": "query",
+                          "description": "The maximum number of versions to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields."
+                        },
+                        "pageToken": {
+                          "description": "A page token, received from a previous `ListApiVersions` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiVersions` must match the call that provided the page token.",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "parent": {
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of versions. Format: `projects/*/locations/*/apis/*`"
+                        },
+                        "orderBy": {
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "type": "string",
+                          "location": "query"
+                        }
+                      },
+                      "response": {
+                        "$ref": "ListApiVersionsResponse"
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "description": "Returns matching versions."
+                    },
+                    "patch": {
+                      "request": {
+                        "$ref": "ApiVersion"
+                      },
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "httpMethod": "PATCH",
+                      "parameters": {
+                        "updateMask": {
+                          "type": "string",
+                          "location": "query",
+                          "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                          "format": "google-fieldmask"
+                        },
+                        "allowMissing": {
+                          "type": "boolean",
+                          "description": "If set to true, and the version is not found, a new version will be created. In this situation, `update_mask` is ignored.",
+                          "location": "query"
+                        },
+                        "name": {
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "description": "Resource name.",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "description": "Used to modify a specified version.",
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.versions.patch"
+                    },
+                    "delete": {
+                      "parameters": {
+                        "force": {
+                          "location": "query",
+                          "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "type": "string",
+                          "description": "Required. The name of the version to delete. Format: `projects/*/locations/*/apis/*/versions/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$"
+                        }
+                      },
+                      "path": "v1/{+name}",
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Removes a specified version and all of the resources that it owns.",
+                      "httpMethod": "DELETE",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.versions.delete",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}"
+                    }
+                  },
+                  "resources": {
+                    "artifacts": {
+                      "methods": {
+                        "get": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "required": true
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "httpMethod": "GET",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.get",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Returns a specified artifact.",
+                          "response": {
+                            "$ref": "Artifact"
+                          }
+                        },
+                        "replaceArtifact": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "description": "Resource name.",
+                              "required": true
+                            }
+                          },
+                          "httpMethod": "PUT",
+                          "description": "Used to replace a specified artifact.",
+                          "path": "v1/{+name}",
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.replaceArtifact",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}"
+                        },
+                        "delete": {
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                              "location": "path",
+                              "required": true,
+                              "type": "string"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "DELETE",
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "description": "Removes a specified artifact.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.delete"
+                        },
+                        "setIamPolicy": {
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.setIamPolicy",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "request": {
+                            "$ref": "SetIamPolicyRequest"
+                          },
+                          "parameters": {
+                            "resource": {
+                              "required": true,
+                              "type": "string",
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$"
+                            }
+                          },
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "httpMethod": "POST",
+                          "path": "v1/{+resource}:setIamPolicy",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:setIamPolicy"
+                        },
+                        "testIamPermissions": {
+                          "response": {
+                            "$ref": "TestIamPermissionsResponse"
+                          },
+                          "request": {
+                            "$ref": "TestIamPermissionsRequest"
+                          },
+                          "path": "v1/{+resource}:testIamPermissions",
+                          "parameters": {
+                            "resource": {
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "required": true,
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.testIamPermissions",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:testIamPermissions",
+                          "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                          "parameterOrder": [
+                            "resource"
+                          ]
+                        },
+                        "getContents": {
+                          "path": "v1/{+name}:getContents",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.getContents",
+                          "httpMethod": "GET",
+                          "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:getContents",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "location": "path",
+                              "type": "string",
+                              "required": true,
+                              "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`"
+                            }
+                          },
+                          "response": {
+                            "$ref": "HttpBody"
+                          }
+                        },
+                        "create": {
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "POST",
+                          "description": "Creates a specified artifact.",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts",
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.create",
+                          "parameters": {
+                            "artifactId": {
+                              "location": "query",
+                              "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "type": "string"
+                            },
+                            "parent": {
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "type": "string",
+                              "required": true
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "path": "v1/{+parent}/artifacts"
+                        },
+                        "list": {
+                          "parameters": {
+                            "pageSize": {
+                              "type": "integer",
+                              "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                              "format": "int32",
+                              "location": "query"
+                            },
+                            "orderBy": {
+                              "type": "string",
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "location": "query"
+                            },
+                            "parent": {
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "location": "path",
+                              "required": true
+                            },
+                            "filter": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                            },
+                            "pageToken": {
+                              "location": "query",
+                              "type": "string",
+                              "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token."
+                            }
+                          },
+                          "path": "v1/{+parent}/artifacts",
+                          "response": {
+                            "$ref": "ListArtifactsResponse"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Returns matching artifacts.",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.list"
+                        },
+                        "getIamPolicy": {
+                          "parameters": {
+                            "resource": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "type": "string",
+                              "location": "path",
+                              "required": true,
+                              "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            },
+                            "options.requestedPolicyVersion": {
+                              "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                              "format": "int32",
+                              "location": "query",
+                              "type": "integer"
+                            }
+                          },
+                          "path": "v1/{+resource}:getIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.getIamPolicy",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:getIamPolicy",
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set."
+                        }
+                      }
+                    },
+                    "specs": {
+                      "resources": {
+                        "artifacts": {
+                          "methods": {
+                            "testIamPermissions": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:testIamPermissions",
+                              "httpMethod": "POST",
+                              "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.testIamPermissions",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "response": {
+                                "$ref": "TestIamPermissionsResponse"
+                              },
+                              "request": {
+                                "$ref": "TestIamPermissionsRequest"
+                              },
+                              "path": "v1/{+resource}:testIamPermissions",
+                              "parameters": {
+                                "resource": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path",
+                                  "type": "string",
+                                  "required": true,
+                                  "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                                }
+                              },
+                              "parameterOrder": [
+                                "resource"
+                              ]
+                            },
+                            "get": {
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "description": "Returns a specified artifact.",
+                              "path": "v1/{+name}",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.get",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "parameters": {
+                                "name": {
+                                  "location": "path",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "type": "string",
+                                  "required": true,
+                                  "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`"
+                                }
+                              },
+                              "httpMethod": "GET"
+                            },
+                            "delete": {
+                              "httpMethod": "DELETE",
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.delete",
+                              "description": "Removes a specified artifact.",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameters": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                                  "location": "path",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "required": true
+                                }
+                              },
+                              "response": {
+                                "$ref": "Empty"
+                              },
+                              "path": "v1/{+name}"
+                            },
+                            "list": {
+                              "description": "Returns matching artifacts.",
+                              "response": {
+                                "$ref": "ListArtifactsResponse"
+                              },
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts",
+                              "parameterOrder": [
+                                "parent"
+                              ],
+                              "parameters": {
+                                "parent": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                                  "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                                  "required": true,
+                                  "location": "path",
+                                  "type": "string"
+                                },
+                                "filter": {
+                                  "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                                  "type": "string",
+                                  "location": "query"
+                                },
+                                "pageToken": {
+                                  "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                                  "type": "string",
+                                  "location": "query"
+                                },
+                                "pageSize": {
+                                  "format": "int32",
+                                  "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                                  "type": "integer",
+                                  "location": "query"
+                                },
+                                "orderBy": {
+                                  "type": "string",
+                                  "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                                  "location": "query"
+                                }
+                              },
+                              "httpMethod": "GET",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.list",
+                              "path": "v1/{+parent}/artifacts"
+                            },
+                            "replaceArtifact": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "description": "Used to replace a specified artifact.",
+                              "request": {
+                                "$ref": "Artifact"
+                              },
+                              "path": "v1/{+name}",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "parameters": {
+                                "name": {
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "Resource name."
+                                }
+                              },
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.replaceArtifact",
+                              "httpMethod": "PUT"
+                            },
+                            "getIamPolicy": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:getIamPolicy",
+                              "httpMethod": "GET",
+                              "response": {
+                                "$ref": "Policy"
+                              },
+                              "parameters": {
+                                "resource": {
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "required": true
+                                },
+                                "options.requestedPolicyVersion": {
+                                  "format": "int32",
+                                  "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                                  "location": "query",
+                                  "type": "integer"
+                                }
+                              },
+                              "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.getIamPolicy",
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "path": "v1/{+resource}:getIamPolicy"
+                            },
+                            "create": {
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts",
+                              "request": {
+                                "$ref": "Artifact"
+                              },
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameterOrder": [
+                                "parent"
+                              ],
+                              "description": "Creates a specified artifact.",
+                              "httpMethod": "POST",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.create",
+                              "path": "v1/{+parent}/artifacts",
+                              "parameters": {
+                                "artifactId": {
+                                  "location": "query",
+                                  "type": "string",
+                                  "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                                },
+                                "parent": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                                  "required": true,
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                                }
+                              }
+                            },
+                            "setIamPolicy": {
+                              "path": "v1/{+resource}:setIamPolicy",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:setIamPolicy",
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "httpMethod": "POST",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.setIamPolicy",
+                              "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                              "parameters": {
+                                "resource": {
+                                  "location": "path",
+                                  "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "required": true,
+                                  "type": "string"
+                                }
+                              },
+                              "request": {
+                                "$ref": "SetIamPolicyRequest"
+                              },
+                              "response": {
+                                "$ref": "Policy"
+                              }
+                            },
+                            "getContents": {
+                              "response": {
+                                "$ref": "HttpBody"
+                              },
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "httpMethod": "GET",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:getContents",
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.getContents",
+                              "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                              "path": "v1/{+name}:getContents",
+                              "parameters": {
+                                "name": {
+                                  "type": "string",
+                                  "required": true,
+                                  "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "methods": {
+                        "create": {
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "request": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Creates a specified spec.",
+                          "path": "v1/{+parent}/specs",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.create",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "POST",
+                          "parameters": {
+                            "parent": {
+                              "type": "string",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "location": "path",
+                              "description": "Required. The parent, which owns this collection of specs. Format: `projects/*/locations/*/apis/*/versions/*`"
+                            },
+                            "apiSpecId": {
+                              "type": "string",
+                              "description": "Required. The ID to use for the spec, which will become the final component of the spec's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "location": "query"
+                            }
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ]
+                        },
+                        "patch": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.patch",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "httpMethod": "PATCH",
+                          "request": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Used to modify a specified spec.",
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameters": {
+                            "allowMissing": {
+                              "location": "query",
+                              "description": "If set to true, and the spec is not found, a new spec will be created. In this situation, `update_mask` is ignored.",
+                              "type": "boolean"
+                            },
+                            "updateMask": {
+                              "location": "query",
+                              "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                              "format": "google-fieldmask",
+                              "type": "string"
+                            },
+                            "name": {
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Resource name."
+                            }
+                          }
+                        },
+                        "rollback": {
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Required. The spec being rolled back.",
+                              "location": "path",
+                              "type": "string"
+                            }
+                          },
+                          "path": "v1/{+name}:rollback",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.rollback",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "request": {
+                            "$ref": "RollbackApiSpecRequest"
+                          },
+                          "description": "Sets the current revision to a specified prior revision. Note that this creates a new revision with a new revision ID.",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:rollback",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "httpMethod": "POST"
+                        },
+                        "get": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "required": true,
+                              "description": "Required. The name of the spec to retrieve. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$"
+                            }
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.get",
+                          "httpMethod": "GET",
+                          "description": "Returns a specified spec.",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "ApiSpec"
+                          }
+                        },
+                        "tagRevision": {
+                          "description": "Adds a tag to a specified revision of a spec.",
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The name of the spec to be tagged, including the revision ID.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$"
+                            }
+                          },
+                          "httpMethod": "POST",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:tagRevision",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.tagRevision",
+                          "request": {
+                            "$ref": "TagApiSpecRevisionRequest"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "path": "v1/{+name}:tagRevision",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          }
+                        },
+                        "delete": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.delete",
+                          "description": "Removes a specified spec, all revisions, and all child resources (e.g., artifacts).",
+                          "parameters": {
+                            "force": {
+                              "location": "query",
+                              "type": "boolean",
+                              "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)"
+                            },
+                            "name": {
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The name of the spec to delete. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "location": "path"
+                            }
+                          },
+                          "httpMethod": "DELETE"
+                        },
+                        "deleteRevision": {
+                          "httpMethod": "DELETE",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:deleteRevision",
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "description": "Required. The name of the spec revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8`",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "type": "string"
+                            }
+                          },
+                          "path": "v1/{+name}:deleteRevision",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.deleteRevision",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Deletes a revision of a spec."
+                        },
+                        "listRevisions": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:listRevisions",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.listRevisions",
+                          "description": "Lists all revisions of a spec. Revisions are returned in descending order of revision creation time.",
+                          "httpMethod": "GET",
+                          "path": "v1/{+name}:listRevisions",
+                          "parameters": {
+                            "pageToken": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "The page token, received from a previous ListApiSpecRevisions call. Provide this to retrieve the subsequent page."
+                            },
+                            "name": {
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Required. The name of the spec to list revisions for.",
+                              "type": "string",
+                              "location": "path"
+                            },
+                            "pageSize": {
+                              "location": "query",
+                              "description": "The maximum number of revisions to return per page.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "filter": {
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                              "location": "query",
+                              "type": "string"
+                            }
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "ListApiSpecRevisionsResponse"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ]
+                        },
+                        "testIamPermissions": {
+                          "parameters": {
+                            "resource": {
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "type": "string",
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            }
+                          },
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "request": {
+                            "$ref": "TestIamPermissionsRequest"
+                          },
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.testIamPermissions",
+                          "path": "v1/{+resource}:testIamPermissions",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "TestIamPermissionsResponse"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:testIamPermissions",
+                          "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning."
+                        },
+                        "getContents": {
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.getContents",
+                          "path": "v1/{+name}:getContents",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "description": "Required. The name of the spec whose contents should be retrieved. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true,
+                              "location": "path"
+                            }
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "description": "Returns the contents of a specified spec. If specs are stored with GZip compression, the default behavior is to return the spec uncompressed (the mime_type response field indicates the exact format returned).",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:getContents"
+                        },
+                        "setIamPolicy": {
+                          "httpMethod": "POST",
+                          "path": "v1/{+resource}:setIamPolicy",
+                          "parameters": {
+                            "resource": {
+                              "location": "path",
+                              "type": "string",
+                              "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true
+                            }
+                          },
+                          "request": {
+                            "$ref": "SetIamPolicyRequest"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.setIamPolicy",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:setIamPolicy",
+                          "response": {
+                            "$ref": "Policy"
+                          }
+                        },
+                        "getIamPolicy": {
+                          "httpMethod": "GET",
+                          "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.getIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "parameters": {
+                            "options.requestedPolicyVersion": {
+                              "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                              "type": "integer",
+                              "format": "int32",
+                              "location": "query"
+                            },
+                            "resource": {
+                              "type": "string",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "location": "path"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:getIamPolicy",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "path": "v1/{+resource}:getIamPolicy"
+                        },
+                        "list": {
+                          "httpMethod": "GET",
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs",
+                          "parameters": {
+                            "pageToken": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "A page token, received from a previous `ListApiSpecs` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiSpecs` must match the call that provided the page token."
+                            },
+                            "pageSize": {
+                              "type": "integer",
+                              "description": "The maximum number of specs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                              "format": "int32",
+                              "location": "query"
+                            },
+                            "orderBy": {
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "type": "string",
+                              "location": "query"
+                            },
+                            "filter": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                            },
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "description": "Required. The parent, which owns this collection of specs. Format: `projects/*/locations/*/apis/*/versions/*`",
+                              "location": "path",
+                              "required": true,
+                              "type": "string"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.list",
+                          "path": "v1/{+parent}/specs",
+                          "description": "Returns matching specs.",
+                          "response": {
+                            "$ref": "ListApiSpecsResponse"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "deployments": {
+                  "resources": {
+                    "artifacts": {
+                      "methods": {
+                        "list": {
+                          "parameters": {
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                              "location": "path",
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                            },
+                            "pageToken": {
+                              "location": "query",
+                              "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                              "type": "string"
+                            },
+                            "orderBy": {
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "type": "string",
+                              "location": "query"
+                            },
+                            "pageSize": {
+                              "location": "query",
+                              "type": "integer",
+                              "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                              "format": "int32"
+                            },
+                            "filter": {
+                              "type": "string",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                              "location": "query"
+                            }
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Returns matching artifacts.",
+                          "response": {
+                            "$ref": "ListArtifactsResponse"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.list",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "GET",
+                          "path": "v1/{+parent}/artifacts"
+                        },
+                        "getContents": {
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "type": "string",
+                              "location": "path"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.getContents",
+                          "path": "v1/{+name}:getContents",
+                          "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}:getContents"
+                        },
+                        "create": {
+                          "path": "v1/{+parent}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Creates a specified artifact.",
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.create",
+                          "parameters": {
+                            "parent": {
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "type": "string",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                              "location": "path"
+                            },
+                            "artifactId": {
+                              "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "type": "string",
+                              "location": "query"
+                            }
+                          },
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts"
+                        },
+                        "delete": {
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "description": "Removes a specified artifact.",
+                          "path": "v1/{+name}",
+                          "httpMethod": "DELETE",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                              "required": true,
+                              "location": "path",
+                              "type": "string"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.delete",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "parameterOrder": [
+                            "name"
+                          ]
+                        },
+                        "replaceArtifact": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "PUT",
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "type": "string",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "description": "Resource name."
+                            }
+                          },
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.replaceArtifact",
+                          "path": "v1/{+name}",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "description": "Used to replace a specified artifact."
+                        },
+                        "get": {
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.get",
+                          "parameters": {
+                            "name": {
+                              "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                              "type": "string",
+                              "location": "path",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Returns a specified artifact."
+                        }
+                      }
+                    }
+                  },
+                  "methods": {
+                    "delete": {
+                      "id": "apigeeregistry.projects.locations.apis.deployments.delete",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "description": "Required. The name of the deployment to delete. Format: `projects/*/locations/*/apis/*/deployments/*`",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        },
+                        "force": {
+                          "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                          "type": "boolean",
+                          "location": "query"
+                        }
+                      },
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Removes a specified deployment, all revisions, and all child resources (e.g., artifacts).",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+name}",
+                      "httpMethod": "DELETE"
+                    },
+                    "tagRevision": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:tagRevision",
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.tagRevision",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+name}:tagRevision",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string",
+                          "description": "Required. The name of the deployment to be tagged, including the revision ID."
+                        }
+                      },
+                      "description": "Adds a tag to a specified revision of a deployment.",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "POST",
+                      "request": {
+                        "$ref": "TagApiDeploymentRevisionRequest"
+                      }
+                    },
+                    "create": {
+                      "parameters": {
+                        "apiDeploymentId": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "Required. The ID to use for the deployment, which will become the final component of the deployment's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                        },
+                        "parent": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "Required. The parent, which owns this collection of deployments. Format: `projects/*/locations/*/apis/*`"
+                        }
+                      },
+                      "httpMethod": "POST",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.create",
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "request": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "path": "v1/{+parent}/deployments",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments",
+                      "description": "Creates a specified deployment."
+                    },
+                    "patch": {
+                      "request": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "Resource name.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        },
+                        "updateMask": {
+                          "format": "google-fieldmask",
+                          "location": "query",
+                          "type": "string",
+                          "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request."
+                        },
+                        "allowMissing": {
+                          "description": "If set to true, and the deployment is not found, a new deployment will be created. In this situation, `update_mask` is ignored.",
+                          "location": "query",
+                          "type": "boolean"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "description": "Used to modify a specified deployment.",
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.patch",
+                      "httpMethod": "PATCH",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "listRevisions": {
+                      "description": "Lists all revisions of a deployment. Revisions are returned in descending order of revision creation time.",
+                      "response": {
+                        "$ref": "ListApiDeploymentRevisionsResponse"
+                      },
+                      "parameters": {
+                        "filter": {
+                          "location": "query",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                          "type": "string"
+                        },
+                        "pageSize": {
+                          "location": "query",
+                          "format": "int32",
+                          "type": "integer",
+                          "description": "The maximum number of revisions to return per page."
+                        },
+                        "pageToken": {
+                          "description": "The page token, received from a previous ListApiDeploymentRevisions call. Provide this to retrieve the subsequent page.",
+                          "location": "query",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string",
+                          "location": "path",
+                          "description": "Required. The name of the deployment to list revisions for.",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:listRevisions",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "path": "v1/{+name}:listRevisions",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.listRevisions"
+                    },
+                    "testIamPermissions": {
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "resource": {
+                          "required": true,
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:testIamPermissions",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.testIamPermissions",
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning."
+                    },
+                    "list": {
+                      "response": {
+                        "$ref": "ListApiDeploymentsResponse"
+                      },
+                      "parameters": {
+                        "pageToken": {
+                          "type": "string",
+                          "location": "query",
+                          "description": "A page token, received from a previous `ListApiDeployments` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiDeployments` must match the call that provided the page token."
+                        },
+                        "parent": {
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of deployments. Format: `projects/*/locations/*/apis/*`"
+                        },
+                        "orderBy": {
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "location": "query",
+                          "type": "string"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                          "type": "string"
+                        },
+                        "pageSize": {
+                          "description": "The maximum number of deployments to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "type": "integer",
+                          "location": "query",
+                          "format": "int32"
+                        }
+                      },
+                      "httpMethod": "GET",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "description": "Returns matching deployments.",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.list",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+parent}/deployments"
+                    },
+                    "get": {
+                      "description": "Returns a specified deployment.",
+                      "httpMethod": "GET",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.get",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "description": "Required. The name of the deployment to retrieve. Format: `projects/*/locations/*/apis/*/deployments/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "location": "path",
+                          "type": "string"
+                        }
+                      },
+                      "path": "v1/{+name}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "deleteRevision": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:deleteRevision",
+                      "path": "v1/{+name}:deleteRevision",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.deleteRevision",
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "description": "Required. The name of the deployment revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/deployments/prod@c7cfa2a8`",
+                          "required": true,
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Deletes a revision of a deployment.",
+                      "httpMethod": "DELETE",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      }
+                    },
+                    "getIamPolicy": {
+                      "parameters": {
+                        "options.requestedPolicyVersion": {
+                          "type": "integer",
+                          "format": "int32",
+                          "location": "query",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                        },
+                        "resource": {
+                          "location": "path",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "required": true
+                        }
+                      },
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.getIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:getIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "rollback": {
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:rollback",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "description": "Required. The deployment being rolled back.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string"
+                        }
+                      },
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "description": "Sets the current revision to a specified prior revision. Note that this creates a new revision with a new revision ID.",
+                      "request": {
+                        "$ref": "RollbackApiDeploymentRequest"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.rollback",
+                      "path": "v1/{+name}:rollback",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "POST"
+                    },
+                    "setIamPolicy": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.setIamPolicy",
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "required": true,
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:setIamPolicy",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      }
+                    }
+                  }
+                }
+              },
+              "methods": {
+                "testIamPermissions": {
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:testIamPermissions",
+                  "id": "apigeeregistry.projects.locations.apis.testIamPermissions"
+                },
+                "list": {
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "path": "v1/{+parent}/apis",
+                  "response": {
+                    "$ref": "ListApisResponse"
+                  },
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "orderBy": {
+                      "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "description": "A page token, received from a previous `ListApis` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApis` must match the call that provided the page token.",
+                      "location": "query"
+                    },
+                    "parent": {
+                      "required": true,
+                      "location": "path",
+                      "description": "Required. The parent, which owns this collection of APIs. Format: `projects/*/locations/*`",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    },
+                    "pageSize": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "The maximum number of APIs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                      "location": "query"
+                    },
+                    "filter": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields."
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.apis.list",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis",
+                  "description": "Returns matching APIs."
+                },
+                "get": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}",
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.get",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "name": {
+                      "description": "Required. The name of the API to retrieve. Format: `projects/*/locations/*/apis/*`",
+                      "type": "string",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "required": true
+                    }
+                  },
+                  "description": "Returns a specified API.",
+                  "parameterOrder": [
+                    "name"
+                  ]
+                },
+                "delete": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Removes a specified API and all of the resources that it owns.",
+                  "httpMethod": "DELETE",
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "description": "Required. The name of the API to delete. Format: `projects/*/locations/*/apis/*`",
+                      "location": "path",
+                      "type": "string"
+                    },
+                    "force": {
+                      "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                      "type": "boolean",
+                      "location": "query"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.delete",
+                  "path": "v1/{+name}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}"
+                },
+                "getIamPolicy": {
+                  "id": "apigeeregistry.projects.locations.apis.getIamPolicy",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "type": "string",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    },
+                    "options.requestedPolicyVersion": {
+                      "format": "int32",
+                      "type": "integer",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query"
+                    }
+                  },
+                  "httpMethod": "GET",
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:getIamPolicy",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "response": {
+                    "$ref": "Policy"
+                  }
+                },
+                "setIamPolicy": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "parameters": {
+                    "resource": {
+                      "required": true,
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "type": "string"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.setIamPolicy",
+                  "parameterOrder": [
+                    "resource"
+                  ]
+                },
+                "patch": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}",
+                  "description": "Used to modify a specified API.",
+                  "path": "v1/{+name}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "PATCH",
+                  "parameters": {
+                    "updateMask": {
+                      "location": "query",
+                      "format": "google-fieldmask",
+                      "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Resource name.",
+                      "required": true,
+                      "location": "path",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$"
+                    },
+                    "allowMissing": {
+                      "location": "query",
+                      "type": "boolean",
+                      "description": "If set to true, and the API is not found, a new API will be created. In this situation, `update_mask` is ignored."
+                    }
+                  },
+                  "request": {
+                    "$ref": "Api"
+                  },
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.patch"
+                },
+                "create": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "parent": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The parent, which owns this collection of APIs. Format: `projects/*/locations/*`"
+                    },
+                    "apiId": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "Required. The ID to use for the API, which will become the final component of the API's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                    }
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis",
+                  "request": {
+                    "$ref": "Api"
+                  },
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.create",
+                  "description": "Creates a specified API.",
+                  "httpMethod": "POST",
+                  "path": "v1/{+parent}/apis"
+                }
+              }
+            },
+            "instances": {
+              "methods": {
+                "setIamPolicy": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.instances.setIamPolicy",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "parameters": {
+                    "resource": {
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "required": true,
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    }
+                  },
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy"
+                },
+                "create": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances",
+                  "request": {
+                    "$ref": "Instance"
+                  },
+                  "path": "v1/{+parent}/instances",
+                  "description": "Provisions instance resources for the Registry.",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "id": "apigeeregistry.projects.locations.instances.create",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "required": true,
+                      "location": "path",
+                      "description": "Required. Parent resource of the Instance, of the form: `projects/*/locations/*`"
+                    },
+                    "instanceId": {
+                      "location": "query",
+                      "description": "Required. Identifier to assign to the Instance. Must be unique within scope of the parent resource.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "delete": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.instances.delete",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the Instance to delete. Format: `projects/*/locations/*/instances/*`."
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}",
+                  "path": "v1/{+name}",
+                  "httpMethod": "DELETE",
+                  "description": "Deletes the Registry instance."
+                },
+                "getIamPolicy": {
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    },
+                    "options.requestedPolicyVersion": {
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:getIamPolicy",
+                  "id": "apigeeregistry.projects.locations.instances.getIamPolicy",
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "resource"
+                  ]
+                },
+                "testIamPermissions": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "id": "apigeeregistry.projects.locations.instances.testIamPermissions",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:testIamPermissions",
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "parameters": {
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "type": "string"
+                    }
+                  },
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "httpMethod": "POST",
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  }
+                },
+                "get": {
+                  "httpMethod": "GET",
+                  "id": "apigeeregistry.projects.locations.instances.get",
+                  "response": {
+                    "$ref": "Instance"
+                  },
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "type": "string",
+                      "description": "Required. The name of the Instance to retrieve. Format: `projects/*/locations/*/instances/*`.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}",
+                  "description": "Gets details of a single Instance.",
+                  "path": "v1/{+name}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "name"
+                  ]
+                }
+              }
+            },
+            "operations": {
+              "methods": {
+                "get": {
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "required": true,
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "description": "The name of the operation resource."
+                    }
+                  },
+                  "httpMethod": "GET",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "description": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.operations.get"
+                },
+                "list": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations",
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE: the `name` binding allows API services to override the binding to use different resource name schemes, such as `users/*/operations`. To override the binding, API services can add a binding such as `\"/v1/{name=users/*}/operations\"` to their service configuration. For backwards compatibility, the default name includes the operations collection id, however overriding users must ensure the name binding is the parent resource, without the operations collection id.",
+                  "path": "v1/{+name}/operations",
+                  "response": {
+                    "$ref": "ListOperationsResponse"
+                  },
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "description": "The name of the operation's parent resource.",
+                      "required": true
+                    },
+                    "filter": {
+                      "description": "The standard list filter.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "pageSize": {
+                      "location": "query",
+                      "type": "integer",
+                      "description": "The standard list page size.",
+                      "format": "int32"
+                    },
+                    "pageToken": {
+                      "description": "The standard list page token.",
+                      "type": "string",
+                      "location": "query"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.operations.list"
+                },
+                "cancel": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}:cancel",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "location": "path",
+                      "description": "The name of the operation resource to be cancelled.",
+                      "type": "string"
+                    }
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.operations.cancel",
+                  "path": "v1/{+name}:cancel",
+                  "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`.",
+                  "request": {
+                    "$ref": "CancelOperationRequest"
+                  }
+                },
+                "delete": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "path": "v1/{+name}",
+                  "httpMethod": "DELETE",
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "description": "The name of the operation resource to be deleted.",
+                      "location": "path",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}",
+                  "description": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`.",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "id": "apigeeregistry.projects.locations.operations.delete"
+                }
+              }
+            },
+            "runtime": {
+              "methods": {
+                "setIamPolicy": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:setIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.setIamPolicy"
+                },
+                "getIamPolicy": {
+                  "parameters": {
+                    "options.requestedPolicyVersion": {
+                      "type": "integer",
+                      "location": "query",
+                      "format": "int32",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                    },
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "location": "path"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.getIamPolicy",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:getIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "GET"
+                },
+                "testIamPermissions": {
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:testIamPermissions",
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "parameters": {
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.testIamPermissions",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "POST"
+                }
+              }
+            },
+            "artifacts": {
+              "methods": {
+                "delete": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Removes a specified artifact.",
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "required": true,
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "httpMethod": "DELETE",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "id": "apigeeregistry.projects.locations.artifacts.delete"
+                },
+                "getIamPolicy": {
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:getIamPolicy",
+                  "id": "apigeeregistry.projects.locations.artifacts.getIamPolicy",
+                  "httpMethod": "GET",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "type": "string",
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    },
+                    "options.requestedPolicyVersion": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query"
+                    }
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set."
+                },
+                "list": {
+                  "description": "Returns matching artifacts.",
+                  "httpMethod": "GET",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts",
+                  "path": "v1/{+parent}/artifacts",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "parameters": {
+                    "orderBy": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\""
+                    },
+                    "pageSize": {
+                      "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer"
+                    },
+                    "parent": {
+                      "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    },
+                    "filter": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                    },
+                    "pageToken": {
+                      "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                      "type": "string",
+                      "location": "query"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.artifacts.list",
+                  "response": {
+                    "$ref": "ListArtifactsResponse"
+                  }
+                },
+                "replaceArtifact": {
+                  "path": "v1/{+name}",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "httpMethod": "PUT",
+                  "id": "apigeeregistry.projects.locations.artifacts.replaceArtifact",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "Artifact"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Used to replace a specified artifact.",
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "type": "string",
+                      "description": "Resource name."
+                    }
+                  }
+                },
+                "create": {
+                  "httpMethod": "POST",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.artifacts.create",
+                  "parameters": {
+                    "artifactId": {
+                      "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "parent": {
+                      "type": "string",
+                      "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    }
+                  },
+                  "path": "v1/{+parent}/artifacts",
+                  "description": "Creates a specified artifact.",
+                  "request": {
+                    "$ref": "Artifact"
+                  }
+                },
+                "get": {
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                      "required": true
+                    }
+                  },
+                  "path": "v1/{+name}",
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Returns a specified artifact.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "id": "apigeeregistry.projects.locations.artifacts.get"
+                },
+                "setIamPolicy": {
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.setIamPolicy",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:setIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "type": "string"
+                    }
+                  },
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors."
+                },
+                "getContents": {
+                  "httpMethod": "GET",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:getContents",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "HttpBody"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                  "path": "v1/{+name}:getContents",
+                  "parameters": {
+                    "name": {
+                      "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "location": "path",
+                      "type": "string"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.getContents"
+                },
+                "testIamPermissions": {
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.testIamPermissions",
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "httpMethod": "POST",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:testIamPermissions",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "path": "v1/{+resource}:testIamPermissions"
+                }
+              }
+            }
+          },
+          "methods": {
+            "list": {
+              "response": {
+                "$ref": "ListLocationsResponse"
+              },
+              "description": "Lists information about the supported locations for this service.",
+              "httpMethod": "GET",
+              "parameters": {
+                "pageToken": {
+                  "description": "A page token received from the `next_page_token` field in the response. Send that page token to receive the subsequent page.",
+                  "location": "query",
+                  "type": "string"
+                },
+                "filter": {
+                  "location": "query",
+                  "description": "A filter to narrow down results to a preferred subset. The filtering language accepts strings like `\"displayName=tokyo\"`, and is documented in more detail in [AIP-160](https://google.aip.dev/160).",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "pattern": "^projects/[^/]+$",
+                  "description": "The resource that owns the locations collection, if applicable.",
+                  "required": true,
+                  "location": "path"
+                },
+                "pageSize": {
+                  "location": "query",
+                  "description": "The maximum number of results to return. If not set, the service selects a default.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "path": "v1/{+name}/locations",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1/projects/{projectsId}/locations",
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "apigeeregistry.projects.locations.list"
+            },
+            "get": {
+              "id": "apigeeregistry.projects.locations.get",
+              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Gets information about a location.",
+              "parameters": {
+                "name": {
+                  "description": "Resource name for the location.",
+                  "type": "string",
+                  "pattern": "^projects/[^/]+/locations/[^/]+$",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "path": "v1/{+name}",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "httpMethod": "GET",
+              "response": {
+                "$ref": "Location"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "revision": "20230127",
+  "fullyEncodeReservedExpansion": true,
+  "rootUrl": "https://apigeeregistry.googleapis.com/",
+  "title": "Apigee Registry API",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account."
+        }
+      }
+    }
+  },
+  "version": "v1",
+  "protocol": "rest",
+  "basePath": ""
+}

--- a/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/discovery/info.yaml
+++ b/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/discovery/info.yaml
@@ -1,0 +1,8 @@
+apiVersion: apigeeregistry/v1
+kind: Spec
+metadata:
+  name: discovery
+  parent: apis/apigeeregistry/versions/v1
+data:
+  filename: discovery.json
+  mimeType: application/x.discovery+gzip

--- a/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/openapi/info.yaml
+++ b/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/openapi/info.yaml
@@ -1,0 +1,8 @@
+apiVersion: apigeeregistry/v1
+kind: Spec
+metadata:
+  name: openapi
+  parent: apis/apigeeregistry/versions/v1
+data:
+  filename: openapi.yaml
+  mimeType: application/x.openapi+gzip;version=3.0.3

--- a/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/openapi/openapi.yaml
+++ b/cmd/registry/cmd/compute/vocabulary/testdata/apigeeregistry/v1/openapi/openapi.yaml
@@ -1,0 +1,2161 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Registry API
+    description: The Registry service allows teams to manage descriptions of APIs.
+    version: 0.0.1
+servers:
+    - url: https://apigeeregistry.googleapis.com
+paths:
+    /v1/projects/{project}/locations/{location}/apis:
+        get:
+            tags:
+                - Registry
+            description: ListApis returns matching APIs.
+            operationId: Registry_ListApis
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of APIs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApis` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApis` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApisResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApi creates a specified API.
+            operationId: Registry_CreateApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiId
+                  in: query
+                  description: Required. The ID to use for the api, which will become the final component of the api's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Api'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Api'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}:
+        get:
+            tags:
+                - Registry
+            description: GetApi returns a specified API.
+            operationId: Registry_GetApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Api'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApi removes a specified API and all of the resources that it
+                 owns.
+            operationId: Registry_DeleteApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApi can be used to modify a specified API.
+            operationId: Registry_UpdateApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the api is not found, a new api_versions will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Api'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Api'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments:
+        get:
+            tags:
+                - Registry
+            description: ListApiDeployments returns matching deployments.
+            operationId: Registry_ListApiDeployments
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of deployments to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApiDeployments` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiDeployments` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiDeploymentsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApiDeployment creates a specified deployment.
+            operationId: Registry_CreateApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiDeploymentId
+                  in: query
+                  description: Required. The ID to use for the deployment, which will become the final component of the deployment's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiDeployment'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:
+        get:
+            tags:
+                - Registry
+            description: GetApiDeployment returns a specified deployment.
+            operationId: Registry_GetApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApiDeployment removes a specified deployment, all revisions, and all
+                 child resources (e.g. artifacts).
+            operationId: Registry_DeleteApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApiDeployment can be used to modify a specified deployment.
+            operationId: Registry_UpdateApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the deployment is not found, a new deployment will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiDeployment'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:deleteRevision:
+        delete:
+            tags:
+                - Registry
+            description: DeleteApiDeploymentRevision deletes a revision of a deployment.
+            operationId: Registry_DeleteApiDeploymentRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:listRevisions:
+        get:
+            tags:
+                - Registry
+            description: |-
+                ListApiDeploymentRevisions lists all revisions of a deployment.
+                 Revisions are returned in descending order of revision creation time.
+            operationId: Registry_ListApiDeploymentRevisions
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of revisions to return per page.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: The page token, received from a previous ListApiDeploymentRevisions call. Provide this to retrieve the subsequent page.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiDeploymentRevisionsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:rollback:
+        post:
+            tags:
+                - Registry
+            description: |-
+                RollbackApiDeployment sets the current revision to a specified prior
+                 revision. Note that this creates a new revision with a new revision ID.
+            operationId: Registry_RollbackApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RollbackApiDeploymentRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:tagRevision:
+        post:
+            tags:
+                - Registry
+            description: |-
+                TagApiDeploymentRevision adds a tag to a specified revision of a
+                 deployment.
+            operationId: Registry_TagApiDeploymentRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TagApiDeploymentRevisionRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions:
+        get:
+            tags:
+                - Registry
+            description: ListApiVersions returns matching versions.
+            operationId: Registry_ListApiVersions
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of versions to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApiVersions` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiVersions` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiVersionsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApiVersion creates a specified version.
+            operationId: Registry_CreateApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiVersionId
+                  in: query
+                  description: Required. The ID to use for the version, which will become the final component of the version's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiVersion'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiVersion'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}:
+        get:
+            tags:
+                - Registry
+            description: GetApiVersion returns a specified version.
+            operationId: Registry_GetApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiVersion'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApiVersion removes a specified version and all of the resources that
+                 it owns.
+            operationId: Registry_DeleteApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApiVersion can be used to modify a specified version.
+            operationId: Registry_UpdateApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the version is not found, a new version will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiVersion'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiVersion'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs:
+        get:
+            tags:
+                - Registry
+            description: ListApiSpecs returns matching specs.
+            operationId: Registry_ListApiSpecs
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of specs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApiSpecs` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiSpecs` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiSpecsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApiSpec creates a specified spec.
+            operationId: Registry_CreateApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiSpecId
+                  in: query
+                  description: Required. The ID to use for the spec, which will become the final component of the spec's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiSpec'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:
+        get:
+            tags:
+                - Registry
+            description: GetApiSpec returns a specified spec.
+            operationId: Registry_GetApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApiSpec removes a specified spec, all revisions, and all child
+                 resources (e.g. artifacts).
+            operationId: Registry_DeleteApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApiSpec can be used to modify a specified spec.
+            operationId: Registry_UpdateApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the spec is not found, a new spec will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiSpec'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:deleteRevision:
+        delete:
+            tags:
+                - Registry
+            description: DeleteApiSpecRevision deletes a revision of a spec.
+            operationId: Registry_DeleteApiSpecRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:getContents:
+        get:
+            tags:
+                - Registry
+            description: |-
+                GetApiSpecContents returns the contents of a specified spec.
+                 If specs are stored with GZip compression, the default behavior
+                 is to return the spec uncompressed (the mime_type response field
+                 indicates the exact format returned).
+            operationId: Registry_GetApiSpecContents
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*': {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:listRevisions:
+        get:
+            tags:
+                - Registry
+            description: |-
+                ListApiSpecRevisions lists all revisions of a spec.
+                 Revisions are returned in descending order of revision creation time.
+            operationId: Registry_ListApiSpecRevisions
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of revisions to return per page.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: The page token, received from a previous ListApiSpecRevisions call. Provide this to retrieve the subsequent page.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiSpecRevisionsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:rollback:
+        post:
+            tags:
+                - Registry
+            description: |-
+                RollbackApiSpec sets the current revision to a specified prior revision.
+                 Note that this creates a new revision with a new revision ID.
+            operationId: Registry_RollbackApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RollbackApiSpecRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:tagRevision:
+        post:
+            tags:
+                - Registry
+            description: TagApiSpecRevision adds a tag to a specified revision of a spec.
+            operationId: Registry_TagApiSpecRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TagApiSpecRevisionRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/artifacts:
+        get:
+            tags:
+                - Registry
+            description: ListArtifacts returns matching artifacts.
+            operationId: Registry_ListArtifacts
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListArtifactsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateArtifact creates a specified artifact.
+            operationId: Registry_CreateArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifactId
+                  in: query
+                  description: Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Artifact'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Artifact'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/artifacts/{artifact}:
+        get:
+            tags:
+                - Registry
+            description: GetArtifact returns a specified artifact.
+            operationId: Registry_GetArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Artifact'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        put:
+            tags:
+                - Registry
+            description: ReplaceArtifact can be used to replace a specified artifact.
+            operationId: Registry_ReplaceArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Artifact'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Artifact'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: DeleteArtifact removes a specified artifact.
+            operationId: Registry_DeleteArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/artifacts/{artifact}:getContents:
+        get:
+            tags:
+                - Registry
+            description: |-
+                GetArtifactContents returns the contents of a specified artifact.
+                 If artifacts are stored with GZip compression, the default behavior
+                 is to return the artifact uncompressed (the mime_type response field
+                 indicates the exact format returned).
+            operationId: Registry_GetArtifactContents
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*': {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        Api:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                displayName:
+                    type: string
+                    description: Human-meaningful name.
+                description:
+                    type: string
+                    description: A detailed description.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp.
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Last update timestamp.
+                    format: date-time
+                availability:
+                    type: string
+                    description: 'A user-definable description of the availability of this service. Format: free-form, but we expect single words that describe availability, e.g. "NONE", "TESTING", "PREVIEW", "GENERAL", "DEPRECATED", "SHUTDOWN".'
+                recommendedVersion:
+                    type: string
+                    description: 'The recommended version of the API. Format: apis/{api}/versions/{version}'
+                recommendedDeployment:
+                    type: string
+                    description: 'The recommended deployment of the API. Format: apis/{api}/deployments/{deployment}'
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "apigeeregistry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An Api is a top-level description of an API. Apis are produced by producers and are commitments to provide services.
+        ApiDeployment:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                displayName:
+                    type: string
+                    description: Human-meaningful name.
+                description:
+                    type: string
+                    description: A detailed description.
+                revisionId:
+                    readOnly: true
+                    type: string
+                    description: Output only. Immutable. The revision ID of the deployment. A new revision is committed whenever the deployment contents are changed. The format is an 8-character hexadecimal string.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp; when the deployment resource was created.
+                    format: date-time
+                revisionCreateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Revision creation timestamp; when the represented revision was created.
+                    format: date-time
+                revisionUpdateTime:
+                    readOnly: true
+                    type: string
+                    description: 'Output only. Last update timestamp: when the represented revision was last modified.'
+                    format: date-time
+                apiSpecRevision:
+                    type: string
+                    description: 'The full resource name (including revision id) of the spec of the API being served by the deployment. Changes to this value will update the revision. Format: apis/{api}/deployments/{deployment}'
+                endpointUri:
+                    type: string
+                    description: The address where the deployment is serving. Changes to this value will update the revision.
+                externalChannelUri:
+                    type: string
+                    description: The address of the external channel of the API (e.g. the Developer Portal). Changes to this value will not affect the revision.
+                intendedAudience:
+                    type: string
+                    description: Text briefly identifying the intended audience of the API. Changes to this value will not affect the revision.
+                accessGuidance:
+                    type: string
+                    description: Text briefly describing how to access the endpoint. Changes to this value will not affect the revision.
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "registry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An ApiDeployment describes a service running at particular address that provides a particular version of an API. ApiDeployments have revisions which correspond to different configurations of a single deployment in time. Revision identifiers should be updated whenever the served API spec or endpoint address changes.
+        ApiSpec:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                filename:
+                    type: string
+                    description: A possibly-hierarchical name used to refer to the spec from other specs.
+                description:
+                    type: string
+                    description: A detailed description.
+                revisionId:
+                    readOnly: true
+                    type: string
+                    description: Output only. Immutable. The revision ID of the spec. A new revision is committed whenever the spec contents are changed. The format is an 8-character hexadecimal string.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp; when the spec resource was created.
+                    format: date-time
+                revisionCreateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Revision creation timestamp; when the represented revision was created.
+                    format: date-time
+                revisionUpdateTime:
+                    readOnly: true
+                    type: string
+                    description: 'Output only. Last update timestamp: when the represented revision was last modified.'
+                    format: date-time
+                mimeType:
+                    type: string
+                    description: A style (format) descriptor for this spec that is specified as a Media Type (https://en.wikipedia.org/wiki/Media_type). Possible values include "application/vnd.apigee.proto", "application/vnd.apigee.openapi", and "application/vnd.apigee.graphql", with possible suffixes representing compression types. These hypothetical names are defined in the vendor tree defined in RFC6838 (https://tools.ietf.org/html/rfc6838) and are not final. Content types can specify compression. Currently only GZip compression is supported (indicated with "+gzip").
+                sizeBytes:
+                    readOnly: true
+                    type: integer
+                    description: Output only. The size of the spec file in bytes. If the spec is gzipped, this is the size of the uncompressed spec.
+                    format: int32
+                hash:
+                    readOnly: true
+                    type: string
+                    description: Output only. A SHA-256 hash of the spec's contents. If the spec is gzipped, this is the hash of the uncompressed spec.
+                sourceUri:
+                    type: string
+                    description: The original source URI of the spec (if one exists). This is an external location that can be used for reference purposes but which may not be authoritative since this external resource may change after the spec is retrieved.
+                contents:
+                    writeOnly: true
+                    type: string
+                    description: Input only. The contents of the spec. Provided by API callers when specs are created or updated. To access the contents of a spec, use GetApiSpecContents.
+                    format: bytes
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "apigeeregistry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An ApiSpec describes a version of an API in a structured way. ApiSpecs provide formal descriptions that consumers can use to use a version. ApiSpec resources are intended to be fully-resolved descriptions of an ApiVersion. When specs consist of multiple files, these should be bundled together (e.g. in a zip archive) and stored as a unit. Multiple specs can exist to provide representations in different API description formats. Synchronization of these representations would be provided by tooling and background services.
+        ApiVersion:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                displayName:
+                    type: string
+                    description: Human-meaningful name.
+                description:
+                    type: string
+                    description: A detailed description.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp.
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Last update timestamp.
+                    format: date-time
+                state:
+                    type: string
+                    description: 'A user-definable description of the lifecycle phase of this API version. Format: free-form, but we expect single words that describe API maturity, e.g. "CONCEPT", "DESIGN", "DEVELOPMENT", "STAGING", "PRODUCTION", "DEPRECATED", "RETIRED".'
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "apigeeregistry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An ApiVersion describes a particular version of an API. ApiVersions are what consumers actually use.
+        Artifact:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp.
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Last update timestamp.
+                    format: date-time
+                mimeType:
+                    type: string
+                    description: A content type specifier for the artifact. Content type specifiers are Media Types (https://en.wikipedia.org/wiki/Media_type) with a possible "schema" parameter that specifies a schema for the stored information. Content types can specify compression. Currently only GZip compression is supported (indicated with "+gzip").
+                sizeBytes:
+                    readOnly: true
+                    type: integer
+                    description: Output only. The size of the artifact in bytes. If the artifact is gzipped, this is the size of the uncompressed artifact.
+                    format: int32
+                hash:
+                    readOnly: true
+                    type: string
+                    description: Output only. A SHA-256 hash of the artifact's contents. If the artifact is gzipped, this is the hash of the uncompressed artifact.
+                contents:
+                    writeOnly: true
+                    type: string
+                    description: Input only. The contents of the artifact. Provided by API callers when artifacts are created or replaced. To access the contents of an artifact, use GetArtifactContents.
+                    format: bytes
+            description: Artifacts of resources. Artifacts are unique (single-value) per resource and are used to store metadata that is too large or numerous to be stored directly on the resource. Since artifacts are stored separately from parent resources, they should generally be used for metadata that is needed infrequently, i.e. not for display in primary views of the resource but perhaps displayed or downloaded upon request. The ListArtifacts method allows artifacts to be quickly enumerated and checked for presence without downloading their (potentially-large) contents.
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        ListApiDeploymentRevisionsResponse:
+            type: object
+            properties:
+                apiDeployments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiDeployment'
+                    description: The revisions of the deployment.
+                nextPageToken:
+                    type: string
+                    description: A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiDeploymentRevisionsResponse.
+        ListApiDeploymentsResponse:
+            type: object
+            properties:
+                apiDeployments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiDeployment'
+                    description: The deployments from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiDeployments.
+        ListApiSpecRevisionsResponse:
+            type: object
+            properties:
+                apiSpecs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiSpec'
+                    description: The revisions of the spec.
+                nextPageToken:
+                    type: string
+                    description: A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiSpecRevisionsResponse.
+        ListApiSpecsResponse:
+            type: object
+            properties:
+                apiSpecs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiSpec'
+                    description: The specs from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiSpecs.
+        ListApiVersionsResponse:
+            type: object
+            properties:
+                apiVersions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiVersion'
+                    description: The versions from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiVersions.
+        ListApisResponse:
+            type: object
+            properties:
+                apis:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Api'
+                    description: The APIs from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApis.
+        ListArtifactsResponse:
+            type: object
+            properties:
+                artifacts:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Artifact'
+                    description: The artifacts from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListArtifacts.
+        RollbackApiDeploymentRequest:
+            required:
+                - name
+                - revisionId
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The deployment being rolled back.
+                revisionId:
+                    type: string
+                    description: 'Required. The revision ID to roll back to. It must be a revision of the same deployment.   Example: c7cfa2a8'
+            description: Request message for RollbackApiDeployment.
+        RollbackApiSpecRequest:
+            required:
+                - name
+                - revisionId
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The spec being rolled back.
+                revisionId:
+                    type: string
+                    description: 'Required. The revision ID to roll back to. It must be a revision of the same spec.   Example: c7cfa2a8'
+            description: Request message for RollbackApiSpec.
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        TagApiDeploymentRevisionRequest:
+            required:
+                - name
+                - tag
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The name of the deployment to be tagged, including the revision ID.
+                tag:
+                    type: string
+                    description: Required. The tag to apply. The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+            description: Request message for TagApiDeploymentRevision.
+        TagApiSpecRevisionRequest:
+            required:
+                - name
+                - tag
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The name of the spec to be tagged, including the revision ID.
+                tag:
+                    type: string
+                    description: Required. The tag to apply. The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+            description: Request message for TagApiSpecRevision.
+tags:
+    - name: Registry


### PR DESCRIPTION
These tests just verify that the command runs and computes something for these two spec types.