### PR TITLE
Add basic tests of `registry compute complexity` for protos, openapi, and discovery formats

### DIFF
--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/info.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/info.yaml
@@ -1,0 +1,8 @@
+apiVersion: apigeeregistry/v1
+kind: API
+metadata:
+  name: apigeeregistry
+  labels:
+    provider: google-com
+data:
+  displayName: Google Apigee Registry API

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/discovery/discovery.json
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/discovery/discovery.json
@@ -1,0 +1,4100 @@
+{
+  "ownerDomain": "google.com",
+  "schemas": {
+    "ApiVersion": {
+      "id": "ApiVersion",
+      "description": "Describes a particular version of an API. ApiVersions are what consumers actually use.",
+      "properties": {
+        "primarySpec": {
+          "type": "string",
+          "description": "The primary spec for this version. Format: projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object"
+        },
+        "description": {
+          "description": "A detailed description.",
+          "type": "string"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. Last update timestamp."
+        },
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "description": "A user-definable description of the lifecycle phase of this API version. Format: free-form, but we expect single words that describe API maturity, e.g., \"CONCEPT\", \"DESIGN\", \"DEVELOPMENT\", \"STAGING\", \"PRODUCTION\", \"DEPRECATED\", \"RETIRED\"."
+        },
+        "createTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Creation timestamp.",
+          "format": "google-datetime"
+        }
+      },
+      "type": "object"
+    },
+    "Instance": {
+      "properties": {
+        "createTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "description": "Output only. Creation timestamp.",
+          "type": "string"
+        },
+        "stateMessage": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Extra information of Instance.State if the state is `FAILED`."
+        },
+        "updateTime": {
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime",
+          "description": "Output only. Last update timestamp."
+        },
+        "config": {
+          "description": "Required. Config of the Instance.",
+          "$ref": "Config"
+        },
+        "state": {
+          "description": "Output only. The current state of the Instance.",
+          "readOnly": true,
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "The Instance has not been initialized or has been deleted.",
+            "The Instance is being created.",
+            "The Instance has been created and is ready for use.",
+            "The Instance is being updated.",
+            "The Instance is being deleted.",
+            "The Instance encountered an error during a state change."
+          ],
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "INACTIVE",
+            "CREATING",
+            "ACTIVE",
+            "UPDATING",
+            "DELETING",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "build": {
+          "$ref": "Build",
+          "description": "Output only. Build info of the Instance if it's in `ACTIVE` state.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Format: `projects/*/locations/*/instance`. Currently only `locations/global` is supported."
+        }
+      },
+      "id": "Instance",
+      "type": "object",
+      "description": "An Instance represents the instance resources of the Registry. Currently, only one instance is allowed for each project."
+    },
+    "Config": {
+      "properties": {
+        "cmekKeyName": {
+          "type": "string",
+          "description": "Required. The Customer Managed Encryption Key (CMEK) used for data encryption. The CMEK name should follow the format of `projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)`, where the `location` must match InstanceConfig.location."
+        },
+        "location": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The GCP location where the Instance resides."
+        }
+      },
+      "id": "Config",
+      "type": "object",
+      "description": "Available configurations to provision an Instance."
+    },
+    "Status": {
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            }
+          }
+        }
+      },
+      "type": "object",
+      "id": "Status",
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
+    },
+    "ListApisResponse": {
+      "id": "ListApisResponse",
+      "properties": {
+        "apis": {
+          "type": "array",
+          "items": {
+            "$ref": "Api"
+          },
+          "description": "The APIs from the specified publisher."
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        }
+      },
+      "description": "Response message for ListApis.",
+      "type": "object"
+    },
+    "Empty": {
+      "id": "Empty",
+      "type": "object",
+      "properties": {},
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }"
+    },
+    "TagApiSpecRevisionRequest": {
+      "description": "Request message for TagApiSpecRevision.",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Required. The tag to apply. The tag should be at most 40 characters, and match `a-z{3,39}`.",
+          "type": "string"
+        }
+      },
+      "id": "TagApiSpecRevisionRequest"
+    },
+    "OperationMetadata": {
+      "id": "OperationMetadata",
+      "type": "object",
+      "properties": {
+        "createTime": {
+          "description": "The time the operation was created.",
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "verb": {
+          "type": "string",
+          "description": "Name of the verb executed by the operation."
+        },
+        "statusMessage": {
+          "type": "string",
+          "description": "Human-readable status of the operation, if any."
+        },
+        "endTime": {
+          "format": "google-datetime",
+          "description": "The time the operation finished running.",
+          "type": "string"
+        },
+        "cancellationRequested": {
+          "description": "Identifies whether the user has requested cancellation of the operation. Operations that have successfully been cancelled have Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`.",
+          "type": "boolean"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "API version used to start the operation."
+        },
+        "target": {
+          "type": "string",
+          "description": "Server-defined resource path for the target of the operation."
+        }
+      },
+      "description": "Represents the metadata of the long-running operation."
+    },
+    "ApiSpec": {
+      "properties": {
+        "filename": {
+          "description": "A possibly-hierarchical name used to refer to the spec from other specs.",
+          "type": "string"
+        },
+        "hash": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. A SHA-256 hash of the spec's contents. If the spec is gzipped, this is the hash of the uncompressed spec."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "A style (format) descriptor for this spec that is specified as a Media Type (https://en.wikipedia.org/wiki/Media_type). Possible values include `application/vnd.apigee.proto`, `application/vnd.apigee.openapi`, and `application/vnd.apigee.graphql`, with possible suffixes representing compression types. These hypothetical names are defined in the vendor tree defined in RFC6838 (https://tools.ietf.org/html/rfc6838) and are not final. Content types can specify compression. Currently only GZip compression is supported (indicated with \"+gzip\")."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object"
+        },
+        "revisionUpdateTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Last update timestamp: when the represented revision was last modified.",
+          "format": "google-datetime"
+        },
+        "createTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "description": "Output only. Creation timestamp; when the spec resource was created.",
+          "type": "string"
+        },
+        "sourceUri": {
+          "description": "The original source URI of the spec (if one exists). This is an external location that can be used for reference purposes but which may not be authoritative since this external resource may change after the spec is retrieved.",
+          "type": "string"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true,
+          "description": "Output only. The size of the spec file in bytes. If the spec is gzipped, this is the size of the uncompressed spec."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "revisionCreateTime": {
+          "description": "Output only. Revision creation timestamp; when the represented revision was created.",
+          "type": "string",
+          "readOnly": true,
+          "format": "google-datetime"
+        },
+        "revisionId": {
+          "description": "Output only. Immutable. The revision ID of the spec. A new revision is committed whenever the spec contents are changed. The format is an 8-character hexadecimal string.",
+          "type": "string",
+          "readOnly": true
+        },
+        "description": {
+          "description": "A detailed description.",
+          "type": "string"
+        },
+        "contents": {
+          "description": "Input only. The contents of the spec. Provided by API callers when specs are created or updated. To access the contents of a spec, use GetApiSpecContents.",
+          "format": "byte",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        }
+      },
+      "type": "object",
+      "description": "Describes a version of an API in a structured way. ApiSpecs provide formal descriptions that consumers can use to use a version. ApiSpec resources are intended to be fully-resolved descriptions of an ApiVersion. When specs consist of multiple files, these should be bundled together (e.g., in a zip archive) and stored as a unit. Multiple specs can exist to provide representations in different API description formats. Synchronization of these representations would be provided by tooling and background services.",
+      "id": "ApiSpec"
+    },
+    "Api": {
+      "description": "A top-level description of an API. Produced by producers and are commitments to provide services.",
+      "type": "object",
+      "id": "Api",
+      "properties": {
+        "updateTime": {
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. Last update timestamp.",
+          "type": "string"
+        },
+        "availability": {
+          "type": "string",
+          "description": "A user-definable description of the availability of this service. Format: free-form, but we expect single words that describe availability, e.g., \"NONE\", \"TESTING\", \"PREVIEW\", \"GENERAL\", \"DEPRECATED\", \"SHUTDOWN\"."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        },
+        "annotations": {
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "createTime": {
+          "description": "Output only. Creation timestamp.",
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "recommendedDeployment": {
+          "description": "The recommended deployment of the API. Format: `projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}`",
+          "type": "string"
+        },
+        "recommendedVersion": {
+          "type": "string",
+          "description": "The recommended version of the API. Format: `projects/{project}/locations/{location}/apis/{api}/versions/{version}`"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores, and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed.",
+          "type": "object"
+        }
+      }
+    },
+    "RollbackApiDeploymentRequest": {
+      "properties": {
+        "revisionId": {
+          "description": "Required. The revision ID to roll back to. It must be a revision of the same deployment. Example: `c7cfa2a8`",
+          "type": "string"
+        }
+      },
+      "description": "Request message for RollbackApiDeployment.",
+      "type": "object",
+      "id": "RollbackApiDeploymentRequest"
+    },
+    "Build": {
+      "type": "object",
+      "id": "Build",
+      "properties": {
+        "repo": {
+          "description": "Output only. Path of the open source repository: github.com/apigee/registry.",
+          "type": "string",
+          "readOnly": true
+        },
+        "commitTime": {
+          "format": "google-datetime",
+          "description": "Output only. Commit time of the latest commit in the build.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "commitId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Commit ID of the latest commit in the build."
+        }
+      },
+      "description": "Build information of the Instance if it's in `ACTIVE` state."
+    },
+    "ListApiSpecsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "apiSpecs": {
+          "type": "array",
+          "items": {
+            "$ref": "ApiSpec"
+          },
+          "description": "The specs from the specified publisher."
+        }
+      },
+      "description": "Response message for ListApiSpecs.",
+      "id": "ListApiSpecsResponse",
+      "type": "object"
+    },
+    "ListArtifactsResponse": {
+      "type": "object",
+      "id": "ListArtifactsResponse",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "artifacts": {
+          "description": "The artifacts from the specified publisher.",
+          "type": "array",
+          "items": {
+            "$ref": "Artifact"
+          }
+        }
+      },
+      "description": "Response message for ListArtifacts."
+    },
+    "ListApiDeploymentRevisionsResponse": {
+      "properties": {
+        "apiDeployments": {
+          "description": "The revisions of the deployment.",
+          "items": {
+            "$ref": "ApiDeployment"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        }
+      },
+      "description": "Response message for ListApiDeploymentRevisionsResponse.",
+      "type": "object",
+      "id": "ListApiDeploymentRevisionsResponse"
+    },
+    "ListApiVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "apiVersions": {
+          "items": {
+            "$ref": "ApiVersion"
+          },
+          "description": "The versions from the specified publisher.",
+          "type": "array"
+        }
+      },
+      "description": "Response message for ListApiVersions.",
+      "id": "ListApiVersionsResponse"
+    },
+    "ApiDeployment": {
+      "type": "object",
+      "description": "Describes a service running at particular address that provides a particular version of an API. ApiDeployments have revisions which correspond to different configurations of a single deployment in time. Revision identifiers should be updated whenever the served API spec or endpoint address changes.",
+      "id": "ApiDeployment",
+      "properties": {
+        "revisionCreateTime": {
+          "type": "string",
+          "description": "Output only. Revision creation timestamp; when the represented revision was created.",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "revisionUpdateTime": {
+          "description": "Output only. Last update timestamp: when the represented revision was last modified.",
+          "type": "string",
+          "readOnly": true,
+          "format": "google-datetime"
+        },
+        "intendedAudience": {
+          "description": "Text briefly identifying the intended audience of the API. Changes to this value will not affect the revision.",
+          "type": "string"
+        },
+        "externalChannelUri": {
+          "type": "string",
+          "description": "The address of the external channel of the API (e.g., the Developer Portal). Changes to this value will not affect the revision."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with `apigeeregistry.googleapis.com/` and cannot be changed."
+        },
+        "createTime": {
+          "type": "string",
+          "description": "Output only. Creation timestamp; when the deployment resource was created.",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "revisionId": {
+          "type": "string",
+          "description": "Output only. Immutable. The revision ID of the deployment. A new revision is committed whenever the deployment contents are changed. The format is an 8-character hexadecimal string.",
+          "readOnly": true
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "description": {
+          "type": "string",
+          "description": "A detailed description."
+        },
+        "displayName": {
+          "description": "Human-meaningful name.",
+          "type": "string"
+        },
+        "accessGuidance": {
+          "type": "string",
+          "description": "Text briefly describing how to access the endpoint. Changes to this value will not affect the revision."
+        },
+        "apiSpecRevision": {
+          "description": "The full resource name (including revision ID) of the spec of the API being served by the deployment. Changes to this value will update the revision. Format: `projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec@revision}`",
+          "type": "string"
+        },
+        "endpointUri": {
+          "type": "string",
+          "description": "The address where the deployment is serving. Changes to this value will update the revision."
+        }
+      }
+    },
+    "RollbackApiSpecRequest": {
+      "id": "RollbackApiSpecRequest",
+      "description": "Request message for RollbackApiSpec.",
+      "properties": {
+        "revisionId": {
+          "type": "string",
+          "description": "Required. The revision ID to roll back to. It must be a revision of the same spec. Example: `c7cfa2a8`"
+        }
+      },
+      "type": "object"
+    },
+    "TagApiDeploymentRevisionRequest": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Required. The tag to apply. The tag should be at most 40 characters, and match `a-z{3,39}`.",
+          "type": "string"
+        }
+      },
+      "id": "TagApiDeploymentRevisionRequest",
+      "description": "Request message for TagApiDeploymentRevision."
+    },
+    "HttpBody": {
+      "id": "HttpBody",
+      "properties": {
+        "extensions": {
+          "description": "Application specific response metadata. Must be set in the first response for streaming APIs.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "any",
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          }
+        },
+        "data": {
+          "description": "The HTTP request/response body as raw binary.",
+          "format": "byte",
+          "type": "string"
+        },
+        "contentType": {
+          "description": "The HTTP Content-Type header value specifying the content type of the body.",
+          "type": "string"
+        }
+      },
+      "description": "Message that represents an arbitrary HTTP body. It should only be used for payload formats that can't be represented as JSON, such as raw binary or an HTML page. This message can be used both in streaming and non-streaming API methods in the request as well as the response. It can be used as a top-level request field, which is convenient if one wants to extract parameters from either the URL or HTTP template into the request fields and also want access to the raw HTTP body. Example: message GetResourceRequest { // A unique request id. string request_id = 1; // The raw HTTP body is bound to this field. google.api.HttpBody http_body = 2; } service ResourceService { rpc GetResource(GetResourceRequest) returns (google.api.HttpBody); rpc UpdateResource(google.api.HttpBody) returns (google.protobuf.Empty); } Example with streaming methods: service CaldavService { rpc GetCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); rpc UpdateCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); } Use of this type only changes how the request and response bodies are handled, all other features will continue to work unchanged.",
+      "type": "object"
+    },
+    "Binding": {
+      "id": "Binding",
+      "type": "object",
+      "description": "Associates `members`, or principals, with a `role`.",
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`."
+        },
+        "condition": {
+          "$ref": "Expr",
+          "description": "The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding."
+        }
+      }
+    },
+    "ListLocationsResponse": {
+      "id": "ListLocationsResponse",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "A list of locations that matches the specified filter in the request.",
+          "items": {
+            "$ref": "Location"
+          }
+        },
+        "nextPageToken": {
+          "description": "The standard List next-page token.",
+          "type": "string"
+        }
+      },
+      "description": "The response message for Locations.ListLocations.",
+      "type": "object"
+    },
+    "Artifact": {
+      "type": "object",
+      "id": "Artifact",
+      "description": "Artifacts of resources. Artifacts are unique (single-value) per resource and are used to store metadata that is too large or numerous to be stored directly on the resource. Since artifacts are stored separately from parent resources, they should generally be used for metadata that is needed infrequently, i.e., not for display in primary views of the resource but perhaps displayed or downloaded upon request. The `ListArtifacts` method allows artifacts to be quickly enumerated and checked for presence without downloading their (potentially-large) contents.",
+      "properties": {
+        "name": {
+          "description": "Resource name.",
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "A content type specifier for the artifact. Content type specifiers are Media Types (https://en.wikipedia.org/wiki/Media_type) with a possible \"schema\" parameter that specifies a schema for the stored information. Content types can specify compression. Currently only GZip compression is supported (indicated with \"+gzip\")."
+        },
+        "hash": {
+          "description": "Output only. A SHA-256 hash of the artifact's contents. If the artifact is gzipped, this is the hash of the uncompressed artifact.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "createTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. Creation timestamp."
+        },
+        "contents": {
+          "description": "Input only. The contents of the artifact. Provided by API callers when artifacts are created or replaced. To access the contents of an artifact, use GetArtifactContents.",
+          "type": "string",
+          "format": "byte"
+        },
+        "updateTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. Last update timestamp."
+        },
+        "labels": {
+          "description": "Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with \"registry.googleapis.com/\" and cannot be changed.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sizeBytes": {
+          "format": "int32",
+          "description": "Output only. The size of the artifact in bytes. If the artifact is gzipped, this is the size of the uncompressed artifact.",
+          "readOnly": true,
+          "type": "integer"
+        }
+      }
+    },
+    "SetIamPolicyRequest": {
+      "description": "Request message for `SetIamPolicy` method.",
+      "properties": {
+        "policy": {
+          "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them.",
+          "$ref": "Policy"
+        }
+      },
+      "id": "SetIamPolicyRequest",
+      "type": "object"
+    },
+    "Operation": {
+      "type": "object",
+      "id": "Operation",
+      "description": "This resource represents a long-running operation that is the result of a network API call.",
+      "properties": {
+        "error": {
+          "description": "The error result of the operation in case of failure or cancellation.",
+          "$ref": "Status"
+        },
+        "response": {
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "description": "The normal response of the operation in case of success. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "type": "object"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          }
+        },
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
+          "type": "string"
+        },
+        "done": {
+          "type": "boolean",
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+        }
+      }
+    },
+    "Location": {
+      "id": "Location",
+      "description": "A resource that represents Google Cloud Platform location.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Resource name for the location, which may vary between implementations. For example: `\"projects/example-project/locations/us-east1\"`"
+        },
+        "locationId": {
+          "description": "The canonical id for this location. For example: `\"us-east1\"`.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The friendly name for this location, typically a nearby city name. For example, \"Tokyo\".",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "description": "Service-specific metadata. For example the available capacity at the given location.",
+          "type": "object"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Cross-service attributes for the location. For example {\"cloud.googleapis.com/region\": \"us-east1\"}"
+        }
+      },
+      "type": "object"
+    },
+    "ListOperationsResponse": {
+      "properties": {
+        "operations": {
+          "description": "A list of operations that matches the specified filter in the request.",
+          "items": {
+            "$ref": "Operation"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The standard List next-page token."
+        }
+      },
+      "id": "ListOperationsResponse",
+      "description": "The response message for Operations.ListOperations.",
+      "type": "object"
+    },
+    "TestIamPermissionsResponse": {
+      "properties": {
+        "permissions": {
+          "items": {
+            "type": "string"
+          },
+          "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed.",
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "TestIamPermissionsResponse",
+      "description": "Response message for `TestIamPermissions` method."
+    },
+    "Expr": {
+      "description": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() \u003c 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.",
+      "properties": {
+        "location": {
+          "description": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "description": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
+        },
+        "expression": {
+          "description": "Textual representation of an expression in Common Expression Language syntax.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "id": "Expr"
+    },
+    "TestIamPermissionsRequest": {
+      "id": "TestIamPermissionsRequest",
+      "properties": {
+        "permissions": {
+          "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "Request message for `TestIamPermissions` method."
+    },
+    "CancelOperationRequest": {
+      "id": "CancelOperationRequest",
+      "properties": {},
+      "description": "The request message for Operations.CancelOperation.",
+      "type": "object"
+    },
+    "ListApiSpecRevisionsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "description": "A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "apiSpecs": {
+          "description": "The revisions of the spec.",
+          "type": "array",
+          "items": {
+            "$ref": "ApiSpec"
+          }
+        }
+      },
+      "type": "object",
+      "description": "Response message for ListApiSpecRevisionsResponse.",
+      "id": "ListApiSpecRevisionsResponse"
+    },
+    "Policy": {
+      "description": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time \u003c timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).",
+      "type": "object",
+      "properties": {
+        "etag": {
+          "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost.",
+          "type": "string",
+          "format": "byte"
+        },
+        "version": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+        },
+        "bindings": {
+          "type": "array",
+          "description": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`.",
+          "items": {
+            "$ref": "Binding"
+          }
+        }
+      },
+      "id": "Policy"
+    },
+    "ListApiDeploymentsResponse": {
+      "properties": {
+        "apiDeployments": {
+          "type": "array",
+          "items": {
+            "$ref": "ApiDeployment"
+          },
+          "description": "The deployments from the specified publisher."
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        }
+      },
+      "id": "ListApiDeploymentsResponse",
+      "description": "Response message for ListApiDeployments.",
+      "type": "object"
+    }
+  },
+  "description": "",
+  "baseUrl": "https://apigeeregistry.googleapis.com/",
+  "batchPath": "batch",
+  "name": "apigeeregistry",
+  "canonicalName": "Apigee Registry",
+  "parameters": {
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true"
+    },
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "type": "string",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query"
+    },
+    "uploadType": {
+      "location": "query",
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string"
+    },
+    "oauth_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user."
+    },
+    "quotaUser": {
+      "type": "string",
+      "location": "query",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+    },
+    "upload_protocol": {
+      "location": "query",
+      "type": "string",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
+    },
+    "alt": {
+      "default": "json",
+      "description": "Data format for response.",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "access_token": {
+      "type": "string",
+      "location": "query",
+      "description": "OAuth access token."
+    },
+    "callback": {
+      "type": "string",
+      "location": "query",
+      "description": "JSONP"
+    }
+  },
+  "documentationLink": "https://cloud.google.com/apigee/docs/api-hub/what-is-api-hub",
+  "icons": {
+    "x32": "http://www.google.com/images/icons/product/search-32.gif",
+    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+  },
+  "discoveryVersion": "v1",
+  "ownerName": "Google",
+  "servicePath": "",
+  "kind": "discovery#restDescription",
+  "id": "apigeeregistry:v1",
+  "version_module": true,
+  "mtlsRootUrl": "https://apigeeregistry.mtls.googleapis.com/",
+  "resources": {
+    "projects": {
+      "resources": {
+        "locations": {
+          "resources": {
+            "apis": {
+              "resources": {
+                "artifacts": {
+                  "methods": {
+                    "getIamPolicy": {
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:getIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.getIamPolicy",
+                      "parameters": {
+                        "resource": {
+                          "type": "string",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true
+                        },
+                        "options.requestedPolicyVersion": {
+                          "location": "query",
+                          "type": "integer",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                          "format": "int32"
+                        }
+                      },
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "Policy"
+                      }
+                    },
+                    "get": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "description": "Returns a specified artifact.",
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "type": "string",
+                          "location": "path"
+                        }
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.get",
+                      "httpMethod": "GET",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "getContents": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                          "type": "string"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.getContents",
+                      "httpMethod": "GET",
+                      "path": "v1/{+name}:getContents",
+                      "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:getContents",
+                      "response": {
+                        "$ref": "HttpBody"
+                      }
+                    },
+                    "replaceArtifact": {
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "type": "string",
+                          "required": true,
+                          "description": "Resource name.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$"
+                        }
+                      },
+                      "httpMethod": "PUT",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "request": {
+                        "$ref": "Artifact"
+                      },
+                      "description": "Used to replace a specified artifact.",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.replaceArtifact",
+                      "path": "v1/{+name}"
+                    },
+                    "setIamPolicy": {
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "type": "string",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:setIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.setIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "httpMethod": "POST"
+                    },
+                    "testIamPermissions": {
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true,
+                          "location": "path",
+                          "type": "string"
+                        }
+                      },
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}:testIamPermissions",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.testIamPermissions",
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "httpMethod": "POST"
+                    },
+                    "create": {
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "Artifact"
+                      },
+                      "parameters": {
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "location": "path",
+                          "required": true
+                        },
+                        "artifactId": {
+                          "type": "string",
+                          "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                          "location": "query"
+                        }
+                      },
+                      "path": "v1/{+parent}/artifacts",
+                      "request": {
+                        "$ref": "Artifact"
+                      },
+                      "description": "Creates a specified artifact.",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.create",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts",
+                      "httpMethod": "POST"
+                    },
+                    "list": {
+                      "path": "v1/{+parent}/artifacts",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "parameters": {
+                        "pageSize": {
+                          "location": "query",
+                          "format": "int32",
+                          "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "type": "integer"
+                        },
+                        "orderBy": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\""
+                        },
+                        "pageToken": {
+                          "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                          "type": "string"
+                        },
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "type": "string",
+                          "location": "path"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.list",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "description": "Returns matching artifacts.",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts",
+                      "response": {
+                        "$ref": "ListArtifactsResponse"
+                      }
+                    },
+                    "delete": {
+                      "description": "Removes a specified artifact.",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/artifacts/{artifactsId}",
+                      "id": "apigeeregistry.projects.locations.apis.artifacts.delete",
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/artifacts/[^/]+$",
+                          "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "path": "v1/{+name}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "DELETE",
+                      "response": {
+                        "$ref": "Empty"
+                      }
+                    }
+                  }
+                },
+                "versions": {
+                  "methods": {
+                    "setIamPolicy": {
+                      "parameters": {
+                        "resource": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      },
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "id": "apigeeregistry.projects.locations.apis.versions.setIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:setIamPolicy",
+                      "response": {
+                        "$ref": "Policy"
+                      }
+                    },
+                    "get": {
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "description": "Returns a specified version.",
+                      "httpMethod": "GET",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "name": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "description": "Required. The name of the version to retrieve. Format: `projects/*/locations/*/apis/*/versions/*`",
+                          "location": "path",
+                          "required": true,
+                          "type": "string"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.versions.get"
+                    },
+                    "testIamPermissions": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "location": "path",
+                          "required": true
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.versions.testIamPermissions",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:testIamPermissions",
+                      "httpMethod": "POST"
+                    },
+                    "create": {
+                      "parameters": {
+                        "apiVersionId": {
+                          "location": "query",
+                          "description": "Required. The ID to use for the version, which will become the final component of the version's resource name. This value should be 1-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                          "type": "string"
+                        },
+                        "parent": {
+                          "description": "Required. The parent, which owns this collection of versions. Format: `projects/*/locations/*/apis/*`",
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$"
+                        }
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.versions.create",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "request": {
+                        "$ref": "ApiVersion"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "description": "Creates a specified version.",
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "path": "v1/{+parent}/versions",
+                      "httpMethod": "POST"
+                    },
+                    "getIamPolicy": {
+                      "parameters": {
+                        "resource": {
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$"
+                        },
+                        "options.requestedPolicyVersion": {
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                          "location": "query",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      },
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}:getIamPolicy",
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.versions.getIamPolicy",
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "path": "v1/{+resource}:getIamPolicy"
+                    },
+                    "list": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "path": "v1/{+parent}/versions",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions",
+                      "id": "apigeeregistry.projects.locations.apis.versions.list",
+                      "parameters": {
+                        "pageSize": {
+                          "location": "query",
+                          "description": "The maximum number of versions to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields."
+                        },
+                        "pageToken": {
+                          "description": "A page token, received from a previous `ListApiVersions` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiVersions` must match the call that provided the page token.",
+                          "type": "string",
+                          "location": "query"
+                        },
+                        "parent": {
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of versions. Format: `projects/*/locations/*/apis/*`"
+                        },
+                        "orderBy": {
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "type": "string",
+                          "location": "query"
+                        }
+                      },
+                      "response": {
+                        "$ref": "ListApiVersionsResponse"
+                      },
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "description": "Returns matching versions."
+                    },
+                    "patch": {
+                      "request": {
+                        "$ref": "ApiVersion"
+                      },
+                      "response": {
+                        "$ref": "ApiVersion"
+                      },
+                      "httpMethod": "PATCH",
+                      "parameters": {
+                        "updateMask": {
+                          "type": "string",
+                          "location": "query",
+                          "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                          "format": "google-fieldmask"
+                        },
+                        "allowMissing": {
+                          "type": "boolean",
+                          "description": "If set to true, and the version is not found, a new version will be created. In this situation, `update_mask` is ignored.",
+                          "location": "query"
+                        },
+                        "name": {
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                          "description": "Resource name.",
+                          "required": true,
+                          "location": "path"
+                        }
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "description": "Used to modify a specified version.",
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.versions.patch"
+                    },
+                    "delete": {
+                      "parameters": {
+                        "force": {
+                          "location": "query",
+                          "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "type": "string",
+                          "description": "Required. The name of the version to delete. Format: `projects/*/locations/*/apis/*/versions/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$"
+                        }
+                      },
+                      "path": "v1/{+name}",
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Removes a specified version and all of the resources that it owns.",
+                      "httpMethod": "DELETE",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.versions.delete",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}"
+                    }
+                  },
+                  "resources": {
+                    "artifacts": {
+                      "methods": {
+                        "get": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "required": true
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "httpMethod": "GET",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.get",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Returns a specified artifact.",
+                          "response": {
+                            "$ref": "Artifact"
+                          }
+                        },
+                        "replaceArtifact": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "description": "Resource name.",
+                              "required": true
+                            }
+                          },
+                          "httpMethod": "PUT",
+                          "description": "Used to replace a specified artifact.",
+                          "path": "v1/{+name}",
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.replaceArtifact",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}"
+                        },
+                        "delete": {
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                              "location": "path",
+                              "required": true,
+                              "type": "string"
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "DELETE",
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}",
+                          "description": "Removes a specified artifact.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.delete"
+                        },
+                        "setIamPolicy": {
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.setIamPolicy",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "request": {
+                            "$ref": "SetIamPolicyRequest"
+                          },
+                          "parameters": {
+                            "resource": {
+                              "required": true,
+                              "type": "string",
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$"
+                            }
+                          },
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "httpMethod": "POST",
+                          "path": "v1/{+resource}:setIamPolicy",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:setIamPolicy"
+                        },
+                        "testIamPermissions": {
+                          "response": {
+                            "$ref": "TestIamPermissionsResponse"
+                          },
+                          "request": {
+                            "$ref": "TestIamPermissionsRequest"
+                          },
+                          "path": "v1/{+resource}:testIamPermissions",
+                          "parameters": {
+                            "resource": {
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "required": true,
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.testIamPermissions",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:testIamPermissions",
+                          "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                          "parameterOrder": [
+                            "resource"
+                          ]
+                        },
+                        "getContents": {
+                          "path": "v1/{+name}:getContents",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.getContents",
+                          "httpMethod": "GET",
+                          "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:getContents",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "location": "path",
+                              "type": "string",
+                              "required": true,
+                              "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`"
+                            }
+                          },
+                          "response": {
+                            "$ref": "HttpBody"
+                          }
+                        },
+                        "create": {
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "POST",
+                          "description": "Creates a specified artifact.",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts",
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.create",
+                          "parameters": {
+                            "artifactId": {
+                              "location": "query",
+                              "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "type": "string"
+                            },
+                            "parent": {
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "type": "string",
+                              "required": true
+                            }
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "path": "v1/{+parent}/artifacts"
+                        },
+                        "list": {
+                          "parameters": {
+                            "pageSize": {
+                              "type": "integer",
+                              "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                              "format": "int32",
+                              "location": "query"
+                            },
+                            "orderBy": {
+                              "type": "string",
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "location": "query"
+                            },
+                            "parent": {
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "location": "path",
+                              "required": true
+                            },
+                            "filter": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                            },
+                            "pageToken": {
+                              "location": "query",
+                              "type": "string",
+                              "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token."
+                            }
+                          },
+                          "path": "v1/{+parent}/artifacts",
+                          "response": {
+                            "$ref": "ListArtifactsResponse"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Returns matching artifacts.",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.list"
+                        },
+                        "getIamPolicy": {
+                          "parameters": {
+                            "resource": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/artifacts/[^/]+$",
+                              "type": "string",
+                              "location": "path",
+                              "required": true,
+                              "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            },
+                            "options.requestedPolicyVersion": {
+                              "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                              "format": "int32",
+                              "location": "query",
+                              "type": "integer"
+                            }
+                          },
+                          "path": "v1/{+resource}:getIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.artifacts.getIamPolicy",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/artifacts/{artifactsId}:getIamPolicy",
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set."
+                        }
+                      }
+                    },
+                    "specs": {
+                      "resources": {
+                        "artifacts": {
+                          "methods": {
+                            "testIamPermissions": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:testIamPermissions",
+                              "httpMethod": "POST",
+                              "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.testIamPermissions",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "response": {
+                                "$ref": "TestIamPermissionsResponse"
+                              },
+                              "request": {
+                                "$ref": "TestIamPermissionsRequest"
+                              },
+                              "path": "v1/{+resource}:testIamPermissions",
+                              "parameters": {
+                                "resource": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path",
+                                  "type": "string",
+                                  "required": true,
+                                  "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                                }
+                              },
+                              "parameterOrder": [
+                                "resource"
+                              ]
+                            },
+                            "get": {
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "description": "Returns a specified artifact.",
+                              "path": "v1/{+name}",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.get",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "parameters": {
+                                "name": {
+                                  "location": "path",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "type": "string",
+                                  "required": true,
+                                  "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`"
+                                }
+                              },
+                              "httpMethod": "GET"
+                            },
+                            "delete": {
+                              "httpMethod": "DELETE",
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.delete",
+                              "description": "Removes a specified artifact.",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameters": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                                  "location": "path",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "required": true
+                                }
+                              },
+                              "response": {
+                                "$ref": "Empty"
+                              },
+                              "path": "v1/{+name}"
+                            },
+                            "list": {
+                              "description": "Returns matching artifacts.",
+                              "response": {
+                                "$ref": "ListArtifactsResponse"
+                              },
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts",
+                              "parameterOrder": [
+                                "parent"
+                              ],
+                              "parameters": {
+                                "parent": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                                  "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                                  "required": true,
+                                  "location": "path",
+                                  "type": "string"
+                                },
+                                "filter": {
+                                  "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                                  "type": "string",
+                                  "location": "query"
+                                },
+                                "pageToken": {
+                                  "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                                  "type": "string",
+                                  "location": "query"
+                                },
+                                "pageSize": {
+                                  "format": "int32",
+                                  "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                                  "type": "integer",
+                                  "location": "query"
+                                },
+                                "orderBy": {
+                                  "type": "string",
+                                  "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                                  "location": "query"
+                                }
+                              },
+                              "httpMethod": "GET",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.list",
+                              "path": "v1/{+parent}/artifacts"
+                            },
+                            "replaceArtifact": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}",
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "description": "Used to replace a specified artifact.",
+                              "request": {
+                                "$ref": "Artifact"
+                              },
+                              "path": "v1/{+name}",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "parameters": {
+                                "name": {
+                                  "required": true,
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "Resource name."
+                                }
+                              },
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.replaceArtifact",
+                              "httpMethod": "PUT"
+                            },
+                            "getIamPolicy": {
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:getIamPolicy",
+                              "httpMethod": "GET",
+                              "response": {
+                                "$ref": "Policy"
+                              },
+                              "parameters": {
+                                "resource": {
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "required": true
+                                },
+                                "options.requestedPolicyVersion": {
+                                  "format": "int32",
+                                  "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                                  "location": "query",
+                                  "type": "integer"
+                                }
+                              },
+                              "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.getIamPolicy",
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "path": "v1/{+resource}:getIamPolicy"
+                            },
+                            "create": {
+                              "response": {
+                                "$ref": "Artifact"
+                              },
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts",
+                              "request": {
+                                "$ref": "Artifact"
+                              },
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "parameterOrder": [
+                                "parent"
+                              ],
+                              "description": "Creates a specified artifact.",
+                              "httpMethod": "POST",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.create",
+                              "path": "v1/{+parent}/artifacts",
+                              "parameters": {
+                                "artifactId": {
+                                  "location": "query",
+                                  "type": "string",
+                                  "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                                },
+                                "parent": {
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                                  "required": true,
+                                  "location": "path",
+                                  "type": "string",
+                                  "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                                }
+                              }
+                            },
+                            "setIamPolicy": {
+                              "path": "v1/{+resource}:setIamPolicy",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:setIamPolicy",
+                              "parameterOrder": [
+                                "resource"
+                              ],
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "httpMethod": "POST",
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.setIamPolicy",
+                              "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                              "parameters": {
+                                "resource": {
+                                  "location": "path",
+                                  "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "required": true,
+                                  "type": "string"
+                                }
+                              },
+                              "request": {
+                                "$ref": "SetIamPolicyRequest"
+                              },
+                              "response": {
+                                "$ref": "Policy"
+                              }
+                            },
+                            "getContents": {
+                              "response": {
+                                "$ref": "HttpBody"
+                              },
+                              "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                              ],
+                              "httpMethod": "GET",
+                              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}/artifacts/{artifactsId}:getContents",
+                              "parameterOrder": [
+                                "name"
+                              ],
+                              "id": "apigeeregistry.projects.locations.apis.versions.specs.artifacts.getContents",
+                              "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                              "path": "v1/{+name}:getContents",
+                              "parameters": {
+                                "name": {
+                                  "type": "string",
+                                  "required": true,
+                                  "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                                  "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+/artifacts/[^/]+$",
+                                  "location": "path"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "methods": {
+                        "create": {
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "request": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Creates a specified spec.",
+                          "path": "v1/{+parent}/specs",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.create",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "POST",
+                          "parameters": {
+                            "parent": {
+                              "type": "string",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "location": "path",
+                              "description": "Required. The parent, which owns this collection of specs. Format: `projects/*/locations/*/apis/*/versions/*`"
+                            },
+                            "apiSpecId": {
+                              "type": "string",
+                              "description": "Required. The ID to use for the spec, which will become the final component of the spec's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "location": "query"
+                            }
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ]
+                        },
+                        "patch": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.patch",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "httpMethod": "PATCH",
+                          "request": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Used to modify a specified spec.",
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameters": {
+                            "allowMissing": {
+                              "location": "query",
+                              "description": "If set to true, and the spec is not found, a new spec will be created. In this situation, `update_mask` is ignored.",
+                              "type": "boolean"
+                            },
+                            "updateMask": {
+                              "location": "query",
+                              "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                              "format": "google-fieldmask",
+                              "type": "string"
+                            },
+                            "name": {
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Resource name."
+                            }
+                          }
+                        },
+                        "rollback": {
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Required. The spec being rolled back.",
+                              "location": "path",
+                              "type": "string"
+                            }
+                          },
+                          "path": "v1/{+name}:rollback",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.rollback",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "request": {
+                            "$ref": "RollbackApiSpecRequest"
+                          },
+                          "description": "Sets the current revision to a specified prior revision. Note that this creates a new revision with a new revision ID.",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:rollback",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "httpMethod": "POST"
+                        },
+                        "get": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "required": true,
+                              "description": "Required. The name of the spec to retrieve. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$"
+                            }
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.get",
+                          "httpMethod": "GET",
+                          "description": "Returns a specified spec.",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "ApiSpec"
+                          }
+                        },
+                        "tagRevision": {
+                          "description": "Adds a tag to a specified revision of a spec.",
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "location": "path",
+                              "type": "string",
+                              "description": "Required. The name of the spec to be tagged, including the revision ID.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$"
+                            }
+                          },
+                          "httpMethod": "POST",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:tagRevision",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.tagRevision",
+                          "request": {
+                            "$ref": "TagApiSpecRevisionRequest"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "path": "v1/{+name}:tagRevision",
+                          "response": {
+                            "$ref": "ApiSpec"
+                          }
+                        },
+                        "delete": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}",
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.delete",
+                          "description": "Removes a specified spec, all revisions, and all child resources (e.g., artifacts).",
+                          "parameters": {
+                            "force": {
+                              "location": "query",
+                              "type": "boolean",
+                              "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)"
+                            },
+                            "name": {
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The name of the spec to delete. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "location": "path"
+                            }
+                          },
+                          "httpMethod": "DELETE"
+                        },
+                        "deleteRevision": {
+                          "httpMethod": "DELETE",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:deleteRevision",
+                          "parameters": {
+                            "name": {
+                              "location": "path",
+                              "description": "Required. The name of the spec revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8`",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "type": "string"
+                            }
+                          },
+                          "path": "v1/{+name}:deleteRevision",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.deleteRevision",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "ApiSpec"
+                          },
+                          "description": "Deletes a revision of a spec."
+                        },
+                        "listRevisions": {
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:listRevisions",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.listRevisions",
+                          "description": "Lists all revisions of a spec. Revisions are returned in descending order of revision creation time.",
+                          "httpMethod": "GET",
+                          "path": "v1/{+name}:listRevisions",
+                          "parameters": {
+                            "pageToken": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "The page token, received from a previous ListApiSpecRevisions call. Provide this to retrieve the subsequent page."
+                            },
+                            "name": {
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "Required. The name of the spec to list revisions for.",
+                              "type": "string",
+                              "location": "path"
+                            },
+                            "pageSize": {
+                              "location": "query",
+                              "description": "The maximum number of revisions to return per page.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "filter": {
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                              "location": "query",
+                              "type": "string"
+                            }
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "response": {
+                            "$ref": "ListApiSpecRevisionsResponse"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ]
+                        },
+                        "testIamPermissions": {
+                          "parameters": {
+                            "resource": {
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "type": "string",
+                              "location": "path",
+                              "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                            }
+                          },
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "request": {
+                            "$ref": "TestIamPermissionsRequest"
+                          },
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.testIamPermissions",
+                          "path": "v1/{+resource}:testIamPermissions",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "TestIamPermissionsResponse"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:testIamPermissions",
+                          "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning."
+                        },
+                        "getContents": {
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.getContents",
+                          "path": "v1/{+name}:getContents",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "description": "Required. The name of the spec whose contents should be retrieved. Format: `projects/*/locations/*/apis/*/versions/*/specs/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true,
+                              "location": "path"
+                            }
+                          },
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "description": "Returns the contents of a specified spec. If specs are stored with GZip compression, the default behavior is to return the spec uncompressed (the mime_type response field indicates the exact format returned).",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:getContents"
+                        },
+                        "setIamPolicy": {
+                          "httpMethod": "POST",
+                          "path": "v1/{+resource}:setIamPolicy",
+                          "parameters": {
+                            "resource": {
+                              "location": "path",
+                              "type": "string",
+                              "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "required": true
+                            }
+                          },
+                          "request": {
+                            "$ref": "SetIamPolicyRequest"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.setIamPolicy",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:setIamPolicy",
+                          "response": {
+                            "$ref": "Policy"
+                          }
+                        },
+                        "getIamPolicy": {
+                          "httpMethod": "GET",
+                          "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.getIamPolicy",
+                          "parameterOrder": [
+                            "resource"
+                          ],
+                          "parameters": {
+                            "options.requestedPolicyVersion": {
+                              "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                              "type": "integer",
+                              "format": "int32",
+                              "location": "query"
+                            },
+                            "resource": {
+                              "type": "string",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+/specs/[^/]+$",
+                              "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                              "location": "path"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs/{specsId}:getIamPolicy",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "Policy"
+                          },
+                          "path": "v1/{+resource}:getIamPolicy"
+                        },
+                        "list": {
+                          "httpMethod": "GET",
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/versions/{versionsId}/specs",
+                          "parameters": {
+                            "pageToken": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "A page token, received from a previous `ListApiSpecs` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiSpecs` must match the call that provided the page token."
+                            },
+                            "pageSize": {
+                              "type": "integer",
+                              "description": "The maximum number of specs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                              "format": "int32",
+                              "location": "query"
+                            },
+                            "orderBy": {
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "type": "string",
+                              "location": "query"
+                            },
+                            "filter": {
+                              "type": "string",
+                              "location": "query",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                            },
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/versions/[^/]+$",
+                              "description": "Required. The parent, which owns this collection of specs. Format: `projects/*/locations/*/apis/*/versions/*`",
+                              "location": "path",
+                              "required": true,
+                              "type": "string"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.versions.specs.list",
+                          "path": "v1/{+parent}/specs",
+                          "description": "Returns matching specs.",
+                          "response": {
+                            "$ref": "ListApiSpecsResponse"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "deployments": {
+                  "resources": {
+                    "artifacts": {
+                      "methods": {
+                        "list": {
+                          "parameters": {
+                            "parent": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                              "location": "path",
+                              "required": true,
+                              "type": "string",
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`"
+                            },
+                            "pageToken": {
+                              "location": "query",
+                              "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                              "type": "string"
+                            },
+                            "orderBy": {
+                              "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                              "type": "string",
+                              "location": "query"
+                            },
+                            "pageSize": {
+                              "location": "query",
+                              "type": "integer",
+                              "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                              "format": "int32"
+                            },
+                            "filter": {
+                              "type": "string",
+                              "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.",
+                              "location": "query"
+                            }
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Returns matching artifacts.",
+                          "response": {
+                            "$ref": "ListArtifactsResponse"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.list",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "httpMethod": "GET",
+                          "path": "v1/{+parent}/artifacts"
+                        },
+                        "getContents": {
+                          "response": {
+                            "$ref": "HttpBody"
+                          },
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "type": "string",
+                              "location": "path"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.getContents",
+                          "path": "v1/{+name}:getContents",
+                          "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                          "httpMethod": "GET",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}:getContents"
+                        },
+                        "create": {
+                          "path": "v1/{+parent}/artifacts",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "parameterOrder": [
+                            "parent"
+                          ],
+                          "description": "Creates a specified artifact.",
+                          "httpMethod": "POST",
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.create",
+                          "parameters": {
+                            "parent": {
+                              "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                              "type": "string",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                              "location": "path"
+                            },
+                            "artifactId": {
+                              "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                              "type": "string",
+                              "location": "query"
+                            }
+                          },
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts"
+                        },
+                        "delete": {
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "response": {
+                            "$ref": "Empty"
+                          },
+                          "description": "Removes a specified artifact.",
+                          "path": "v1/{+name}",
+                          "httpMethod": "DELETE",
+                          "parameters": {
+                            "name": {
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`",
+                              "required": true,
+                              "location": "path",
+                              "type": "string"
+                            }
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.delete",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "parameterOrder": [
+                            "name"
+                          ]
+                        },
+                        "replaceArtifact": {
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "request": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "PUT",
+                          "parameters": {
+                            "name": {
+                              "required": true,
+                              "type": "string",
+                              "location": "path",
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$",
+                              "description": "Resource name."
+                            }
+                          },
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.replaceArtifact",
+                          "path": "v1/{+name}",
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "description": "Used to replace a specified artifact."
+                        },
+                        "get": {
+                          "id": "apigeeregistry.projects.locations.apis.deployments.artifacts.get",
+                          "parameters": {
+                            "name": {
+                              "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                              "type": "string",
+                              "location": "path",
+                              "required": true,
+                              "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+/artifacts/[^/]+$"
+                            }
+                          },
+                          "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}/artifacts/{artifactsId}",
+                          "parameterOrder": [
+                            "name"
+                          ],
+                          "path": "v1/{+name}",
+                          "response": {
+                            "$ref": "Artifact"
+                          },
+                          "httpMethod": "GET",
+                          "scopes": [
+                            "https://www.googleapis.com/auth/cloud-platform"
+                          ],
+                          "description": "Returns a specified artifact."
+                        }
+                      }
+                    }
+                  },
+                  "methods": {
+                    "delete": {
+                      "id": "apigeeregistry.projects.locations.apis.deployments.delete",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "description": "Required. The name of the deployment to delete. Format: `projects/*/locations/*/apis/*/deployments/*`",
+                          "required": true,
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        },
+                        "force": {
+                          "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                          "type": "boolean",
+                          "location": "query"
+                        }
+                      },
+                      "response": {
+                        "$ref": "Empty"
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Removes a specified deployment, all revisions, and all child resources (e.g., artifacts).",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+name}",
+                      "httpMethod": "DELETE"
+                    },
+                    "tagRevision": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:tagRevision",
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.tagRevision",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+name}:tagRevision",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string",
+                          "description": "Required. The name of the deployment to be tagged, including the revision ID."
+                        }
+                      },
+                      "description": "Adds a tag to a specified revision of a deployment.",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "httpMethod": "POST",
+                      "request": {
+                        "$ref": "TagApiDeploymentRevisionRequest"
+                      }
+                    },
+                    "create": {
+                      "parameters": {
+                        "apiDeploymentId": {
+                          "location": "query",
+                          "type": "string",
+                          "description": "Required. The ID to use for the deployment, which will become the final component of the deployment's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                        },
+                        "parent": {
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "Required. The parent, which owns this collection of deployments. Format: `projects/*/locations/*/apis/*`"
+                        }
+                      },
+                      "httpMethod": "POST",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.create",
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "request": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "path": "v1/{+parent}/deployments",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments",
+                      "description": "Creates a specified deployment."
+                    },
+                    "patch": {
+                      "request": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "required": true,
+                          "location": "path",
+                          "description": "Resource name.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        },
+                        "updateMask": {
+                          "format": "google-fieldmask",
+                          "location": "query",
+                          "type": "string",
+                          "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request."
+                        },
+                        "allowMissing": {
+                          "description": "If set to true, and the deployment is not found, a new deployment will be created. In this situation, `update_mask` is ignored.",
+                          "location": "query",
+                          "type": "boolean"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "description": "Used to modify a specified deployment.",
+                      "path": "v1/{+name}",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.patch",
+                      "httpMethod": "PATCH",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "listRevisions": {
+                      "description": "Lists all revisions of a deployment. Revisions are returned in descending order of revision creation time.",
+                      "response": {
+                        "$ref": "ListApiDeploymentRevisionsResponse"
+                      },
+                      "parameters": {
+                        "filter": {
+                          "location": "query",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                          "type": "string"
+                        },
+                        "pageSize": {
+                          "location": "query",
+                          "format": "int32",
+                          "type": "integer",
+                          "description": "The maximum number of revisions to return per page."
+                        },
+                        "pageToken": {
+                          "description": "The page token, received from a previous ListApiDeploymentRevisions call. Provide this to retrieve the subsequent page.",
+                          "location": "query",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string",
+                          "location": "path",
+                          "description": "Required. The name of the deployment to list revisions for.",
+                          "required": true,
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:listRevisions",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "GET",
+                      "path": "v1/{+name}:listRevisions",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.listRevisions"
+                    },
+                    "testIamPermissions": {
+                      "request": {
+                        "$ref": "TestIamPermissionsRequest"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+resource}:testIamPermissions",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "resource": {
+                          "required": true,
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                        }
+                      },
+                      "response": {
+                        "$ref": "TestIamPermissionsResponse"
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:testIamPermissions",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.testIamPermissions",
+                      "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning."
+                    },
+                    "list": {
+                      "response": {
+                        "$ref": "ListApiDeploymentsResponse"
+                      },
+                      "parameters": {
+                        "pageToken": {
+                          "type": "string",
+                          "location": "query",
+                          "description": "A page token, received from a previous `ListApiDeployments` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiDeployments` must match the call that provided the page token."
+                        },
+                        "parent": {
+                          "required": true,
+                          "location": "path",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                          "description": "Required. The parent, which owns this collection of deployments. Format: `projects/*/locations/*/apis/*`"
+                        },
+                        "orderBy": {
+                          "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                          "location": "query",
+                          "type": "string"
+                        },
+                        "filter": {
+                          "location": "query",
+                          "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.",
+                          "type": "string"
+                        },
+                        "pageSize": {
+                          "description": "The maximum number of deployments to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                          "type": "integer",
+                          "location": "query",
+                          "format": "int32"
+                        }
+                      },
+                      "httpMethod": "GET",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments",
+                      "parameterOrder": [
+                        "parent"
+                      ],
+                      "description": "Returns matching deployments.",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.list",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "path": "v1/{+parent}/deployments"
+                    },
+                    "get": {
+                      "description": "Returns a specified deployment.",
+                      "httpMethod": "GET",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.get",
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}",
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "parameters": {
+                        "name": {
+                          "required": true,
+                          "description": "Required. The name of the deployment to retrieve. Format: `projects/*/locations/*/apis/*/deployments/*`",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "location": "path",
+                          "type": "string"
+                        }
+                      },
+                      "path": "v1/{+name}",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "deleteRevision": {
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:deleteRevision",
+                      "path": "v1/{+name}:deleteRevision",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.deleteRevision",
+                      "parameters": {
+                        "name": {
+                          "type": "string",
+                          "description": "Required. The name of the deployment revision to be deleted, with a revision ID explicitly included. Example: `projects/sample/locations/global/apis/petstore/deployments/prod@c7cfa2a8`",
+                          "required": true,
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "description": "Deletes a revision of a deployment.",
+                      "httpMethod": "DELETE",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      }
+                    },
+                    "getIamPolicy": {
+                      "parameters": {
+                        "options.requestedPolicyVersion": {
+                          "type": "integer",
+                          "format": "int32",
+                          "location": "query",
+                          "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                        },
+                        "resource": {
+                          "location": "path",
+                          "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "type": "string",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "required": true
+                        }
+                      },
+                      "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "path": "v1/{+resource}:getIamPolicy",
+                      "id": "apigeeregistry.projects.locations.apis.deployments.getIamPolicy",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:getIamPolicy",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ]
+                    },
+                    "rollback": {
+                      "parameterOrder": [
+                        "name"
+                      ],
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:rollback",
+                      "parameters": {
+                        "name": {
+                          "location": "path",
+                          "required": true,
+                          "description": "Required. The deployment being rolled back.",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$",
+                          "type": "string"
+                        }
+                      },
+                      "response": {
+                        "$ref": "ApiDeployment"
+                      },
+                      "description": "Sets the current revision to a specified prior revision. Note that this creates a new revision with a new revision ID.",
+                      "request": {
+                        "$ref": "RollbackApiDeploymentRequest"
+                      },
+                      "id": "apigeeregistry.projects.locations.apis.deployments.rollback",
+                      "path": "v1/{+name}:rollback",
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "httpMethod": "POST"
+                    },
+                    "setIamPolicy": {
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform"
+                      ],
+                      "id": "apigeeregistry.projects.locations.apis.deployments.setIamPolicy",
+                      "path": "v1/{+resource}:setIamPolicy",
+                      "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "resource"
+                      ],
+                      "parameters": {
+                        "resource": {
+                          "required": true,
+                          "type": "string",
+                          "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                          "location": "path",
+                          "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+/deployments/[^/]+$"
+                        }
+                      },
+                      "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}/deployments/{deploymentsId}:setIamPolicy",
+                      "response": {
+                        "$ref": "Policy"
+                      },
+                      "request": {
+                        "$ref": "SetIamPolicyRequest"
+                      }
+                    }
+                  }
+                }
+              },
+              "methods": {
+                "testIamPermissions": {
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:testIamPermissions",
+                  "id": "apigeeregistry.projects.locations.apis.testIamPermissions"
+                },
+                "list": {
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "path": "v1/{+parent}/apis",
+                  "response": {
+                    "$ref": "ListApisResponse"
+                  },
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "orderBy": {
+                      "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\"",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "description": "A page token, received from a previous `ListApis` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApis` must match the call that provided the page token.",
+                      "location": "query"
+                    },
+                    "parent": {
+                      "required": true,
+                      "location": "path",
+                      "description": "Required. The parent, which owns this collection of APIs. Format: `projects/*/locations/*`",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    },
+                    "pageSize": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "The maximum number of APIs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                      "location": "query"
+                    },
+                    "filter": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields."
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.apis.list",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis",
+                  "description": "Returns matching APIs."
+                },
+                "get": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}",
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.get",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "name": {
+                      "description": "Required. The name of the API to retrieve. Format: `projects/*/locations/*/apis/*`",
+                      "type": "string",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "required": true
+                    }
+                  },
+                  "description": "Returns a specified API.",
+                  "parameterOrder": [
+                    "name"
+                  ]
+                },
+                "delete": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Removes a specified API and all of the resources that it owns.",
+                  "httpMethod": "DELETE",
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "description": "Required. The name of the API to delete. Format: `projects/*/locations/*/apis/*`",
+                      "location": "path",
+                      "type": "string"
+                    },
+                    "force": {
+                      "description": "If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)",
+                      "type": "boolean",
+                      "location": "query"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.delete",
+                  "path": "v1/{+name}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}"
+                },
+                "getIamPolicy": {
+                  "id": "apigeeregistry.projects.locations.apis.getIamPolicy",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "type": "string",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    },
+                    "options.requestedPolicyVersion": {
+                      "format": "int32",
+                      "type": "integer",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query"
+                    }
+                  },
+                  "httpMethod": "GET",
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:getIamPolicy",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "response": {
+                    "$ref": "Policy"
+                  }
+                },
+                "setIamPolicy": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}:setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "parameters": {
+                    "resource": {
+                      "required": true,
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "type": "string"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.setIamPolicy",
+                  "parameterOrder": [
+                    "resource"
+                  ]
+                },
+                "patch": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis/{apisId}",
+                  "description": "Used to modify a specified API.",
+                  "path": "v1/{+name}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "PATCH",
+                  "parameters": {
+                    "updateMask": {
+                      "location": "query",
+                      "format": "google-fieldmask",
+                      "description": "The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If an asterisk \"*\" is specified, all fields are updated, including fields that are unspecified/default in the request.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Resource name.",
+                      "required": true,
+                      "location": "path",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/apis/[^/]+$"
+                    },
+                    "allowMissing": {
+                      "location": "query",
+                      "type": "boolean",
+                      "description": "If set to true, and the API is not found, a new API will be created. In this situation, `update_mask` is ignored."
+                    }
+                  },
+                  "request": {
+                    "$ref": "Api"
+                  },
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.patch"
+                },
+                "create": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "parent": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The parent, which owns this collection of APIs. Format: `projects/*/locations/*`"
+                    },
+                    "apiId": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "Required. The ID to use for the API, which will become the final component of the API's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID."
+                    }
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/apis",
+                  "request": {
+                    "$ref": "Api"
+                  },
+                  "response": {
+                    "$ref": "Api"
+                  },
+                  "id": "apigeeregistry.projects.locations.apis.create",
+                  "description": "Creates a specified API.",
+                  "httpMethod": "POST",
+                  "path": "v1/{+parent}/apis"
+                }
+              }
+            },
+            "instances": {
+              "methods": {
+                "setIamPolicy": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.instances.setIamPolicy",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "parameters": {
+                    "resource": {
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "required": true,
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    }
+                  },
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:setIamPolicy",
+                  "path": "v1/{+resource}:setIamPolicy"
+                },
+                "create": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances",
+                  "request": {
+                    "$ref": "Instance"
+                  },
+                  "path": "v1/{+parent}/instances",
+                  "description": "Provisions instance resources for the Registry.",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "id": "apigeeregistry.projects.locations.instances.create",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "required": true,
+                      "location": "path",
+                      "description": "Required. Parent resource of the Instance, of the form: `projects/*/locations/*`"
+                    },
+                    "instanceId": {
+                      "location": "query",
+                      "description": "Required. Identifier to assign to the Instance. Must be unique within scope of the parent resource.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "delete": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.instances.delete",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the Instance to delete. Format: `projects/*/locations/*/instances/*`."
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}",
+                  "path": "v1/{+name}",
+                  "httpMethod": "DELETE",
+                  "description": "Deletes the Registry instance."
+                },
+                "getIamPolicy": {
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    },
+                    "options.requestedPolicyVersion": {
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:getIamPolicy",
+                  "id": "apigeeregistry.projects.locations.instances.getIamPolicy",
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "resource"
+                  ]
+                },
+                "testIamPermissions": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "id": "apigeeregistry.projects.locations.instances.testIamPermissions",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}:testIamPermissions",
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "parameters": {
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$",
+                      "type": "string"
+                    }
+                  },
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "httpMethod": "POST",
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  }
+                },
+                "get": {
+                  "httpMethod": "GET",
+                  "id": "apigeeregistry.projects.locations.instances.get",
+                  "response": {
+                    "$ref": "Instance"
+                  },
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "type": "string",
+                      "description": "Required. The name of the Instance to retrieve. Format: `projects/*/locations/*/instances/*`.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/instances/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/instances/{instancesId}",
+                  "description": "Gets details of a single Instance.",
+                  "path": "v1/{+name}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "name"
+                  ]
+                }
+              }
+            },
+            "operations": {
+              "methods": {
+                "get": {
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "required": true,
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "description": "The name of the operation resource."
+                    }
+                  },
+                  "httpMethod": "GET",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "Operation"
+                  },
+                  "description": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.operations.get"
+                },
+                "list": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations",
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`. NOTE: the `name` binding allows API services to override the binding to use different resource name schemes, such as `users/*/operations`. To override the binding, API services can add a binding such as `\"/v1/{name=users/*}/operations\"` to their service configuration. For backwards compatibility, the default name includes the operations collection id, however overriding users must ensure the name binding is the parent resource, without the operations collection id.",
+                  "path": "v1/{+name}/operations",
+                  "response": {
+                    "$ref": "ListOperationsResponse"
+                  },
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "description": "The name of the operation's parent resource.",
+                      "required": true
+                    },
+                    "filter": {
+                      "description": "The standard list filter.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "pageSize": {
+                      "location": "query",
+                      "type": "integer",
+                      "description": "The standard list page size.",
+                      "format": "int32"
+                    },
+                    "pageToken": {
+                      "description": "The standard list page token.",
+                      "type": "string",
+                      "location": "query"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.operations.list"
+                },
+                "cancel": {
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}:cancel",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "location": "path",
+                      "description": "The name of the operation resource to be cancelled.",
+                      "type": "string"
+                    }
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "apigeeregistry.projects.locations.operations.cancel",
+                  "path": "v1/{+name}:cancel",
+                  "description": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`.",
+                  "request": {
+                    "$ref": "CancelOperationRequest"
+                  }
+                },
+                "delete": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "path": "v1/{+name}",
+                  "httpMethod": "DELETE",
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/operations/[^/]+$",
+                      "description": "The name of the operation resource to be deleted.",
+                      "location": "path",
+                      "required": true
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}",
+                  "description": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`.",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "id": "apigeeregistry.projects.locations.operations.delete"
+                }
+              }
+            },
+            "runtime": {
+              "methods": {
+                "setIamPolicy": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:setIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.",
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.setIamPolicy"
+                },
+                "getIamPolicy": {
+                  "parameters": {
+                    "options.requestedPolicyVersion": {
+                      "type": "integer",
+                      "location": "query",
+                      "format": "int32",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+                    },
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$",
+                      "location": "path"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.getIamPolicy",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set.",
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:getIamPolicy",
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "GET"
+                },
+                "testIamPermissions": {
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/runtime:testIamPermissions",
+                  "path": "v1/{+resource}:testIamPermissions",
+                  "parameters": {
+                    "resource": {
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/runtime$"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.runtime.testIamPermissions",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "httpMethod": "POST"
+                }
+              }
+            },
+            "artifacts": {
+              "methods": {
+                "delete": {
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+name}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Removes a specified artifact.",
+                  "parameters": {
+                    "name": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "required": true,
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the artifact to delete. Format: `{parent}/artifacts/*`"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "httpMethod": "DELETE",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "id": "apigeeregistry.projects.locations.artifacts.delete"
+                },
+                "getIamPolicy": {
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:getIamPolicy",
+                  "id": "apigeeregistry.projects.locations.artifacts.getIamPolicy",
+                  "httpMethod": "GET",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "path": "v1/{+resource}:getIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "type": "string",
+                      "description": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field."
+                    },
+                    "options.requestedPolicyVersion": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+                      "location": "query"
+                    }
+                  },
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Gets the access control policy for a resource. Returns an empty policy if the resource exists and does not have a policy set."
+                },
+                "list": {
+                  "description": "Returns matching artifacts.",
+                  "httpMethod": "GET",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts",
+                  "path": "v1/{+parent}/artifacts",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "parameters": {
+                    "orderBy": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "A comma-separated list of fields, e.g. \"foo,bar\" Fields can be sorted in descending order using the \"desc\" identifier, e.g. \"foo desc,bar\""
+                    },
+                    "pageSize": {
+                      "description": "The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.",
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer"
+                    },
+                    "parent": {
+                      "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    },
+                    "filter": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents."
+                    },
+                    "pageToken": {
+                      "description": "A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.",
+                      "type": "string",
+                      "location": "query"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.artifacts.list",
+                  "response": {
+                    "$ref": "ListArtifactsResponse"
+                  }
+                },
+                "replaceArtifact": {
+                  "path": "v1/{+name}",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "httpMethod": "PUT",
+                  "id": "apigeeregistry.projects.locations.artifacts.replaceArtifact",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "Artifact"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Used to replace a specified artifact.",
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "type": "string",
+                      "description": "Resource name."
+                    }
+                  }
+                },
+                "create": {
+                  "httpMethod": "POST",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "id": "apigeeregistry.projects.locations.artifacts.create",
+                  "parameters": {
+                    "artifactId": {
+                      "description": "Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /a-z-/. Following AIP-162, IDs must not have the form of a UUID.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "parent": {
+                      "type": "string",
+                      "description": "Required. The parent, which owns this collection of artifacts. Format: `{parent}`",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+$"
+                    }
+                  },
+                  "path": "v1/{+parent}/artifacts",
+                  "description": "Creates a specified artifact.",
+                  "request": {
+                    "$ref": "Artifact"
+                  }
+                },
+                "get": {
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "type": "string",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "description": "Required. The name of the artifact to retrieve. Format: `{parent}/artifacts/*`",
+                      "required": true
+                    }
+                  },
+                  "path": "v1/{+name}",
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "Artifact"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Returns a specified artifact.",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}",
+                  "id": "apigeeregistry.projects.locations.artifacts.get"
+                },
+                "setIamPolicy": {
+                  "response": {
+                    "$ref": "Policy"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.setIamPolicy",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:setIamPolicy",
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "required": true,
+                      "description": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "location": "path",
+                      "type": "string"
+                    }
+                  },
+                  "request": {
+                    "$ref": "SetIamPolicyRequest"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "httpMethod": "POST",
+                  "path": "v1/{+resource}:setIamPolicy",
+                  "description": "Sets the access control policy on the specified resource. Replaces any existing policy. Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors."
+                },
+                "getContents": {
+                  "httpMethod": "GET",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:getContents",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "HttpBody"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "description": "Returns the contents of a specified artifact. If artifacts are stored with GZip compression, the default behavior is to return the artifact uncompressed (the mime_type response field indicates the exact format returned).",
+                  "path": "v1/{+name}:getContents",
+                  "parameters": {
+                    "name": {
+                      "description": "Required. The name of the artifact whose contents should be retrieved. Format: `{parent}/artifacts/*`",
+                      "required": true,
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "location": "path",
+                      "type": "string"
+                    }
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.getContents"
+                },
+                "testIamPermissions": {
+                  "response": {
+                    "$ref": "TestIamPermissionsResponse"
+                  },
+                  "id": "apigeeregistry.projects.locations.artifacts.testIamPermissions",
+                  "parameters": {
+                    "resource": {
+                      "pattern": "^projects/[^/]+/locations/[^/]+/artifacts/[^/]+$",
+                      "location": "path",
+                      "description": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ],
+                  "request": {
+                    "$ref": "TestIamPermissionsRequest"
+                  },
+                  "httpMethod": "POST",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/artifacts/{artifactsId}:testIamPermissions",
+                  "parameterOrder": [
+                    "resource"
+                  ],
+                  "description": "Returns permissions that a caller has on the specified resource. If the resource does not exist, this will return an empty set of permissions, not a `NOT_FOUND` error. Note: This operation is designed to be used for building permission-aware UIs and command-line tools, not for authorization checking. This operation may \"fail open\" without warning.",
+                  "path": "v1/{+resource}:testIamPermissions"
+                }
+              }
+            }
+          },
+          "methods": {
+            "list": {
+              "response": {
+                "$ref": "ListLocationsResponse"
+              },
+              "description": "Lists information about the supported locations for this service.",
+              "httpMethod": "GET",
+              "parameters": {
+                "pageToken": {
+                  "description": "A page token received from the `next_page_token` field in the response. Send that page token to receive the subsequent page.",
+                  "location": "query",
+                  "type": "string"
+                },
+                "filter": {
+                  "location": "query",
+                  "description": "A filter to narrow down results to a preferred subset. The filtering language accepts strings like `\"displayName=tokyo\"`, and is documented in more detail in [AIP-160](https://google.aip.dev/160).",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "pattern": "^projects/[^/]+$",
+                  "description": "The resource that owns the locations collection, if applicable.",
+                  "required": true,
+                  "location": "path"
+                },
+                "pageSize": {
+                  "location": "query",
+                  "description": "The maximum number of results to return. If not set, the service selects a default.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "path": "v1/{+name}/locations",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1/projects/{projectsId}/locations",
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "apigeeregistry.projects.locations.list"
+            },
+            "get": {
+              "id": "apigeeregistry.projects.locations.get",
+              "flatPath": "v1/projects/{projectsId}/locations/{locationsId}",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Gets information about a location.",
+              "parameters": {
+                "name": {
+                  "description": "Resource name for the location.",
+                  "type": "string",
+                  "pattern": "^projects/[^/]+/locations/[^/]+$",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "path": "v1/{+name}",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "httpMethod": "GET",
+              "response": {
+                "$ref": "Location"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "revision": "20230127",
+  "fullyEncodeReservedExpansion": true,
+  "rootUrl": "https://apigeeregistry.googleapis.com/",
+  "title": "Apigee Registry API",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account."
+        }
+      }
+    }
+  },
+  "version": "v1",
+  "protocol": "rest",
+  "basePath": ""
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/discovery/info.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/discovery/info.yaml
@@ -1,0 +1,8 @@
+apiVersion: apigeeregistry/v1
+kind: Spec
+metadata:
+  name: discovery
+  parent: apis/apigeeregistry/versions/v1
+data:
+  filename: discovery.json
+  mimeType: application/x.discovery+gzip

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/info.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/info.yaml
@@ -1,0 +1,7 @@
+apiVersion: apigeeregistry/v1
+kind: Version
+metadata:
+  name: v1
+  parent: apis/apigeeregistry
+data:
+  displayName: v1

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/openapi/info.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/openapi/info.yaml
@@ -1,0 +1,8 @@
+apiVersion: apigeeregistry/v1
+kind: Spec
+metadata:
+  name: openapi
+  parent: apis/apigeeregistry/versions/v1
+data:
+  filename: openapi.yaml
+  mimeType: application/x.openapi+gzip;version=3.0.3

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/openapi/openapi.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/openapi/openapi.yaml
@@ -1,0 +1,2161 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generated with protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi
+
+openapi: 3.0.3
+info:
+    title: Registry API
+    description: The Registry service allows teams to manage descriptions of APIs.
+    version: 0.0.1
+servers:
+    - url: https://apigeeregistry.googleapis.com
+paths:
+    /v1/projects/{project}/locations/{location}/apis:
+        get:
+            tags:
+                - Registry
+            description: ListApis returns matching APIs.
+            operationId: Registry_ListApis
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of APIs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApis` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApis` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApisResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApi creates a specified API.
+            operationId: Registry_CreateApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiId
+                  in: query
+                  description: Required. The ID to use for the api, which will become the final component of the api's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Api'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Api'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}:
+        get:
+            tags:
+                - Registry
+            description: GetApi returns a specified API.
+            operationId: Registry_GetApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Api'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApi removes a specified API and all of the resources that it
+                 owns.
+            operationId: Registry_DeleteApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApi can be used to modify a specified API.
+            operationId: Registry_UpdateApi
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the api is not found, a new api_versions will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Api'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Api'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments:
+        get:
+            tags:
+                - Registry
+            description: ListApiDeployments returns matching deployments.
+            operationId: Registry_ListApiDeployments
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of deployments to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApiDeployments` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiDeployments` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiDeploymentsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApiDeployment creates a specified deployment.
+            operationId: Registry_CreateApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiDeploymentId
+                  in: query
+                  description: Required. The ID to use for the deployment, which will become the final component of the deployment's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiDeployment'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:
+        get:
+            tags:
+                - Registry
+            description: GetApiDeployment returns a specified deployment.
+            operationId: Registry_GetApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApiDeployment removes a specified deployment, all revisions, and all
+                 child resources (e.g. artifacts).
+            operationId: Registry_DeleteApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApiDeployment can be used to modify a specified deployment.
+            operationId: Registry_UpdateApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the deployment is not found, a new deployment will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiDeployment'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:deleteRevision:
+        delete:
+            tags:
+                - Registry
+            description: DeleteApiDeploymentRevision deletes a revision of a deployment.
+            operationId: Registry_DeleteApiDeploymentRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:listRevisions:
+        get:
+            tags:
+                - Registry
+            description: |-
+                ListApiDeploymentRevisions lists all revisions of a deployment.
+                 Revisions are returned in descending order of revision creation time.
+            operationId: Registry_ListApiDeploymentRevisions
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of revisions to return per page.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: The page token, received from a previous ListApiDeploymentRevisions call. Provide this to retrieve the subsequent page.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiDeploymentRevisionsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:rollback:
+        post:
+            tags:
+                - Registry
+            description: |-
+                RollbackApiDeployment sets the current revision to a specified prior
+                 revision. Note that this creates a new revision with a new revision ID.
+            operationId: Registry_RollbackApiDeployment
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RollbackApiDeploymentRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}:tagRevision:
+        post:
+            tags:
+                - Registry
+            description: |-
+                TagApiDeploymentRevision adds a tag to a specified revision of a
+                 deployment.
+            operationId: Registry_TagApiDeploymentRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: deployment
+                  in: path
+                  description: The deployment id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TagApiDeploymentRevisionRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiDeployment'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions:
+        get:
+            tags:
+                - Registry
+            description: ListApiVersions returns matching versions.
+            operationId: Registry_ListApiVersions
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of versions to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApiVersions` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiVersions` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiVersionsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApiVersion creates a specified version.
+            operationId: Registry_CreateApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiVersionId
+                  in: query
+                  description: Required. The ID to use for the version, which will become the final component of the version's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiVersion'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiVersion'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}:
+        get:
+            tags:
+                - Registry
+            description: GetApiVersion returns a specified version.
+            operationId: Registry_GetApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiVersion'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApiVersion removes a specified version and all of the resources that
+                 it owns.
+            operationId: Registry_DeleteApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApiVersion can be used to modify a specified version.
+            operationId: Registry_UpdateApiVersion
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the version is not found, a new version will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiVersion'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiVersion'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs:
+        get:
+            tags:
+                - Registry
+            description: ListApiSpecs returns matching specs.
+            operationId: Registry_ListApiSpecs
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of specs to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListApiSpecs` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListApiSpecs` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiSpecsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateApiSpec creates a specified spec.
+            operationId: Registry_CreateApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: apiSpecId
+                  in: query
+                  description: Required. The ID to use for the spec, which will become the final component of the spec's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiSpec'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:
+        get:
+            tags:
+                - Registry
+            description: GetApiSpec returns a specified spec.
+            operationId: Registry_GetApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: |-
+                DeleteApiSpec removes a specified spec, all revisions, and all child
+                 resources (e.g. artifacts).
+            operationId: Registry_DeleteApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+                - name: force
+                  in: query
+                  description: If set to true, any child resources will also be deleted. (Otherwise, the request will only work if there are no child resources.)
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        patch:
+            tags:
+                - Registry
+            description: UpdateApiSpec can be used to modify a specified spec.
+            operationId: Registry_UpdateApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+                - name: updateMask
+                  in: query
+                  description: The list of fields to be updated. If omitted, all fields are updated that are set in the request message (fields set to default values are ignored). If a "*" is specified, all fields are updated, including fields that are unspecified/default in the request.
+                  schema:
+                    type: string
+                    format: field-mask
+                - name: allowMissing
+                  in: query
+                  description: If set to true, and the spec is not found, a new spec will be created. In this situation, `update_mask` is ignored.
+                  schema:
+                    type: boolean
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ApiSpec'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:deleteRevision:
+        delete:
+            tags:
+                - Registry
+            description: DeleteApiSpecRevision deletes a revision of a spec.
+            operationId: Registry_DeleteApiSpecRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:getContents:
+        get:
+            tags:
+                - Registry
+            description: |-
+                GetApiSpecContents returns the contents of a specified spec.
+                 If specs are stored with GZip compression, the default behavior
+                 is to return the spec uncompressed (the mime_type response field
+                 indicates the exact format returned).
+            operationId: Registry_GetApiSpecContents
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*': {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:listRevisions:
+        get:
+            tags:
+                - Registry
+            description: |-
+                ListApiSpecRevisions lists all revisions of a spec.
+                 Revisions are returned in descending order of revision creation time.
+            operationId: Registry_ListApiSpecRevisions
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of revisions to return per page.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: The page token, received from a previous ListApiSpecRevisions call. Provide this to retrieve the subsequent page.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListApiSpecRevisionsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:rollback:
+        post:
+            tags:
+                - Registry
+            description: |-
+                RollbackApiSpec sets the current revision to a specified prior revision.
+                 Note that this creates a new revision with a new revision ID.
+            operationId: Registry_RollbackApiSpec
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RollbackApiSpecRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}:tagRevision:
+        post:
+            tags:
+                - Registry
+            description: TagApiSpecRevision adds a tag to a specified revision of a spec.
+            operationId: Registry_TagApiSpecRevision
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: api
+                  in: path
+                  description: The api id.
+                  required: true
+                  schema:
+                    type: string
+                - name: version
+                  in: path
+                  description: The version id.
+                  required: true
+                  schema:
+                    type: string
+                - name: spec
+                  in: path
+                  description: The spec id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TagApiSpecRevisionRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ApiSpec'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/artifacts:
+        get:
+            tags:
+                - Registry
+            description: ListArtifacts returns matching artifacts.
+            operationId: Registry_ListArtifacts
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: pageSize
+                  in: query
+                  description: The maximum number of artifacts to return. The service may return fewer than this value. If unspecified, at most 50 values will be returned. The maximum is 1000; values above 1000 will be coerced to 1000.
+                  schema:
+                    type: integer
+                    format: int32
+                - name: pageToken
+                  in: query
+                  description: A page token, received from a previous `ListArtifacts` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListArtifacts` must match the call that provided the page token.
+                  schema:
+                    type: string
+                - name: filter
+                  in: query
+                  description: An expression that can be used to filter the list. Filters use the Common Expression Language and can refer to all message fields except contents.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ListArtifactsResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        post:
+            tags:
+                - Registry
+            description: CreateArtifact creates a specified artifact.
+            operationId: Registry_CreateArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifactId
+                  in: query
+                  description: Required. The ID to use for the artifact, which will become the final component of the artifact's resource name. This value should be 4-63 characters, and valid characters are /[a-z][0-9]-/. Following AIP-162, IDs must not have the form of a UUID.
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Artifact'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Artifact'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/artifacts/{artifact}:
+        get:
+            tags:
+                - Registry
+            description: GetArtifact returns a specified artifact.
+            operationId: Registry_GetArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Artifact'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        put:
+            tags:
+                - Registry
+            description: ReplaceArtifact can be used to replace a specified artifact.
+            operationId: Registry_ReplaceArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Artifact'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Artifact'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Registry
+            description: DeleteArtifact removes a specified artifact.
+            operationId: Registry_DeleteArtifact
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content: {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/projects/{project}/locations/{location}/artifacts/{artifact}:getContents:
+        get:
+            tags:
+                - Registry
+            description: |-
+                GetArtifactContents returns the contents of a specified artifact.
+                 If artifacts are stored with GZip compression, the default behavior
+                 is to return the artifact uncompressed (the mime_type response field
+                 indicates the exact format returned).
+            operationId: Registry_GetArtifactContents
+            parameters:
+                - name: project
+                  in: path
+                  description: The project id.
+                  required: true
+                  schema:
+                    type: string
+                - name: location
+                  in: path
+                  description: The location id.
+                  required: true
+                  schema:
+                    type: string
+                - name: artifact
+                  in: path
+                  description: The artifact id.
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        '*/*': {}
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+components:
+    schemas:
+        Api:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                displayName:
+                    type: string
+                    description: Human-meaningful name.
+                description:
+                    type: string
+                    description: A detailed description.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp.
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Last update timestamp.
+                    format: date-time
+                availability:
+                    type: string
+                    description: 'A user-definable description of the availability of this service. Format: free-form, but we expect single words that describe availability, e.g. "NONE", "TESTING", "PREVIEW", "GENERAL", "DEPRECATED", "SHUTDOWN".'
+                recommendedVersion:
+                    type: string
+                    description: 'The recommended version of the API. Format: apis/{api}/versions/{version}'
+                recommendedDeployment:
+                    type: string
+                    description: 'The recommended deployment of the API. Format: apis/{api}/deployments/{deployment}'
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "apigeeregistry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An Api is a top-level description of an API. Apis are produced by producers and are commitments to provide services.
+        ApiDeployment:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                displayName:
+                    type: string
+                    description: Human-meaningful name.
+                description:
+                    type: string
+                    description: A detailed description.
+                revisionId:
+                    readOnly: true
+                    type: string
+                    description: Output only. Immutable. The revision ID of the deployment. A new revision is committed whenever the deployment contents are changed. The format is an 8-character hexadecimal string.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp; when the deployment resource was created.
+                    format: date-time
+                revisionCreateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Revision creation timestamp; when the represented revision was created.
+                    format: date-time
+                revisionUpdateTime:
+                    readOnly: true
+                    type: string
+                    description: 'Output only. Last update timestamp: when the represented revision was last modified.'
+                    format: date-time
+                apiSpecRevision:
+                    type: string
+                    description: 'The full resource name (including revision id) of the spec of the API being served by the deployment. Changes to this value will update the revision. Format: apis/{api}/deployments/{deployment}'
+                endpointUri:
+                    type: string
+                    description: The address where the deployment is serving. Changes to this value will update the revision.
+                externalChannelUri:
+                    type: string
+                    description: The address of the external channel of the API (e.g. the Developer Portal). Changes to this value will not affect the revision.
+                intendedAudience:
+                    type: string
+                    description: Text briefly identifying the intended audience of the API. Changes to this value will not affect the revision.
+                accessGuidance:
+                    type: string
+                    description: Text briefly describing how to access the endpoint. Changes to this value will not affect the revision.
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "registry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An ApiDeployment describes a service running at particular address that provides a particular version of an API. ApiDeployments have revisions which correspond to different configurations of a single deployment in time. Revision identifiers should be updated whenever the served API spec or endpoint address changes.
+        ApiSpec:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                filename:
+                    type: string
+                    description: A possibly-hierarchical name used to refer to the spec from other specs.
+                description:
+                    type: string
+                    description: A detailed description.
+                revisionId:
+                    readOnly: true
+                    type: string
+                    description: Output only. Immutable. The revision ID of the spec. A new revision is committed whenever the spec contents are changed. The format is an 8-character hexadecimal string.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp; when the spec resource was created.
+                    format: date-time
+                revisionCreateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Revision creation timestamp; when the represented revision was created.
+                    format: date-time
+                revisionUpdateTime:
+                    readOnly: true
+                    type: string
+                    description: 'Output only. Last update timestamp: when the represented revision was last modified.'
+                    format: date-time
+                mimeType:
+                    type: string
+                    description: A style (format) descriptor for this spec that is specified as a Media Type (https://en.wikipedia.org/wiki/Media_type). Possible values include "application/vnd.apigee.proto", "application/vnd.apigee.openapi", and "application/vnd.apigee.graphql", with possible suffixes representing compression types. These hypothetical names are defined in the vendor tree defined in RFC6838 (https://tools.ietf.org/html/rfc6838) and are not final. Content types can specify compression. Currently only GZip compression is supported (indicated with "+gzip").
+                sizeBytes:
+                    readOnly: true
+                    type: integer
+                    description: Output only. The size of the spec file in bytes. If the spec is gzipped, this is the size of the uncompressed spec.
+                    format: int32
+                hash:
+                    readOnly: true
+                    type: string
+                    description: Output only. A SHA-256 hash of the spec's contents. If the spec is gzipped, this is the hash of the uncompressed spec.
+                sourceUri:
+                    type: string
+                    description: The original source URI of the spec (if one exists). This is an external location that can be used for reference purposes but which may not be authoritative since this external resource may change after the spec is retrieved.
+                contents:
+                    writeOnly: true
+                    type: string
+                    description: Input only. The contents of the spec. Provided by API callers when specs are created or updated. To access the contents of a spec, use GetApiSpecContents.
+                    format: bytes
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "apigeeregistry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An ApiSpec describes a version of an API in a structured way. ApiSpecs provide formal descriptions that consumers can use to use a version. ApiSpec resources are intended to be fully-resolved descriptions of an ApiVersion. When specs consist of multiple files, these should be bundled together (e.g. in a zip archive) and stored as a unit. Multiple specs can exist to provide representations in different API description formats. Synchronization of these representations would be provided by tooling and background services.
+        ApiVersion:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                displayName:
+                    type: string
+                    description: Human-meaningful name.
+                description:
+                    type: string
+                    description: A detailed description.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp.
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Last update timestamp.
+                    format: date-time
+                state:
+                    type: string
+                    description: 'A user-definable description of the lifecycle phase of this API version. Format: free-form, but we expect single words that describe API maturity, e.g. "CONCEPT", "DESIGN", "DEVELOPMENT", "STAGING", "PRODUCTION", "DEPRECATED", "RETIRED".'
+                labels:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Labels attach identifying metadata to resources. Identifying metadata can be used to filter list operations. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. No more than 64 user labels can be associated with one resource (System labels are excluded). See https://goo.gl/xmQnxf for more information and examples of labels. System reserved label keys are prefixed with "apigeeregistry.googleapis.com/" and cannot be changed.
+                annotations:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Annotations attach non-identifying metadata to resources. Annotation keys and values are less restricted than those of labels, but should be generally used for small values of broad interest. Larger, topic- specific metadata should be stored in Artifacts.
+            description: An ApiVersion describes a particular version of an API. ApiVersions are what consumers actually use.
+        Artifact:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Resource name.
+                createTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Creation timestamp.
+                    format: date-time
+                updateTime:
+                    readOnly: true
+                    type: string
+                    description: Output only. Last update timestamp.
+                    format: date-time
+                mimeType:
+                    type: string
+                    description: A content type specifier for the artifact. Content type specifiers are Media Types (https://en.wikipedia.org/wiki/Media_type) with a possible "schema" parameter that specifies a schema for the stored information. Content types can specify compression. Currently only GZip compression is supported (indicated with "+gzip").
+                sizeBytes:
+                    readOnly: true
+                    type: integer
+                    description: Output only. The size of the artifact in bytes. If the artifact is gzipped, this is the size of the uncompressed artifact.
+                    format: int32
+                hash:
+                    readOnly: true
+                    type: string
+                    description: Output only. A SHA-256 hash of the artifact's contents. If the artifact is gzipped, this is the hash of the uncompressed artifact.
+                contents:
+                    writeOnly: true
+                    type: string
+                    description: Input only. The contents of the artifact. Provided by API callers when artifacts are created or replaced. To access the contents of an artifact, use GetArtifactContents.
+                    format: bytes
+            description: Artifacts of resources. Artifacts are unique (single-value) per resource and are used to store metadata that is too large or numerous to be stored directly on the resource. Since artifacts are stored separately from parent resources, they should generally be used for metadata that is needed infrequently, i.e. not for display in primary views of the resource but perhaps displayed or downloaded upon request. The ListArtifacts method allows artifacts to be quickly enumerated and checked for presence without downloading their (potentially-large) contents.
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        ListApiDeploymentRevisionsResponse:
+            type: object
+            properties:
+                apiDeployments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiDeployment'
+                    description: The revisions of the deployment.
+                nextPageToken:
+                    type: string
+                    description: A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiDeploymentRevisionsResponse.
+        ListApiDeploymentsResponse:
+            type: object
+            properties:
+                apiDeployments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiDeployment'
+                    description: The deployments from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiDeployments.
+        ListApiSpecRevisionsResponse:
+            type: object
+            properties:
+                apiSpecs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiSpec'
+                    description: The revisions of the spec.
+                nextPageToken:
+                    type: string
+                    description: A token that can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiSpecRevisionsResponse.
+        ListApiSpecsResponse:
+            type: object
+            properties:
+                apiSpecs:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiSpec'
+                    description: The specs from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiSpecs.
+        ListApiVersionsResponse:
+            type: object
+            properties:
+                apiVersions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ApiVersion'
+                    description: The versions from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApiVersions.
+        ListApisResponse:
+            type: object
+            properties:
+                apis:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Api'
+                    description: The APIs from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListApis.
+        ListArtifactsResponse:
+            type: object
+            properties:
+                artifacts:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Artifact'
+                    description: The artifacts from the specified publisher.
+                nextPageToken:
+                    type: string
+                    description: A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.
+            description: Response message for ListArtifacts.
+        RollbackApiDeploymentRequest:
+            required:
+                - name
+                - revisionId
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The deployment being rolled back.
+                revisionId:
+                    type: string
+                    description: 'Required. The revision ID to roll back to. It must be a revision of the same deployment.   Example: c7cfa2a8'
+            description: Request message for RollbackApiDeployment.
+        RollbackApiSpecRequest:
+            required:
+                - name
+                - revisionId
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The spec being rolled back.
+                revisionId:
+                    type: string
+                    description: 'Required. The revision ID to roll back to. It must be a revision of the same spec.   Example: c7cfa2a8'
+            description: Request message for RollbackApiSpec.
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        TagApiDeploymentRevisionRequest:
+            required:
+                - name
+                - tag
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The name of the deployment to be tagged, including the revision ID.
+                tag:
+                    type: string
+                    description: Required. The tag to apply. The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+            description: Request message for TagApiDeploymentRevision.
+        TagApiSpecRevisionRequest:
+            required:
+                - name
+                - tag
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: Required. The name of the spec to be tagged, including the revision ID.
+                tag:
+                    type: string
+                    description: Required. The tag to apply. The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+            description: Request message for TagApiSpecRevision.
+tags:
+    - name: Registry

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/annotations.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/annotations.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/api/http.proto";
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "AnnotationsProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See `HttpRule`.
+  HttpRule http = 72295728;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/client.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/client.proto
@@ -1,0 +1,349 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/api/launch_stage.proto";
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "ClientProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // A definition of a client library method signature.
+  //
+  // In client libraries, each proto RPC corresponds to one or more methods
+  // which the end user is able to call, and calls the underlying RPC.
+  // Normally, this method receives a single argument (a struct or instance
+  // corresponding to the RPC request object). Defining this field will
+  // add one or more overloads providing flattened or simpler method signatures
+  // in some languages.
+  //
+  // The fields on the method signature are provided as a comma-separated
+  // string.
+  //
+  // For example, the proto RPC and annotation:
+  //
+  //   rpc CreateSubscription(CreateSubscriptionRequest)
+  //       returns (Subscription) {
+  //     option (google.api.method_signature) = "name,topic";
+  //   }
+  //
+  // Would add the following Java overload (in addition to the method accepting
+  // the request object):
+  //
+  //   public final Subscription createSubscription(String name, String topic)
+  //
+  // The following backwards-compatibility guidelines apply:
+  //
+  //   * Adding this annotation to an unannotated method is backwards
+  //     compatible.
+  //   * Adding this annotation to a method which already has existing
+  //     method signature annotations is backwards compatible if and only if
+  //     the new method signature annotation is last in the sequence.
+  //   * Modifying or removing an existing method signature annotation is
+  //     a breaking change.
+  //   * Re-ordering existing method signature annotations is a breaking
+  //     change.
+  repeated string method_signature = 1051;
+}
+
+extend google.protobuf.ServiceOptions {
+  // The hostname for this service.
+  // This should be specified with no prefix or protocol.
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.default_host) = "foo.googleapi.com";
+  //     ...
+  //   }
+  string default_host = 1049;
+
+  // OAuth scopes needed for the client.
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.oauth_scopes) = \
+  //       "https://www.googleapis.com/auth/cloud-platform";
+  //     ...
+  //   }
+  //
+  // If there is more than one scope, use a comma-separated string:
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.oauth_scopes) = \
+  //       "https://www.googleapis.com/auth/cloud-platform,"
+  //       "https://www.googleapis.com/auth/monitoring";
+  //     ...
+  //   }
+  string oauth_scopes = 1050;
+}
+
+// Required information for every language.
+message CommonLanguageSettings {
+  // Link to automatically generated reference documentation.  Example:
+  // https://cloud.google.com/nodejs/docs/reference/asset/latest
+  string reference_docs_uri = 1 [deprecated = true];
+
+  // The destination where API teams want this client library to be published.
+  repeated ClientLibraryDestination destinations = 2;
+}
+
+// Details about how and where to publish client libraries.
+message ClientLibrarySettings {
+  // Version of the API to apply these settings to.
+  string version = 1;
+
+  // Launch stage of this version of the API.
+  LaunchStage launch_stage = 2;
+
+  // When using transport=rest, the client request will encode enums as
+  // numbers rather than strings.
+  bool rest_numeric_enums = 3;
+
+  // Settings for legacy Java features, supported in the Service YAML.
+  JavaSettings java_settings = 21;
+
+  // Settings for C++ client libraries.
+  CppSettings cpp_settings = 22;
+
+  // Settings for PHP client libraries.
+  PhpSettings php_settings = 23;
+
+  // Settings for Python client libraries.
+  PythonSettings python_settings = 24;
+
+  // Settings for Node client libraries.
+  NodeSettings node_settings = 25;
+
+  // Settings for .NET client libraries.
+  DotnetSettings dotnet_settings = 26;
+
+  // Settings for Ruby client libraries.
+  RubySettings ruby_settings = 27;
+
+  // Settings for Go client libraries.
+  GoSettings go_settings = 28;
+}
+
+// This message configures the settings for publishing [Google Cloud Client
+// libraries](https://cloud.google.com/apis/docs/cloud-client-libraries)
+// generated from the service config.
+message Publishing {
+  // A list of API method settings, e.g. the behavior for methods that use the
+  // long-running operation pattern.
+  repeated MethodSettings method_settings = 2;
+
+  // Link to a place that API users can report issues.  Example:
+  // https://issuetracker.google.com/issues/new?component=190865&template=1161103
+  string new_issue_uri = 101;
+
+  // Link to product home page.  Example:
+  // https://cloud.google.com/asset-inventory/docs/overview
+  string documentation_uri = 102;
+
+  // Used as a tracking tag when collecting data about the APIs developer
+  // relations artifacts like docs, packages delivered to package managers,
+  // etc.  Example: "speech".
+  string api_short_name = 103;
+
+  // GitHub label to apply to issues and pull requests opened for this API.
+  string github_label = 104;
+
+  // GitHub teams to be added to CODEOWNERS in the directory in GitHub
+  // containing source code for the client libraries for this API.
+  repeated string codeowner_github_teams = 105;
+
+  // A prefix used in sample code when demarking regions to be included in
+  // documentation.
+  string doc_tag_prefix = 106;
+
+  // For whom the client library is being published.
+  ClientLibraryOrganization organization = 107;
+
+  // Client library settings.  If the same version string appears multiple
+  // times in this list, then the last one wins.  Settings from earlier
+  // settings with the same version string are discarded.
+  repeated ClientLibrarySettings library_settings = 109;
+}
+
+// Settings for Java client libraries.
+message JavaSettings {
+  // The package name to use in Java. Clobbers the java_package option
+  // set in the protobuf. This should be used **only** by APIs
+  // who have already set the language_settings.java.package_name" field
+  // in gapic.yaml. API teams should use the protobuf java_package option
+  // where possible.
+  //
+  // Example of a YAML configuration::
+  //
+  //  publishing:
+  //    java_settings:
+  //      library_package: com.google.cloud.pubsub.v1
+  string library_package = 1;
+
+  // Configure the Java class name to use instead of the service's for its
+  // corresponding generated GAPIC client. Keys are fully-qualified
+  // service names as they appear in the protobuf (including the full
+  // the language_settings.java.interface_names" field in gapic.yaml. API
+  // teams should otherwise use the service name as it appears in the
+  // protobuf.
+  //
+  // Example of a YAML configuration::
+  //
+  //  publishing:
+  //    java_settings:
+  //      service_class_names:
+  //        - google.pubsub.v1.Publisher: TopicAdmin
+  //        - google.pubsub.v1.Subscriber: SubscriptionAdmin
+  map<string, string> service_class_names = 2;
+
+  // Some settings.
+  CommonLanguageSettings common = 3;
+}
+
+// Settings for C++ client libraries.
+message CppSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Php client libraries.
+message PhpSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Python client libraries.
+message PythonSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Node client libraries.
+message NodeSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Dotnet client libraries.
+message DotnetSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Ruby client libraries.
+message RubySettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Go client libraries.
+message GoSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Describes the generator configuration for a method.
+message MethodSettings {
+  // Describes settings to use when generating API methods that use the
+  // long-running operation pattern.
+  // All default values below are from those used in the client library
+  // generators (e.g.
+  // [Java](https://github.com/googleapis/gapic-generator-java/blob/04c2faa191a9b5a10b92392fe8482279c4404803/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java)).
+  message LongRunning {
+    // Initial delay after which the first poll request will be made.
+    // Default value: 5 seconds.
+    google.protobuf.Duration initial_poll_delay = 1;
+
+    // Multiplier to gradually increase delay between subsequent polls until it
+    // reaches max_poll_delay.
+    // Default value: 1.5.
+    float poll_delay_multiplier = 2;
+
+    // Maximum time between two subsequent poll requests.
+    // Default value: 45 seconds.
+    google.protobuf.Duration max_poll_delay = 3;
+
+    // Total polling timeout.
+    // Default value: 5 minutes.
+    google.protobuf.Duration total_poll_timeout = 4;
+  }
+
+  // The fully qualified name of the method, for which the options below apply.
+  // This is used to find the method to apply the options.
+  string selector = 1;
+
+  // Describes settings to use for long-running operations when generating
+  // API methods for RPCs. Complements RPCs that use the annotations in
+  // google/longrunning/operations.proto.
+  //
+  // Example of a YAML configuration::
+  //
+  //  publishing:
+  //    method_behavior:
+  //      - selector: CreateAdDomain
+  //        long_running:
+  //          initial_poll_delay:
+  //            seconds: 60 # 1 minute
+  //          poll_delay_multiplier: 1.5
+  //          max_poll_delay:
+  //            seconds: 360 # 6 minutes
+  //          total_poll_timeout:
+  //             seconds: 54000 # 90 minutes
+  LongRunning long_running = 2;
+}
+
+// The organization for which the client libraries are being published.
+// Affects the url where generated docs are published, etc.
+enum ClientLibraryOrganization {
+  // Not useful.
+  CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED = 0;
+
+  // Google Cloud Platform Org.
+  CLOUD = 1;
+
+  // Ads (Advertising) Org.
+  ADS = 2;
+
+  // Photos Org.
+  PHOTOS = 3;
+
+  // Street View Org.
+  STREET_VIEW = 4;
+}
+
+// To where should client libraries be published?
+enum ClientLibraryDestination {
+  // Client libraries will neither be generated nor published to package
+  // managers.
+  CLIENT_LIBRARY_DESTINATION_UNSPECIFIED = 0;
+
+  // Generate the client library in a repo under github.com/googleapis,
+  // but don't publish it to package managers.
+  GITHUB = 10;
+
+  // Publish the library to package managers like nuget.org and npmjs.com.
+  PACKAGE_MANAGER = 20;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/field_behavior.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/field_behavior.proto
@@ -1,0 +1,90 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "FieldBehaviorProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.FieldOptions {
+  // A designation of a specific field behavior (required, output only, etc.)
+  // in protobuf messages.
+  //
+  // Examples:
+  //
+  //   string name = 1 [(google.api.field_behavior) = REQUIRED];
+  //   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  //   google.protobuf.Duration ttl = 1
+  //     [(google.api.field_behavior) = INPUT_ONLY];
+  //   google.protobuf.Timestamp expire_time = 1
+  //     [(google.api.field_behavior) = OUTPUT_ONLY,
+  //      (google.api.field_behavior) = IMMUTABLE];
+  repeated google.api.FieldBehavior field_behavior = 1052;
+}
+
+// An indicator of the behavior of a given field (for example, that a field
+// is required in requests, or given as output but ignored as input).
+// This **does not** change the behavior in protocol buffers itself; it only
+// denotes the behavior and may affect how API tooling handles the field.
+//
+// Note: This enum **may** receive new values in the future.
+enum FieldBehavior {
+  // Conventional default for enums. Do not use this.
+  FIELD_BEHAVIOR_UNSPECIFIED = 0;
+
+  // Specifically denotes a field as optional.
+  // While all fields in protocol buffers are optional, this may be specified
+  // for emphasis if appropriate.
+  OPTIONAL = 1;
+
+  // Denotes a field as required.
+  // This indicates that the field **must** be provided as part of the request,
+  // and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
+  REQUIRED = 2;
+
+  // Denotes a field as output only.
+  // This indicates that the field is provided in responses, but including the
+  // field in a request does nothing (the server *must* ignore it and
+  // *must not* throw an error as a result of the field's presence).
+  OUTPUT_ONLY = 3;
+
+  // Denotes a field as input only.
+  // This indicates that the field is provided in requests, and the
+  // corresponding field is not included in output.
+  INPUT_ONLY = 4;
+
+  // Denotes a field as immutable.
+  // This indicates that the field may be set once in a request to create a
+  // resource, but may not be changed thereafter.
+  IMMUTABLE = 5;
+
+  // Denotes that a (repeated) field is an unordered list.
+  // This indicates that the service may provide the elements of the list
+  // in any arbitrary  order, rather than the order the user originally
+  // provided. Additionally, the list's order may or may not be stable.
+  UNORDERED_LIST = 6;
+
+  // Denotes that this field returns a non-empty default value if not set.
+  // This indicates that if the user provides the empty value in a request,
+  // a non-empty value will be returned. The user will not be aware of what
+  // non-empty value to expect.
+  NON_EMPTY_DEFAULT = 7;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/http.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/http.proto
@@ -1,0 +1,375 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "HttpProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// Defines the HTTP configuration for an API service. It contains a list of
+// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+message Http {
+  // A list of HTTP configuration rules that apply to individual API methods.
+  //
+  // **NOTE:** All service configuration rules follow "last one wins" order.
+  repeated HttpRule rules = 1;
+
+  // When set to true, URL path parameters will be fully URI-decoded except in
+  // cases of single segment matches in reserved expansion, where "%2F" will be
+  // left encoded.
+  //
+  // The default behavior is to not decode RFC 6570 reserved characters in multi
+  // segment matches.
+  bool fully_decode_reserved_expansion = 2;
+}
+
+// # gRPC Transcoding
+//
+// gRPC Transcoding is a feature for mapping between a gRPC method and one or
+// more HTTP REST endpoints. It allows developers to build a single API service
+// that supports both gRPC APIs and REST APIs. Many systems, including [Google
+// APIs](https://github.com/googleapis/googleapis),
+// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+// and use it for large scale production services.
+//
+// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
+// how different portions of the gRPC request message are mapped to the URL
+// path, URL query parameters, and HTTP request body. It also controls how the
+// gRPC response message is mapped to the HTTP response body. `HttpRule` is
+// typically specified as an `google.api.http` annotation on the gRPC method.
+//
+// Each mapping specifies a URL path template and an HTTP method. The path
+// template may refer to one or more fields in the gRPC request message, as long
+// as each field is a non-repeated field with a primitive (non-message) type.
+// The path template controls how fields of the request message are mapped to
+// the URL path.
+//
+// Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get: "/v1/{name=messages/*}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string name = 1; // Mapped to URL path.
+//     }
+//     message Message {
+//       string text = 1; // The resource content.
+//     }
+//
+// This enables an HTTP REST to gRPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+//
+// Any fields in the request message which are not bound by the path template
+// automatically become HTTP query parameters if there is no HTTP request body.
+// For example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get:"/v1/messages/{message_id}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       message SubMessage {
+//         string subfield = 1;
+//       }
+//       string message_id = 1; // Mapped to URL path.
+//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+//     }
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
+// "foo"))`
+//
+// Note that fields which are mapped to URL query parameters must have a
+// primitive type or a repeated primitive type or a non-repeated message type.
+// In the case of a repeated type, the parameter can be repeated in the URL
+// as `...?param=A&param=B`. In the case of a message type, each field of the
+// message is mapped to a separate parameter, such as
+// `...?foo.a=A&foo.b=B&foo.c=C`.
+//
+// For HTTP methods that allow a request body, the `body` field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+//     service Messaging {
+//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "message"
+//         };
+//       }
+//     }
+//     message UpdateMessageRequest {
+//       string message_id = 1; // mapped to the URL
+//       Message message = 2;   // mapped to the body
+//     }
+//
+// The following HTTP JSON to RPC mapping is enabled, where the
+// representation of the JSON in the request body is determined by
+// protos JSON encoding:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define that
+// every field not bound by the path template should be mapped to the
+// request body.  This enables the following alternative definition of
+// the update method:
+//
+//     service Messaging {
+//       rpc UpdateMessage(Message) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "*"
+//         };
+//       }
+//     }
+//     message Message {
+//       string message_id = 1;
+//       string text = 2;
+//     }
+//
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice when
+// defining REST APIs. The common usage of `*` is in custom methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by using
+// the `additional_bindings` option. Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           get: "/v1/messages/{message_id}"
+//           additional_bindings {
+//             get: "/v1/users/{user_id}/messages/{message_id}"
+//           }
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string message_id = 1;
+//       string user_id = 2;
+//     }
+//
+// This enables the following two alternative HTTP JSON to RPC mappings:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
+// "123456")`
+//
+// ## Rules for HTTP mapping
+//
+// 1. Leaf request fields (recursive expansion nested messages in the request
+//    message) are classified into three categories:
+//    - Fields referred by the path template. They are passed via the URL path.
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//      request body.
+//    - All other fields are passed via the URL query parameters, and the
+//      parameter name is the field path in the request message. A repeated
+//      field can be represented as multiple query parameters under the same
+//      name.
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//     are passed via URL path and HTTP request body.
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//     fields are passed via URL path and URL query parameters.
+//
+// ### Path template syntax
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single URL path segment. The syntax `**` matches
+// zero or more URL path segments, which must be the last part of the URL path
+// except the `Verb`.
+//
+// The syntax `Variable` matches part of the URL path as specified by its
+// template. A variable template must not contain other variables. If a variable
+// matches a single path segment, its template may be omitted, e.g. `{var}`
+// is equivalent to `{var=*}`.
+//
+// The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
+// contains any reserved character, such characters should be percent-encoded
+// before the matching.
+//
+// If a variable contains exactly one path segment, such as `"{var}"` or
+// `"{var=*}"`, when such a variable is expanded into a URL path on the client
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+// server side does the reverse decoding. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{var}`.
+//
+// If a variable contains multiple path segments, such as `"{var=foo/*}"`
+// or `"{var=**}"`, when such a variable is expanded into a URL path on the
+// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+// The server side does the reverse decoding, except "%2F" and "%2f" are left
+// unchanged. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{+var}`.
+//
+// ## Using gRPC API Service Configuration
+//
+// gRPC API Service Configuration (service config) is a configuration language
+// for configuring a gRPC service to become a user-facing product. The
+// service config is simply the YAML representation of the `google.api.Service`
+// proto message.
+//
+// As an alternative to annotating your proto file, you can configure gRPC
+// transcoding in your service config YAML files. You do this by specifying a
+// `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
+// effect as the proto annotation. This can be particularly useful if you
+// have a proto that is reused in multiple services. Note that any transcoding
+// specified in the service config will override any matching transcoding
+// configuration in the proto.
+//
+// Example:
+//
+//     http:
+//       rules:
+//         # Selects a gRPC method and applies HttpRule to it.
+//         - selector: example.v1.Messaging.GetMessage
+//           get: /v1/messages/{message_id}/{sub.subfield}
+//
+// ## Special notes
+//
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
+// proto to JSON conversion must follow the [proto3
+// specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+//
+// While the single segment variable follows the semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+// Expansion, the multi segment variable **does not** follow RFC 6570 Section
+// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
+// does not expand special characters like `?` and `#`, which would lead
+// to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
+// for multi segment variables.
+//
+// The path variables **must not** refer to any repeated or mapped field,
+// because client libraries are not capable of handling such variable expansion.
+//
+// The path variables **must not** capture the leading "/" character. The reason
+// is that the most common use case "{var}" does not capture the leading "/"
+// character. For consistency, all path variables must share the same behavior.
+//
+// Repeated message fields must not be mapped to URL query parameters, because
+// no client library can support such complicated mapping.
+//
+// If an API needs to use a JSON array for request or response body, it can map
+// the request or response body to a repeated field. However, some gRPC
+// Transcoding implementations may not support this feature.
+message HttpRule {
+  // Selects a method to which this rule applies.
+  //
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  string selector = 1;
+
+  // Determines the URL pattern is matched by this rules. This pattern can be
+  // used with any of the {get|put|post|delete|patch} methods. A custom method
+  // can be defined using the 'custom' field.
+  oneof pattern {
+    // Maps to HTTP GET. Used for listing and getting information about
+    // resources.
+    string get = 2;
+
+    // Maps to HTTP PUT. Used for replacing a resource.
+    string put = 3;
+
+    // Maps to HTTP POST. Used for creating a resource or performing an action.
+    string post = 4;
+
+    // Maps to HTTP DELETE. Used for deleting a resource.
+    string delete = 5;
+
+    // Maps to HTTP PATCH. Used for updating a resource.
+    string patch = 6;
+
+    // The custom pattern is used for specifying an HTTP method that is not
+    // included in the `pattern` field, such as HEAD, or "*" to leave the
+    // HTTP method unspecified for this rule. The wild-card rule is useful
+    // for services that provide content to Web (HTML) clients.
+    CustomHttpPattern custom = 8;
+  }
+
+  // The name of the request field whose value is mapped to the HTTP request
+  // body, or `*` for mapping all request fields not captured by the path
+  // pattern to the HTTP body, or omitted for not having any HTTP request body.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  string body = 7;
+
+  // Optional. The name of the response field whose value is mapped to the HTTP
+  // response body. When omitted, the entire response message will be used
+  // as the HTTP response body.
+  //
+  // NOTE: The referred field must be present at the top-level of the response
+  // message type.
+  string response_body = 12;
+
+  // Additional HTTP bindings for the selector. Nested bindings must
+  // not contain an `additional_bindings` field themselves (that is,
+  // the nesting may only be one level deep).
+  repeated HttpRule additional_bindings = 11;
+}
+
+// A custom pattern is used for defining custom HTTP verb.
+message CustomHttpPattern {
+  // The name of this custom HTTP verb.
+  string kind = 1;
+
+  // The path matched by this custom verb.
+  string path = 2;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/httpbody.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/httpbody.proto
@@ -1,0 +1,81 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/any.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/api/httpbody;httpbody";
+option java_multiple_files = true;
+option java_outer_classname = "HttpBodyProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// Message that represents an arbitrary HTTP body. It should only be used for
+// payload formats that can't be represented as JSON, such as raw binary or
+// an HTML page.
+//
+//
+// This message can be used both in streaming and non-streaming API methods in
+// the request as well as the response.
+//
+// It can be used as a top-level request field, which is convenient if one
+// wants to extract parameters from either the URL or HTTP template into the
+// request fields and also want access to the raw HTTP body.
+//
+// Example:
+//
+//     message GetResourceRequest {
+//       // A unique request id.
+//       string request_id = 1;
+//
+//       // The raw HTTP body is bound to this field.
+//       google.api.HttpBody http_body = 2;
+//
+//     }
+//
+//     service ResourceService {
+//       rpc GetResource(GetResourceRequest)
+//         returns (google.api.HttpBody);
+//       rpc UpdateResource(google.api.HttpBody)
+//         returns (google.protobuf.Empty);
+//
+//     }
+//
+// Example with streaming methods:
+//
+//     service CaldavService {
+//       rpc GetCalendar(stream google.api.HttpBody)
+//         returns (stream google.api.HttpBody);
+//       rpc UpdateCalendar(stream google.api.HttpBody)
+//         returns (stream google.api.HttpBody);
+//
+//     }
+//
+// Use of this type only changes how the request and response bodies are
+// handled, all other features will continue to work unchanged.
+message HttpBody {
+  // The HTTP Content-Type header value specifying the content type of the body.
+  string content_type = 1;
+
+  // The HTTP request/response body as raw binary.
+  bytes data = 2;
+
+  // Application specific response metadata. Must be set in the first response
+  // for streaming APIs.
+  repeated google.protobuf.Any extensions = 3;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/launch_stage.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/launch_stage.proto
@@ -1,0 +1,72 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option go_package = "google.golang.org/genproto/googleapis/api;api";
+option java_multiple_files = true;
+option java_outer_classname = "LaunchStageProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// The launch stage as defined by [Google Cloud Platform
+// Launch Stages](https://cloud.google.com/terms/launch-stages).
+enum LaunchStage {
+  // Do not use this default value.
+  LAUNCH_STAGE_UNSPECIFIED = 0;
+
+  // The feature is not yet implemented. Users can not use it.
+  UNIMPLEMENTED = 6;
+
+  // Prelaunch features are hidden from users and are only visible internally.
+  PRELAUNCH = 7;
+
+  // Early Access features are limited to a closed group of testers. To use
+  // these features, you must sign up in advance and sign a Trusted Tester
+  // agreement (which includes confidentiality provisions). These features may
+  // be unstable, changed in backward-incompatible ways, and are not
+  // guaranteed to be released.
+  EARLY_ACCESS = 1;
+
+  // Alpha is a limited availability test for releases before they are cleared
+  // for widespread use. By Alpha, all significant design issues are resolved
+  // and we are in the process of verifying functionality. Alpha customers
+  // need to apply for access, agree to applicable terms, and have their
+  // projects allowlisted. Alpha releases don't have to be feature complete,
+  // no SLAs are provided, and there are no technical support obligations, but
+  // they will be far enough along that customers can actually use them in
+  // test environments or for limited-use tests -- just like they would in
+  // normal production cases.
+  ALPHA = 2;
+
+  // Beta is the point at which we are ready to open a release for any
+  // customer to use. There are no SLA or technical support obligations in a
+  // Beta release. Products will be complete from a feature perspective, but
+  // may have some open outstanding issues. Beta releases are suitable for
+  // limited production use cases.
+  BETA = 3;
+
+  // GA features are open to all developers and are considered stable and
+  // fully qualified for production use.
+  GA = 4;
+
+  // Deprecated features are scheduled to be shut down and removed. For more
+  // information, see the "Deprecation Policy" section of our [Terms of
+  // Service](https://cloud.google.com/terms/)
+  // and the [Google Cloud Platform Subject to the Deprecation
+  // Policy](https://cloud.google.com/terms/deprecation) documentation.
+  DEPRECATED = 5;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/resource.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/api/resource.proto
@@ -1,0 +1,238 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "ResourceProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.FieldOptions {
+  // An annotation that describes a resource reference, see
+  // [ResourceReference][].
+  google.api.ResourceReference resource_reference = 1055;
+}
+
+extend google.protobuf.FileOptions {
+  // An annotation that describes a resource definition without a corresponding
+  // message; see [ResourceDescriptor][].
+  repeated google.api.ResourceDescriptor resource_definition = 1053;
+}
+
+extend google.protobuf.MessageOptions {
+  // An annotation that describes a resource definition, see
+  // [ResourceDescriptor][].
+  google.api.ResourceDescriptor resource = 1053;
+}
+
+// A simple descriptor of a resource type.
+//
+// ResourceDescriptor annotates a resource message (either by means of a
+// protobuf annotation or use in the service config), and associates the
+// resource's schema, the resource type, and the pattern of the resource name.
+//
+// Example:
+//
+//     message Topic {
+//       // Indicates this message defines a resource schema.
+//       // Declares the resource type in the format of {service}/{kind}.
+//       // For Kubernetes resources, the format is {api group}/{kind}.
+//       option (google.api.resource) = {
+//         type: "pubsub.googleapis.com/Topic"
+//         pattern: "projects/{project}/topics/{topic}"
+//       };
+//     }
+//
+// The ResourceDescriptor Yaml config will look like:
+//
+//     resources:
+//     - type: "pubsub.googleapis.com/Topic"
+//       pattern: "projects/{project}/topics/{topic}"
+//
+// Sometimes, resources have multiple patterns, typically because they can
+// live under multiple parents.
+//
+// Example:
+//
+//     message LogEntry {
+//       option (google.api.resource) = {
+//         type: "logging.googleapis.com/LogEntry"
+//         pattern: "projects/{project}/logs/{log}"
+//         pattern: "folders/{folder}/logs/{log}"
+//         pattern: "organizations/{organization}/logs/{log}"
+//         pattern: "billingAccounts/{billing_account}/logs/{log}"
+//       };
+//     }
+//
+// The ResourceDescriptor Yaml config will look like:
+//
+//     resources:
+//     - type: 'logging.googleapis.com/LogEntry'
+//       pattern: "projects/{project}/logs/{log}"
+//       pattern: "folders/{folder}/logs/{log}"
+//       pattern: "organizations/{organization}/logs/{log}"
+//       pattern: "billingAccounts/{billing_account}/logs/{log}"
+message ResourceDescriptor {
+  // A description of the historical or future-looking state of the
+  // resource pattern.
+  enum History {
+    // The "unset" value.
+    HISTORY_UNSPECIFIED = 0;
+
+    // The resource originally had one pattern and launched as such, and
+    // additional patterns were added later.
+    ORIGINALLY_SINGLE_PATTERN = 1;
+
+    // The resource has one pattern, but the API owner expects to add more
+    // later. (This is the inverse of ORIGINALLY_SINGLE_PATTERN, and prevents
+    // that from being necessary once there are multiple patterns.)
+    FUTURE_MULTI_PATTERN = 2;
+  }
+
+  // A flag representing a specific style that a resource claims to conform to.
+  enum Style {
+    // The unspecified value. Do not use.
+    STYLE_UNSPECIFIED = 0;
+
+    // This resource is intended to be "declarative-friendly".
+    //
+    // Declarative-friendly resources must be more strictly consistent, and
+    // setting this to true communicates to tools that this resource should
+    // adhere to declarative-friendly expectations.
+    //
+    // Note: This is used by the API linter (linter.aip.dev) to enable
+    // additional checks.
+    DECLARATIVE_FRIENDLY = 1;
+  }
+
+  // The resource type. It must be in the format of
+  // {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+  // singular and must not include version numbers.
+  //
+  // Example: `storage.googleapis.com/Bucket`
+  //
+  // The value of the resource_type_kind must follow the regular expression
+  // /[A-Za-z][a-zA-Z0-9]+/. It should start with an upper case character and
+  // should use PascalCase (UpperCamelCase). The maximum number of
+  // characters allowed for the `resource_type_kind` is 100.
+  string type = 1;
+
+  // Optional. The relative resource name pattern associated with this resource
+  // type. The DNS prefix of the full resource name shouldn't be specified here.
+  //
+  // The path pattern must follow the syntax, which aligns with HTTP binding
+  // syntax:
+  //
+  //     Template = Segment { "/" Segment } ;
+  //     Segment = LITERAL | Variable ;
+  //     Variable = "{" LITERAL "}" ;
+  //
+  // Examples:
+  //
+  //     - "projects/{project}/topics/{topic}"
+  //     - "projects/{project}/knowledgeBases/{knowledge_base}"
+  //
+  // The components in braces correspond to the IDs for each resource in the
+  // hierarchy. It is expected that, if multiple patterns are provided,
+  // the same component name (e.g. "project") refers to IDs of the same
+  // type of resource.
+  repeated string pattern = 2;
+
+  // Optional. The field on the resource that designates the resource name
+  // field. If omitted, this is assumed to be "name".
+  string name_field = 3;
+
+  // Optional. The historical or future-looking state of the resource pattern.
+  //
+  // Example:
+  //
+  //     // The InspectTemplate message originally only supported resource
+  //     // names with organization, and project was added later.
+  //     message InspectTemplate {
+  //       option (google.api.resource) = {
+  //         type: "dlp.googleapis.com/InspectTemplate"
+  //         pattern:
+  //         "organizations/{organization}/inspectTemplates/{inspect_template}"
+  //         pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+  //         history: ORIGINALLY_SINGLE_PATTERN
+  //       };
+  //     }
+  History history = 4;
+
+  // The plural name used in the resource name and permission names, such as
+  // 'projects' for the resource name of 'projects/{project}' and the permission
+  // name of 'cloudresourcemanager.googleapis.com/projects.get'. It is the same
+  // concept of the `plural` field in k8s CRD spec
+  // https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+  //
+  // Note: The plural form is required even for singleton resources. See
+  // https://aip.dev/156
+  string plural = 5;
+
+  // The same concept of the `singular` field in k8s CRD spec
+  // https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+  // Such as "project" for the `resourcemanager.googleapis.com/Project` type.
+  string singular = 6;
+
+  // Style flag(s) for this resource.
+  // These indicate that a resource is expected to conform to a given
+  // style. See the specific style flags for additional information.
+  repeated Style style = 10;
+}
+
+// Defines a proto annotation that describes a string field that refers to
+// an API resource.
+message ResourceReference {
+  // The resource type that the annotated field references.
+  //
+  // Example:
+  //
+  //     message Subscription {
+  //       string topic = 2 [(google.api.resource_reference) = {
+  //         type: "pubsub.googleapis.com/Topic"
+  //       }];
+  //     }
+  //
+  // Occasionally, a field may reference an arbitrary resource. In this case,
+  // APIs use the special value * in their resource reference.
+  //
+  // Example:
+  //
+  //     message GetIamPolicyRequest {
+  //       string resource = 2 [(google.api.resource_reference) = {
+  //         type: "*"
+  //       }];
+  //     }
+  string type = 1;
+
+  // The resource type of a child collection that the annotated field
+  // references. This is useful for annotating the `parent` field that
+  // doesn't have a fixed resource type.
+  //
+  // Example:
+  //
+  //     message ListLogEntriesRequest {
+  //       string parent = 1 [(google.api.resource_reference) = {
+  //         child_type: "logging.googleapis.com/LogEntry"
+  //       };
+  //     }
+  string child_type = 2;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/apigeeregistry_v1.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/apigeeregistry_v1.yaml
@@ -1,0 +1,159 @@
+type: google.api.Service
+config_version: 3
+name: apigeeregistry.googleapis.com
+title: Apigee Registry API
+
+apis:
+- name: google.cloud.apigeeregistry.v1.Provisioning
+- name: google.cloud.apigeeregistry.v1.Registry
+- name: google.cloud.location.Locations
+- name: google.iam.v1.IAMPolicy
+- name: google.longrunning.Operations
+
+types:
+- name: google.cloud.apigeeregistry.v1.OperationMetadata
+
+documentation:
+  rules:
+  - selector: google.cloud.location.Locations.GetLocation
+    description: Gets information about a location.
+
+  - selector: google.cloud.location.Locations.ListLocations
+    description: Lists information about the supported locations for this service.
+
+  - selector: google.iam.v1.IAMPolicy.GetIamPolicy
+    description: |-
+      Gets the access control policy for a resource. Returns an empty policy
+      if the resource exists and does not have a policy set.
+
+  - selector: google.iam.v1.IAMPolicy.SetIamPolicy
+    description: |-
+      Sets the access control policy on the specified resource. Replaces
+      any existing policy.
+
+      Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
+      errors.
+
+  - selector: google.iam.v1.IAMPolicy.TestIamPermissions
+    description: |-
+      Returns permissions that a caller has on the specified resource. If the
+      resource does not exist, this will return an empty set of
+      permissions, not a `NOT_FOUND` error.
+
+      Note: This operation is designed to be used for building
+      permission-aware UIs and command-line tools, not for authorization
+      checking. This operation may "fail open" without warning.
+
+backend:
+  rules:
+  - selector: 'google.cloud.apigeeregistry.v1.Provisioning.*'
+    deadline: 60.0
+  - selector: 'google.cloud.apigeeregistry.v1.Registry.*'
+    deadline: 60.0
+  - selector: google.cloud.location.Locations.GetLocation
+    deadline: 60.0
+  - selector: google.cloud.location.Locations.ListLocations
+    deadline: 60.0
+  - selector: 'google.iam.v1.IAMPolicy.*'
+    deadline: 60.0
+  - selector: 'google.longrunning.Operations.*'
+    deadline: 60.0
+
+http:
+  rules:
+  - selector: google.cloud.location.Locations.GetLocation
+    get: '/v1/{name=projects/*/locations/*}'
+  - selector: google.cloud.location.Locations.ListLocations
+    get: '/v1/{name=projects/*}/locations'
+  - selector: google.iam.v1.IAMPolicy.GetIamPolicy
+    get: '/v1/{resource=projects/*/locations/*/apis/*}:getIamPolicy'
+    additional_bindings:
+    - get: '/v1/{resource=projects/*/locations/*/apis/*/deployments/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/apis/*/versions/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/specs/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/artifacts/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/apis/*/artifacts/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/artifacts/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/instances/*}:getIamPolicy'
+    - get: '/v1/{resource=projects/*/locations/*/runtime}:getIamPolicy'
+  - selector: google.iam.v1.IAMPolicy.SetIamPolicy
+    post: '/v1/{resource=projects/*/locations/*/apis/*}:setIamPolicy'
+    body: '*'
+    additional_bindings:
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/deployments/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/specs/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/artifacts/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/artifacts/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/artifacts/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/instances/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/runtime}:setIamPolicy'
+      body: '*'
+  - selector: google.iam.v1.IAMPolicy.TestIamPermissions
+    post: '/v1/{resource=projects/*/locations/*/apis/*}:testIamPermissions'
+    body: '*'
+    additional_bindings:
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/deployments/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/specs/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/artifacts/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/artifacts/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/artifacts/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/instances/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1/{resource=projects/*/locations/*/runtime}:testIamPermissions'
+      body: '*'
+  - selector: google.longrunning.Operations.CancelOperation
+    post: '/v1/{name=projects/*/locations/*/operations/*}:cancel'
+    body: '*'
+  - selector: google.longrunning.Operations.DeleteOperation
+    delete: '/v1/{name=projects/*/locations/*/operations/*}'
+  - selector: google.longrunning.Operations.GetOperation
+    get: '/v1/{name=projects/*/locations/*/operations/*}'
+  - selector: google.longrunning.Operations.ListOperations
+    get: '/v1/{name=projects/*/locations/*}/operations'
+
+authentication:
+  rules:
+  - selector: 'google.cloud.apigeeregistry.v1.Provisioning.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: 'google.cloud.apigeeregistry.v1.Registry.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: google.cloud.location.Locations.GetLocation
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: google.cloud.location.Locations.ListLocations
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: 'google.iam.v1.IAMPolicy.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform
+  - selector: 'google.longrunning.Operations.*'
+    oauth:
+      canonical_scopes: |-
+        https://www.googleapis.com/auth/cloud-platform

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/provisioning_service.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/provisioning_service.proto
@@ -1,0 +1,205 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.apigeeregistry.v1;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/longrunning/operations.proto";
+import "google/protobuf/timestamp.proto";
+
+option csharp_namespace = "Google.Cloud.ApigeeRegistry.V1";
+option go_package = "cloud.google.com/go/apigeeregistry/apiv1/apigeeregistrypb;apigeeregistrypb";
+option java_multiple_files = true;
+option java_outer_classname = "ProvisioningServiceProto";
+option java_package = "com.google.cloud.apigeeregistry.v1";
+option php_namespace = "Google\\Cloud\\ApigeeRegistry\\V1";
+option ruby_package = "Google::Cloud::ApigeeRegistry::V1";
+
+// The service that is used for managing the data plane provisioning of the
+// Registry.
+service Provisioning {
+  option (google.api.default_host) = "apigeeregistry.googleapis.com";
+  option (google.api.oauth_scopes) = "https://www.googleapis.com/auth/cloud-platform";
+
+  // Provisions instance resources for the Registry.
+  rpc CreateInstance(CreateInstanceRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/locations/*}/instances"
+      body: "instance"
+    };
+    option (google.api.method_signature) = "parent,instance,instance_id";
+    option (google.longrunning.operation_info) = {
+      response_type: "Instance"
+      metadata_type: "OperationMetadata"
+    };
+  }
+
+  // Deletes the Registry instance.
+  rpc DeleteInstance(DeleteInstanceRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/instances/*}"
+    };
+    option (google.api.method_signature) = "name";
+    option (google.longrunning.operation_info) = {
+      response_type: "google.protobuf.Empty"
+      metadata_type: "OperationMetadata"
+    };
+  }
+
+  // Gets details of a single Instance.
+  rpc GetInstance(GetInstanceRequest) returns (Instance) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/instances/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+}
+
+// Request message for CreateInstance.
+message CreateInstanceRequest {
+  // Required. Parent resource of the Instance, of the form: `projects/*/locations/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "locations.googleapis.com/Location"
+    }
+  ];
+
+  // Required. Identifier to assign to the Instance. Must be unique within scope of the
+  // parent resource.
+  string instance_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The Instance.
+  Instance instance = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for DeleteInstance.
+message DeleteInstanceRequest {
+  // Required. The name of the Instance to delete.
+  // Format: `projects/*/locations/*/instances/*`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Instance"
+    }
+  ];
+}
+
+// Request message for GetInstance.
+message GetInstanceRequest {
+  // Required. The name of the Instance to retrieve.
+  // Format: `projects/*/locations/*/instances/*`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Instance"
+    }
+  ];
+}
+
+// Represents the metadata of the long-running operation.
+message OperationMetadata {
+  // The time the operation was created.
+  google.protobuf.Timestamp create_time = 1;
+
+  // The time the operation finished running.
+  google.protobuf.Timestamp end_time = 2;
+
+  // Server-defined resource path for the target of the operation.
+  string target = 3;
+
+  // Name of the verb executed by the operation.
+  string verb = 4;
+
+  // Human-readable status of the operation, if any.
+  string status_message = 5;
+
+  // Identifies whether the user has requested cancellation
+  // of the operation. Operations that have successfully been cancelled
+  // have [Operation.error][] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+  // corresponding to `Code.CANCELLED`.
+  bool cancellation_requested = 6;
+
+  // API version used to start the operation.
+  string api_version = 7;
+}
+
+// An Instance represents the instance resources of the Registry.
+// Currently, only one instance is allowed for each project.
+message Instance {
+  option (google.api.resource) = {
+    type: "apigeeregistry.googleapis.com/Instance"
+    pattern: "projects/{project}/locations/{location}/instances/{instance}"
+  };
+
+  // State of the Instance.
+  enum State {
+    // The default value. This value is used if the state is omitted.
+    STATE_UNSPECIFIED = 0;
+
+    // The Instance has not been initialized or has been deleted.
+    INACTIVE = 1;
+
+    // The Instance is being created.
+    CREATING = 2;
+
+    // The Instance has been created and is ready for use.
+    ACTIVE = 3;
+
+    // The Instance is being updated.
+    UPDATING = 4;
+
+    // The Instance is being deleted.
+    DELETING = 5;
+
+    // The Instance encountered an error during a state change.
+    FAILED = 6;
+  }
+
+  // Available configurations to provision an Instance.
+  message Config {
+    // Output only. The GCP location where the Instance resides.
+    string location = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+    // Required. The Customer Managed Encryption Key (CMEK) used for data encryption.
+    // The CMEK name should follow the format of
+    // `projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+)`,
+    // where the `location` must match InstanceConfig.location.
+    string cmek_key_name = 2 [(google.api.field_behavior) = REQUIRED];
+  }
+
+  // Format: `projects/*/locations/*/instance`.
+  // Currently only `locations/global` is supported.
+  string name = 1;
+
+  // Output only. Creation timestamp.
+  google.protobuf.Timestamp create_time = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Last update timestamp.
+  google.protobuf.Timestamp update_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The current state of the Instance.
+  State state = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Extra information of Instance.State if the state is `FAILED`.
+  string state_message = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Required. Config of the Instance.
+  Config config = 6 [(google.api.field_behavior) = REQUIRED];
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/registry_models.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/registry_models.proto
@@ -1,0 +1,364 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.apigeeregistry.v1;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+option csharp_namespace = "Google.Cloud.ApigeeRegistry.V1";
+option go_package = "cloud.google.com/go/apigeeregistry/apiv1/apigeeregistrypb;apigeeregistrypb";
+option java_multiple_files = true;
+option java_outer_classname = "RegistryModelsProto";
+option java_package = "com.google.cloud.apigeeregistry.v1";
+option php_namespace = "Google\\Cloud\\ApigeeRegistry\\V1";
+option ruby_package = "Google::Cloud::ApigeeRegistry::V1";
+
+// A top-level description of an API.
+// Produced by producers and are commitments to provide services.
+message Api {
+  option (google.api.resource) = {
+    type: "apigeeregistry.googleapis.com/Api"
+    pattern: "projects/{project}/locations/{location}/apis/{api}"
+  };
+
+  // Resource name.
+  string name = 1;
+
+  // Human-meaningful name.
+  string display_name = 2;
+
+  // A detailed description.
+  string description = 3;
+
+  // Output only. Creation timestamp.
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Last update timestamp.
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // A user-definable description of the availability of this service.
+  // Format: free-form, but we expect single words that describe availability,
+  // e.g., "NONE", "TESTING", "PREVIEW", "GENERAL", "DEPRECATED", "SHUTDOWN".
+  string availability = 6;
+
+  // The recommended version of the API.
+  // Format: `apis/{api}/versions/{version}`
+  string recommended_version = 7 [(google.api.resource_reference) = {
+                                    type: "apigeeregistry.googleapis.com/ApiVersion"
+                                  }];
+
+  // The recommended deployment of the API.
+  // Format: `apis/{api}/deployments/{deployment}`
+  string recommended_deployment = 8 [(google.api.resource_reference) = {
+                                       type: "apigeeregistry.googleapis.com/ApiDeployment"
+                                     }];
+
+  // Labels attach identifying metadata to resources. Identifying metadata can
+  // be used to filter list operations.
+  //
+  // Label keys and values can be no longer than 64 characters
+  // (Unicode codepoints), can only contain lowercase letters, numeric
+  // characters, underscores, and dashes. International characters are allowed.
+  // No more than 64 user labels can be associated with one resource (System
+  // labels are excluded).
+  //
+  // See https://goo.gl/xmQnxf for more information and examples of labels.
+  // System reserved label keys are prefixed with
+  // `apigeeregistry.googleapis.com/` and cannot be changed.
+  map<string, string> labels = 9;
+
+  // Annotations attach non-identifying metadata to resources.
+  //
+  // Annotation keys and values are less restricted than those of labels, but
+  // should be generally used for small values of broad interest. Larger, topic-
+  // specific metadata should be stored in Artifacts.
+  map<string, string> annotations = 10;
+}
+
+// Describes a particular version of an API.
+// ApiVersions are what consumers actually use.
+message ApiVersion {
+  option (google.api.resource) = {
+    type: "apigeeregistry.googleapis.com/ApiVersion"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/versions/{version}"
+  };
+
+  // Resource name.
+  string name = 1;
+
+  // Human-meaningful name.
+  string display_name = 2;
+
+  // A detailed description.
+  string description = 3;
+
+  // Output only. Creation timestamp.
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Last update timestamp.
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // A user-definable description of the lifecycle phase of this API version.
+  // Format: free-form, but we expect single words that describe API maturity,
+  // e.g., "CONCEPT", "DESIGN", "DEVELOPMENT", "STAGING", "PRODUCTION",
+  // "DEPRECATED", "RETIRED".
+  string state = 6;
+
+  // Labels attach identifying metadata to resources. Identifying metadata can
+  // be used to filter list operations.
+  //
+  // Label keys and values can be no longer than 64 characters
+  // (Unicode codepoints), can only contain lowercase letters, numeric
+  // characters, underscores and dashes. International characters are allowed.
+  // No more than 64 user labels can be associated with one resource (System
+  // labels are excluded).
+  //
+  // See https://goo.gl/xmQnxf for more information and examples of labels.
+  // System reserved label keys are prefixed with
+  // `apigeeregistry.googleapis.com/` and cannot be changed.
+  map<string, string> labels = 7;
+
+  // Annotations attach non-identifying metadata to resources.
+  //
+  // Annotation keys and values are less restricted than those of labels, but
+  // should be generally used for small values of broad interest. Larger, topic-
+  // specific metadata should be stored in Artifacts.
+  map<string, string> annotations = 8;
+}
+
+// Describes a version of an API in a structured way.
+// ApiSpecs provide formal descriptions that consumers can use to use a version.
+// ApiSpec resources are intended to be fully-resolved descriptions of an
+// ApiVersion. When specs consist of multiple files, these should be bundled
+// together (e.g., in a zip archive) and stored as a unit. Multiple specs can
+// exist to provide representations in different API description formats.
+// Synchronization of these representations would be provided by tooling and
+// background services.
+message ApiSpec {
+  option (google.api.resource) = {
+    type: "apigeeregistry.googleapis.com/ApiSpec"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}"
+  };
+
+  // Resource name.
+  string name = 1;
+
+  // A possibly-hierarchical name used to refer to the spec from other specs.
+  string filename = 2;
+
+  // A detailed description.
+  string description = 3;
+
+  // Output only. Immutable. The revision ID of the spec.
+  // A new revision is committed whenever the spec contents are changed.
+  // The format is an 8-character hexadecimal string.
+  string revision_id = 4 [
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
+
+  // Output only. Creation timestamp; when the spec resource was created.
+  google.protobuf.Timestamp create_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Revision creation timestamp; when the represented revision was created.
+  google.protobuf.Timestamp revision_create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Last update timestamp: when the represented revision was last modified.
+  google.protobuf.Timestamp revision_update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // A style (format) descriptor for this spec that is specified as a Media Type
+  // (https://en.wikipedia.org/wiki/Media_type). Possible values include
+  // `application/vnd.apigee.proto`, `application/vnd.apigee.openapi`, and
+  // `application/vnd.apigee.graphql`, with possible suffixes representing
+  // compression types. These hypothetical names are defined in the vendor tree
+  // defined in RFC6838 (https://tools.ietf.org/html/rfc6838) and are not final.
+  // Content types can specify compression. Currently only GZip compression is
+  // supported (indicated with "+gzip").
+  string mime_type = 8;
+
+  // Output only. The size of the spec file in bytes. If the spec is gzipped, this is the
+  // size of the uncompressed spec.
+  int32 size_bytes = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. A SHA-256 hash of the spec's contents. If the spec is gzipped, this is
+  // the hash of the uncompressed spec.
+  string hash = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The original source URI of the spec (if one exists).
+  // This is an external location that can be used for reference purposes
+  // but which may not be authoritative since this external resource may
+  // change after the spec is retrieved.
+  string source_uri = 11;
+
+  // Input only. The contents of the spec.
+  // Provided by API callers when specs are created or updated.
+  // To access the contents of a spec, use GetApiSpecContents.
+  bytes contents = 12 [(google.api.field_behavior) = INPUT_ONLY];
+
+  // Labels attach identifying metadata to resources. Identifying metadata can
+  // be used to filter list operations.
+  //
+  // Label keys and values can be no longer than 64 characters
+  // (Unicode codepoints), can only contain lowercase letters, numeric
+  // characters, underscores and dashes. International characters are allowed.
+  // No more than 64 user labels can be associated with one resource (System
+  // labels are excluded).
+  //
+  // See https://goo.gl/xmQnxf for more information and examples of labels.
+  // System reserved label keys are prefixed with
+  // `apigeeregistry.googleapis.com/` and cannot be changed.
+  map<string, string> labels = 14;
+
+  // Annotations attach non-identifying metadata to resources.
+  //
+  // Annotation keys and values are less restricted than those of labels, but
+  // should be generally used for small values of broad interest. Larger, topic-
+  // specific metadata should be stored in Artifacts.
+  map<string, string> annotations = 15;
+}
+
+// Describes a service running at particular address that
+// provides a particular version of an API. ApiDeployments have revisions which
+// correspond to different configurations of a single deployment in time.
+// Revision identifiers should be updated whenever the served API spec or
+// endpoint address changes.
+message ApiDeployment {
+  option (google.api.resource) = {
+    type: "apigeeregistry.googleapis.com/ApiDeployment"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}"
+  };
+
+  // Resource name.
+  string name = 1;
+
+  // Human-meaningful name.
+  string display_name = 2;
+
+  // A detailed description.
+  string description = 3;
+
+  // Output only. Immutable. The revision ID of the deployment.
+  // A new revision is committed whenever the deployment contents are changed.
+  // The format is an 8-character hexadecimal string.
+  string revision_id = 4 [
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
+
+  // Output only. Creation timestamp; when the deployment resource was created.
+  google.protobuf.Timestamp create_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Revision creation timestamp; when the represented revision was created.
+  google.protobuf.Timestamp revision_create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Last update timestamp: when the represented revision was last modified.
+  google.protobuf.Timestamp revision_update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The full resource name (including revision ID) of the spec of the API being
+  // served by the deployment. Changes to this value will update the revision.
+  // Format: `apis/{api}/deployments/{deployment}`
+  string api_spec_revision = 8 [(google.api.resource_reference) = {
+                                  type: "apigeeregistry.googleapis.com/ApiSpec"
+                                }];
+
+  // The address where the deployment is serving. Changes to this value will
+  // update the revision.
+  string endpoint_uri = 9;
+
+  // The address of the external channel of the API (e.g., the Developer
+  // Portal). Changes to this value will not affect the revision.
+  string external_channel_uri = 10;
+
+  // Text briefly identifying the intended audience of the API. Changes to this
+  // value will not affect the revision.
+  string intended_audience = 11;
+
+  // Text briefly describing how to access the endpoint. Changes to this value
+  // will not affect the revision.
+  string access_guidance = 12;
+
+  // Labels attach identifying metadata to resources. Identifying metadata can
+  // be used to filter list operations.
+  //
+  // Label keys and values can be no longer than 64 characters
+  // (Unicode codepoints), can only contain lowercase letters, numeric
+  // characters, underscores and dashes. International characters are allowed.
+  // No more than 64 user labels can be associated with one resource (System
+  // labels are excluded).
+  //
+  // See https://goo.gl/xmQnxf for more information and examples of labels.
+  // System reserved label keys are prefixed with
+  // `apigeeregistry.googleapis.com/` and cannot be changed.
+  map<string, string> labels = 14;
+
+  // Annotations attach non-identifying metadata to resources.
+  //
+  // Annotation keys and values are less restricted than those of labels, but
+  // should be generally used for small values of broad interest. Larger, topic-
+  // specific metadata should be stored in Artifacts.
+  map<string, string> annotations = 15;
+}
+
+// Artifacts of resources. Artifacts are unique (single-value) per resource
+// and are used to store metadata that is too large or numerous to be stored
+// directly on the resource. Since artifacts are stored separately from parent
+// resources, they should generally be used for metadata that is needed
+// infrequently, i.e., not for display in primary views of the resource but
+// perhaps displayed or downloaded upon request. The `ListArtifacts` method
+// allows artifacts to be quickly enumerated and checked for presence without
+// downloading their (potentially-large) contents.
+message Artifact {
+  option (google.api.resource) = {
+    type: "apigeeregistry.googleapis.com/Artifact"
+    pattern: "projects/{project}/locations/{location}/artifacts/{artifact}"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/artifacts/{artifact}"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/versions/{version}/artifacts/{artifact}"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/versions/{version}/specs/{spec}/artifacts/{artifact}"
+    pattern: "projects/{project}/locations/{location}/apis/{api}/deployments/{deployment}/artifacts/{artifact}"
+  };
+
+  // Resource name.
+  string name = 1;
+
+  // Output only. Creation timestamp.
+  google.protobuf.Timestamp create_time = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. Last update timestamp.
+  google.protobuf.Timestamp update_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // A content type specifier for the artifact.
+  // Content type specifiers are Media Types
+  // (https://en.wikipedia.org/wiki/Media_type) with a possible "schema"
+  // parameter that specifies a schema for the stored information.
+  // Content types can specify compression. Currently only GZip compression is
+  // supported (indicated with "+gzip").
+  string mime_type = 4;
+
+  // Output only. The size of the artifact in bytes. If the artifact is gzipped, this is
+  // the size of the uncompressed artifact.
+  int32 size_bytes = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. A SHA-256 hash of the artifact's contents. If the artifact is gzipped,
+  // this is the hash of the uncompressed artifact.
+  string hash = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Input only. The contents of the artifact.
+  // Provided by API callers when artifacts are created or replaced.
+  // To access the contents of an artifact, use GetArtifactContents.
+  bytes contents = 7 [(google.api.field_behavior) = INPUT_ONLY];
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/registry_service.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/cloud/apigeeregistry/v1/registry_service.proto
@@ -1,0 +1,1133 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.apigeeregistry.v1;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/httpbody.proto";
+import "google/api/resource.proto";
+import "google/cloud/apigeeregistry/v1/registry_models.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option csharp_namespace = "Google.Cloud.ApigeeRegistry.V1";
+option go_package = "cloud.google.com/go/apigeeregistry/apiv1/apigeeregistrypb;apigeeregistrypb";
+option java_multiple_files = true;
+option java_outer_classname = "RegistryServiceProto";
+option java_package = "com.google.cloud.apigeeregistry.v1";
+option php_namespace = "Google\\Cloud\\ApigeeRegistry\\V1";
+option ruby_package = "Google::Cloud::ApigeeRegistry::V1";
+
+// The Registry service allows teams to manage descriptions of APIs.
+service Registry {
+  option (google.api.default_host) = "apigeeregistry.googleapis.com";
+  option (google.api.oauth_scopes) = "https://www.googleapis.com/auth/cloud-platform";
+
+  // Returns matching APIs.
+  rpc ListApis(ListApisRequest) returns (ListApisResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/locations/*}/apis"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Returns a specified API.
+  rpc GetApi(GetApiRequest) returns (Api) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a specified API.
+  rpc CreateApi(CreateApiRequest) returns (Api) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/locations/*}/apis"
+      body: "api"
+    };
+    option (google.api.method_signature) = "parent,api,api_id";
+  }
+
+  // Used to modify a specified API.
+  rpc UpdateApi(UpdateApiRequest) returns (Api) {
+    option (google.api.http) = {
+      patch: "/v1/{api.name=projects/*/locations/*/apis/*}"
+      body: "api"
+    };
+    option (google.api.method_signature) = "api,update_mask";
+  }
+
+  // Removes a specified API and all of the resources that it
+  // owns.
+  rpc DeleteApi(DeleteApiRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/apis/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns matching versions.
+  rpc ListApiVersions(ListApiVersionsRequest) returns (ListApiVersionsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/locations/*/apis/*}/versions"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Returns a specified version.
+  rpc GetApiVersion(GetApiVersionRequest) returns (ApiVersion) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*/versions/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a specified version.
+  rpc CreateApiVersion(CreateApiVersionRequest) returns (ApiVersion) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/locations/*/apis/*}/versions"
+      body: "api_version"
+    };
+    option (google.api.method_signature) = "parent,api_version,api_version_id";
+  }
+
+  // Used to modify a specified version.
+  rpc UpdateApiVersion(UpdateApiVersionRequest) returns (ApiVersion) {
+    option (google.api.http) = {
+      patch: "/v1/{api_version.name=projects/*/locations/*/apis/*/versions/*}"
+      body: "api_version"
+    };
+    option (google.api.method_signature) = "api_version,update_mask";
+  }
+
+  // Removes a specified version and all of the resources that
+  // it owns.
+  rpc DeleteApiVersion(DeleteApiVersionRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/apis/*/versions/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns matching specs.
+  rpc ListApiSpecs(ListApiSpecsRequest) returns (ListApiSpecsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/locations/*/apis/*/versions/*}/specs"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Returns a specified spec.
+  rpc GetApiSpec(GetApiSpecRequest) returns (ApiSpec) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns the contents of a specified spec.
+  // If specs are stored with GZip compression, the default behavior
+  // is to return the spec uncompressed (the mime_type response field
+  // indicates the exact format returned).
+  rpc GetApiSpecContents(GetApiSpecContentsRequest) returns (google.api.HttpBody) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}:getContents"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a specified spec.
+  rpc CreateApiSpec(CreateApiSpecRequest) returns (ApiSpec) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/locations/*/apis/*/versions/*}/specs"
+      body: "api_spec"
+    };
+    option (google.api.method_signature) = "parent,api_spec,api_spec_id";
+  }
+
+  // Used to modify a specified spec.
+  rpc UpdateApiSpec(UpdateApiSpecRequest) returns (ApiSpec) {
+    option (google.api.http) = {
+      patch: "/v1/{api_spec.name=projects/*/locations/*/apis/*/versions/*/specs/*}"
+      body: "api_spec"
+    };
+    option (google.api.method_signature) = "api_spec,update_mask";
+  }
+
+  // Removes a specified spec, all revisions, and all child
+  // resources (e.g., artifacts).
+  rpc DeleteApiSpec(DeleteApiSpecRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Adds a tag to a specified revision of a spec.
+  rpc TagApiSpecRevision(TagApiSpecRevisionRequest) returns (ApiSpec) {
+    option (google.api.http) = {
+      post: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}:tagRevision"
+      body: "*"
+    };
+  }
+
+  // Lists all revisions of a spec.
+  // Revisions are returned in descending order of revision creation time.
+  rpc ListApiSpecRevisions(ListApiSpecRevisionsRequest) returns (ListApiSpecRevisionsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}:listRevisions"
+    };
+  }
+
+  // Sets the current revision to a specified prior revision.
+  // Note that this creates a new revision with a new revision ID.
+  rpc RollbackApiSpec(RollbackApiSpecRequest) returns (ApiSpec) {
+    option (google.api.http) = {
+      post: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}:rollback"
+      body: "*"
+    };
+  }
+
+  // Deletes a revision of a spec.
+  rpc DeleteApiSpecRevision(DeleteApiSpecRevisionRequest) returns (ApiSpec) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*}:deleteRevision"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns matching deployments.
+  rpc ListApiDeployments(ListApiDeploymentsRequest) returns (ListApiDeploymentsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/locations/*/apis/*}/deployments"
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Returns a specified deployment.
+  rpc GetApiDeployment(GetApiDeploymentRequest) returns (ApiDeployment) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*/deployments/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a specified deployment.
+  rpc CreateApiDeployment(CreateApiDeploymentRequest) returns (ApiDeployment) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/locations/*/apis/*}/deployments"
+      body: "api_deployment"
+    };
+    option (google.api.method_signature) = "parent,api_deployment,api_deployment_id";
+  }
+
+  // Used to modify a specified deployment.
+  rpc UpdateApiDeployment(UpdateApiDeploymentRequest) returns (ApiDeployment) {
+    option (google.api.http) = {
+      patch: "/v1/{api_deployment.name=projects/*/locations/*/apis/*/deployments/*}"
+      body: "api_deployment"
+    };
+    option (google.api.method_signature) = "api_deployment,update_mask";
+  }
+
+  // Removes a specified deployment, all revisions, and all
+  // child resources (e.g., artifacts).
+  rpc DeleteApiDeployment(DeleteApiDeploymentRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/apis/*/deployments/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Adds a tag to a specified revision of a
+  // deployment.
+  rpc TagApiDeploymentRevision(TagApiDeploymentRevisionRequest) returns (ApiDeployment) {
+    option (google.api.http) = {
+      post: "/v1/{name=projects/*/locations/*/apis/*/deployments/*}:tagRevision"
+      body: "*"
+    };
+  }
+
+  // Lists all revisions of a deployment.
+  // Revisions are returned in descending order of revision creation time.
+  rpc ListApiDeploymentRevisions(ListApiDeploymentRevisionsRequest) returns (ListApiDeploymentRevisionsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/apis/*/deployments/*}:listRevisions"
+    };
+  }
+
+  // Sets the current revision to a specified prior
+  // revision. Note that this creates a new revision with a new revision ID.
+  rpc RollbackApiDeployment(RollbackApiDeploymentRequest) returns (ApiDeployment) {
+    option (google.api.http) = {
+      post: "/v1/{name=projects/*/locations/*/apis/*/deployments/*}:rollback"
+      body: "*"
+    };
+  }
+
+  // Deletes a revision of a deployment.
+  rpc DeleteApiDeploymentRevision(DeleteApiDeploymentRevisionRequest) returns (ApiDeployment) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/apis/*/deployments/*}:deleteRevision"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns matching artifacts.
+  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/locations/*}/artifacts"
+      additional_bindings {
+        get: "/v1/{parent=projects/*/locations/*/apis/*}/artifacts"
+      }
+      additional_bindings {
+        get: "/v1/{parent=projects/*/locations/*/apis/*/versions/*}/artifacts"
+      }
+      additional_bindings {
+        get: "/v1/{parent=projects/*/locations/*/apis/*/versions/*/specs/*}/artifacts"
+      }
+      additional_bindings {
+        get: "/v1/{parent=projects/*/locations/*/apis/*/deployments/*}/artifacts"
+      }
+    };
+    option (google.api.method_signature) = "parent";
+  }
+
+  // Returns a specified artifact.
+  rpc GetArtifact(GetArtifactRequest) returns (Artifact) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/artifacts/*}"
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/artifacts/*}"
+      }
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/artifacts/*}"
+      }
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}"
+      }
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/deployments/*/artifacts/*}"
+      }
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Returns the contents of a specified artifact.
+  // If artifacts are stored with GZip compression, the default behavior
+  // is to return the artifact uncompressed (the mime_type response field
+  // indicates the exact format returned).
+  rpc GetArtifactContents(GetArtifactContentsRequest) returns (google.api.HttpBody) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/locations/*/artifacts/*}:getContents"
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/artifacts/*}:getContents"
+      }
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/artifacts/*}:getContents"
+      }
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}:getContents"
+      }
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*/apis/*/deployments/*/artifacts/*}:getContents"
+      }
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a specified artifact.
+  rpc CreateArtifact(CreateArtifactRequest) returns (Artifact) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/locations/*}/artifacts"
+      body: "artifact"
+      additional_bindings {
+        post: "/v1/{parent=projects/*/locations/*/apis/*}/artifacts"
+        body: "artifact"
+      }
+      additional_bindings {
+        post: "/v1/{parent=projects/*/locations/*/apis/*/versions/*}/artifacts"
+        body: "artifact"
+      }
+      additional_bindings {
+        post: "/v1/{parent=projects/*/locations/*/apis/*/versions/*/specs/*}/artifacts"
+        body: "artifact"
+      }
+      additional_bindings {
+        post: "/v1/{parent=projects/*/locations/*/apis/*/deployments/*}/artifacts"
+        body: "artifact"
+      }
+    };
+    option (google.api.method_signature) = "parent,artifact,artifact_id";
+  }
+
+  // Used to replace a specified artifact.
+  rpc ReplaceArtifact(ReplaceArtifactRequest) returns (Artifact) {
+    option (google.api.http) = {
+      put: "/v1/{artifact.name=projects/*/locations/*/artifacts/*}"
+      body: "artifact"
+      additional_bindings {
+        put: "/v1/{artifact.name=projects/*/locations/*/apis/*/artifacts/*}"
+        body: "artifact"
+      }
+      additional_bindings {
+        put: "/v1/{artifact.name=projects/*/locations/*/apis/*/versions/*/artifacts/*}"
+        body: "artifact"
+      }
+      additional_bindings {
+        put: "/v1/{artifact.name=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}"
+        body: "artifact"
+      }
+      additional_bindings {
+        put: "/v1/{artifact.name=projects/*/locations/*/apis/*/deployments/*/artifacts/*}"
+        body: "artifact"
+      }
+    };
+    option (google.api.method_signature) = "artifact";
+  }
+
+  // Removes a specified artifact.
+  rpc DeleteArtifact(DeleteArtifactRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/locations/*/artifacts/*}"
+      additional_bindings {
+        delete: "/v1/{name=projects/*/locations/*/apis/*/artifacts/*}"
+      }
+      additional_bindings {
+        delete: "/v1/{name=projects/*/locations/*/apis/*/versions/*/artifacts/*}"
+      }
+      additional_bindings {
+        delete: "/v1/{name=projects/*/locations/*/apis/*/versions/*/specs/*/artifacts/*}"
+      }
+      additional_bindings {
+        delete: "/v1/{name=projects/*/locations/*/apis/*/deployments/*/artifacts/*}"
+      }
+    };
+    option (google.api.method_signature) = "name";
+  }
+}
+
+// Request message for ListApis.
+message ListApisRequest {
+  // Required. The parent, which owns this collection of APIs.
+  // Format: `projects/*/locations/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/Api"
+    }
+  ];
+
+  // The maximum number of APIs to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 values will be returned.
+  // The maximum is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListApis` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to `ListApis` must match
+  // the call that provided the page token.
+  string page_token = 3;
+
+  // An expression that can be used to filter the list. Filters use the Common
+  // Expression Language and can refer to all message fields.
+  string filter = 4;
+}
+
+// Response message for ListApis.
+message ListApisResponse {
+  // The APIs from the specified publisher.
+  repeated Api apis = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for GetApi.
+message GetApiRequest {
+  // Required. The name of the API to retrieve.
+  // Format: `projects/*/locations/*/apis/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Api"
+    }
+  ];
+}
+
+// Request message for CreateApi.
+message CreateApiRequest {
+  // Required. The parent, which owns this collection of APIs.
+  // Format: `projects/*/locations/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/Api"
+    }
+  ];
+
+  // Required. The API to create.
+  Api api = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The ID to use for the API, which will become the final component of
+  // the API's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  //
+  // Following AIP-162, IDs must not have the form of a UUID.
+  string api_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for UpdateApi.
+message UpdateApiRequest {
+  // Required. The API to update.
+  //
+  // The `name` field is used to identify the API to update.
+  // Format: `projects/*/locations/*/apis/*`
+  Api api = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of fields to be updated. If omitted, all fields are updated that
+  // are set in the request message (fields set to default values are ignored).
+  // If an asterisk "*" is specified, all fields are updated, including fields
+  // that are unspecified/default in the request.
+  google.protobuf.FieldMask update_mask = 2;
+
+  // If set to true, and the API is not found, a new API will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3;
+}
+
+// Request message for DeleteApi.
+message DeleteApiRequest {
+  // Required. The name of the API to delete.
+  // Format: `projects/*/locations/*/apis/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Api"
+    }
+  ];
+
+  // If set to true, any child resources will also be deleted.
+  // (Otherwise, the request will only work if there are no child resources.)
+  bool force = 2;
+}
+
+// Request message for ListApiVersions.
+message ListApiVersionsRequest {
+  // Required. The parent, which owns this collection of versions.
+  // Format: `projects/*/locations/*/apis/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/ApiVersion"
+    }
+  ];
+
+  // The maximum number of versions to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 values will be returned.
+  // The maximum is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListApiVersions` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to `ListApiVersions` must
+  // match the call that provided the page token.
+  string page_token = 3;
+
+  // An expression that can be used to filter the list. Filters use the Common
+  // Expression Language and can refer to all message fields.
+  string filter = 4;
+}
+
+// Response message for ListApiVersions.
+message ListApiVersionsResponse {
+  // The versions from the specified publisher.
+  repeated ApiVersion api_versions = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for GetApiVersion.
+message GetApiVersionRequest {
+  // Required. The name of the version to retrieve.
+  // Format: `projects/*/locations/*/apis/*/versions/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiVersion"
+    }
+  ];
+}
+
+// Request message for CreateApiVersion.
+message CreateApiVersionRequest {
+  // Required. The parent, which owns this collection of versions.
+  // Format: `projects/*/locations/*/apis/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/ApiVersion"
+    }
+  ];
+
+  // Required. The version to create.
+  ApiVersion api_version = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The ID to use for the version, which will become the final component of
+  // the version's resource name.
+  //
+  // This value should be 1-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  //
+  // Following AIP-162, IDs must not have the form of a UUID.
+  string api_version_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for UpdateApiVersion.
+message UpdateApiVersionRequest {
+  // Required. The version to update.
+  //
+  // The `name` field is used to identify the version to update.
+  // Format: `projects/*/locations/*/apis/*/versions/*`
+  ApiVersion api_version = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of fields to be updated. If omitted, all fields are updated that
+  // are set in the request message (fields set to default values are ignored).
+  // If an asterisk "*" is specified, all fields are updated, including fields
+  // that are unspecified/default in the request.
+  google.protobuf.FieldMask update_mask = 2;
+
+  // If set to true, and the version is not found, a new version will be
+  // created. In this situation, `update_mask` is ignored.
+  bool allow_missing = 3;
+}
+
+// Request message for DeleteApiVersion.
+message DeleteApiVersionRequest {
+  // Required. The name of the version to delete.
+  // Format: `projects/*/locations/*/apis/*/versions/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiVersion"
+    }
+  ];
+
+  // If set to true, any child resources will also be deleted.
+  // (Otherwise, the request will only work if there are no child resources.)
+  bool force = 2;
+}
+
+// Request message for ListApiSpecs.
+message ListApiSpecsRequest {
+  // Required. The parent, which owns this collection of specs.
+  // Format: `projects/*/locations/*/apis/*/versions/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+
+  // The maximum number of specs to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 values will be returned.
+  // The maximum is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListApiSpecs` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to `ListApiSpecs` must match
+  // the call that provided the page token.
+  string page_token = 3;
+
+  // An expression that can be used to filter the list. Filters use the Common
+  // Expression Language and can refer to all message fields except contents.
+  string filter = 4;
+}
+
+// Response message for ListApiSpecs.
+message ListApiSpecsResponse {
+  // The specs from the specified publisher.
+  repeated ApiSpec api_specs = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for GetApiSpec.
+message GetApiSpecRequest {
+  // Required. The name of the spec to retrieve.
+  // Format: `projects/*/locations/*/apis/*/versions/*/specs/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+}
+
+// Request message for GetApiSpecContents.
+message GetApiSpecContentsRequest {
+  // Required. The name of the spec whose contents should be retrieved.
+  // Format: `projects/*/locations/*/apis/*/versions/*/specs/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+}
+
+// Request message for CreateApiSpec.
+message CreateApiSpecRequest {
+  // Required. The parent, which owns this collection of specs.
+  // Format: `projects/*/locations/*/apis/*/versions/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+
+  // Required. The spec to create.
+  ApiSpec api_spec = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The ID to use for the spec, which will become the final component of
+  // the spec's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  //
+  // Following AIP-162, IDs must not have the form of a UUID.
+  string api_spec_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for UpdateApiSpec.
+message UpdateApiSpecRequest {
+  // Required. The spec to update.
+  //
+  // The `name` field is used to identify the spec to update.
+  // Format: `projects/*/locations/*/apis/*/versions/*/specs/*`
+  ApiSpec api_spec = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of fields to be updated. If omitted, all fields are updated that
+  // are set in the request message (fields set to default values are ignored).
+  // If an asterisk "*" is specified, all fields are updated, including fields
+  // that are unspecified/default in the request.
+  google.protobuf.FieldMask update_mask = 2;
+
+  // If set to true, and the spec is not found, a new spec will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3;
+}
+
+// Request message for DeleteApiSpec.
+message DeleteApiSpecRequest {
+  // Required. The name of the spec to delete.
+  // Format: `projects/*/locations/*/apis/*/versions/*/specs/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+
+  // If set to true, any child resources will also be deleted.
+  // (Otherwise, the request will only work if there are no child resources.)
+  bool force = 2;
+}
+
+// Request message for TagApiSpecRevision.
+message TagApiSpecRevisionRequest {
+  // Required. The name of the spec to be tagged, including the revision ID.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+
+  // Required. The tag to apply.
+  // The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+  string tag = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for ListApiSpecRevisions.
+message ListApiSpecRevisionsRequest {
+  // Required. The name of the spec to list revisions for.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+
+  // The maximum number of revisions to return per page.
+  int32 page_size = 2;
+
+  // The page token, received from a previous ListApiSpecRevisions call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 3;
+}
+
+// Response message for ListApiSpecRevisionsResponse.
+message ListApiSpecRevisionsResponse {
+  // The revisions of the spec.
+  repeated ApiSpec api_specs = 1;
+
+  // A token that can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for RollbackApiSpec.
+message RollbackApiSpecRequest {
+  // Required. The spec being rolled back.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+
+  // Required. The revision ID to roll back to.
+  // It must be a revision of the same spec.
+  //
+  //   Example: `c7cfa2a8`
+  string revision_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for DeleteApiSpecRevision.
+message DeleteApiSpecRevisionRequest {
+  // Required. The name of the spec revision to be deleted,
+  // with a revision ID explicitly included.
+  //
+  // Example:
+  // `projects/sample/locations/global/apis/petstore/versions/1.0.0/specs/openapi.yaml@c7cfa2a8`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiSpec"
+    }
+  ];
+}
+
+// Request message for ListApiDeployments.
+message ListApiDeploymentsRequest {
+  // Required. The parent, which owns this collection of deployments.
+  // Format: `projects/*/locations/*/apis/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+
+  // The maximum number of deployments to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 values will be returned.
+  // The maximum is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListApiDeployments` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to `ListApiDeployments` must
+  // match the call that provided the page token.
+  string page_token = 3;
+
+  // An expression that can be used to filter the list. Filters use the Common
+  // Expression Language and can refer to all message fields.
+  string filter = 4;
+}
+
+// Response message for ListApiDeployments.
+message ListApiDeploymentsResponse {
+  // The deployments from the specified publisher.
+  repeated ApiDeployment api_deployments = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for GetApiDeployment.
+message GetApiDeploymentRequest {
+  // Required. The name of the deployment to retrieve.
+  // Format: `projects/*/locations/*/apis/*/deployments/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+}
+
+// Request message for CreateApiDeployment.
+message CreateApiDeploymentRequest {
+  // Required. The parent, which owns this collection of deployments.
+  // Format: `projects/*/locations/*/apis/*`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+
+  // Required. The deployment to create.
+  ApiDeployment api_deployment = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The ID to use for the deployment, which will become the final component of
+  // the deployment's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  //
+  // Following AIP-162, IDs must not have the form of a UUID.
+  string api_deployment_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for UpdateApiDeployment.
+message UpdateApiDeploymentRequest {
+  // Required. The deployment to update.
+  //
+  // The `name` field is used to identify the deployment to update.
+  // Format: `projects/*/locations/*/apis/*/deployments/*`
+  ApiDeployment api_deployment = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of fields to be updated. If omitted, all fields are updated that
+  // are set in the request message (fields set to default values are ignored).
+  // If an asterisk "*" is specified, all fields are updated, including fields
+  // that are unspecified/default in the request.
+  google.protobuf.FieldMask update_mask = 2;
+
+  // If set to true, and the deployment is not found, a new deployment will be
+  // created. In this situation, `update_mask` is ignored.
+  bool allow_missing = 3;
+}
+
+// Request message for DeleteApiDeployment.
+message DeleteApiDeploymentRequest {
+  // Required. The name of the deployment to delete.
+  // Format: `projects/*/locations/*/apis/*/deployments/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+
+  // If set to true, any child resources will also be deleted.
+  // (Otherwise, the request will only work if there are no child resources.)
+  bool force = 2;
+}
+
+// Request message for TagApiDeploymentRevision.
+message TagApiDeploymentRevisionRequest {
+  // Required. The name of the deployment to be tagged, including the revision ID.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+
+  // Required. The tag to apply.
+  // The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+  string tag = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for ListApiDeploymentRevisions.
+message ListApiDeploymentRevisionsRequest {
+  // Required. The name of the deployment to list revisions for.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+
+  // The maximum number of revisions to return per page.
+  int32 page_size = 2;
+
+  // The page token, received from a previous ListApiDeploymentRevisions call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 3;
+}
+
+// Response message for ListApiDeploymentRevisionsResponse.
+message ListApiDeploymentRevisionsResponse {
+  // The revisions of the deployment.
+  repeated ApiDeployment api_deployments = 1;
+
+  // A token that can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for RollbackApiDeployment.
+message RollbackApiDeploymentRequest {
+  // Required. The deployment being rolled back.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+
+  // Required. The revision ID to roll back to.
+  // It must be a revision of the same deployment.
+  //
+  //   Example: `c7cfa2a8`
+  string revision_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for DeleteApiDeploymentRevision.
+message DeleteApiDeploymentRevisionRequest {
+  // Required. The name of the deployment revision to be deleted,
+  // with a revision ID explicitly included.
+  //
+  // Example:
+  // `projects/sample/locations/global/apis/petstore/deployments/prod@c7cfa2a8`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/ApiDeployment"
+    }
+  ];
+}
+
+// Request message for ListArtifacts.
+message ListArtifactsRequest {
+  // Required. The parent, which owns this collection of artifacts.
+  // Format: `{parent}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/Artifact"
+    }
+  ];
+
+  // The maximum number of artifacts to return.
+  // The service may return fewer than this value.
+  // If unspecified, at most 50 values will be returned.
+  // The maximum is 1000; values above 1000 will be coerced to 1000.
+  int32 page_size = 2;
+
+  // A page token, received from a previous `ListArtifacts` call.
+  // Provide this to retrieve the subsequent page.
+  //
+  // When paginating, all other parameters provided to `ListArtifacts` must
+  // match the call that provided the page token.
+  string page_token = 3;
+
+  // An expression that can be used to filter the list. Filters use the Common
+  // Expression Language and can refer to all message fields except contents.
+  string filter = 4;
+}
+
+// Response message for ListArtifacts.
+message ListArtifactsResponse {
+  // The artifacts from the specified publisher.
+  repeated Artifact artifacts = 1;
+
+  // A token, which can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+
+// Request message for GetArtifact.
+message GetArtifactRequest {
+  // Required. The name of the artifact to retrieve.
+  // Format: `{parent}/artifacts/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Artifact"
+    }
+  ];
+}
+
+// Request message for GetArtifactContents.
+message GetArtifactContentsRequest {
+  // Required. The name of the artifact whose contents should be retrieved.
+  // Format: `{parent}/artifacts/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Artifact"
+    }
+  ];
+}
+
+// Request message for CreateArtifact.
+message CreateArtifactRequest {
+  // Required. The parent, which owns this collection of artifacts.
+  // Format: `{parent}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "apigeeregistry.googleapis.com/Artifact"
+    }
+  ];
+
+  // Required. The artifact to create.
+  Artifact artifact = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. The ID to use for the artifact, which will become the final component of
+  // the artifact's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  //
+  // Following AIP-162, IDs must not have the form of a UUID.
+  string artifact_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for ReplaceArtifact.
+message ReplaceArtifactRequest {
+  // Required. The artifact to replace.
+  //
+  // The `name` field is used to identify the artifact to replace.
+  // Format: `{parent}/artifacts/*`
+  Artifact artifact = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for DeleteArtifact.
+message DeleteArtifactRequest {
+  // Required. The name of the artifact to delete.
+  // Format: `{parent}/artifacts/*`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "apigeeregistry.googleapis.com/Artifact"
+    }
+  ];
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/longrunning/operations.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/longrunning/operations.proto
@@ -1,0 +1,247 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.longrunning;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "google/rpc/status.proto";
+import "google/protobuf/descriptor.proto";
+
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.LongRunning";
+option go_package = "google.golang.org/genproto/googleapis/longrunning;longrunning";
+option java_multiple_files = true;
+option java_outer_classname = "OperationsProto";
+option java_package = "com.google.longrunning";
+option php_namespace = "Google\\LongRunning";
+
+extend google.protobuf.MethodOptions {
+  // Additional information regarding long-running operations.
+  // In particular, this specifies the types that are returned from
+  // long-running operations.
+  //
+  // Required for methods that return `google.longrunning.Operation`; invalid
+  // otherwise.
+  google.longrunning.OperationInfo operation_info = 1049;
+}
+
+// Manages long-running operations with an API service.
+//
+// When an API method normally takes long time to complete, it can be designed
+// to return [Operation][google.longrunning.Operation] to the client, and the client can use this
+// interface to receive the real response asynchronously by polling the
+// operation resource, or pass the operation resource to another API (such as
+// Google Cloud Pub/Sub API) to receive the response.  Any API service that
+// returns long-running operations should implement the `Operations` interface
+// so developers can have a consistent client experience.
+service Operations {
+  option (google.api.default_host) = "longrunning.googleapis.com";
+
+  // Lists operations that match the specified filter in the request. If the
+  // server doesn't support this method, it returns `UNIMPLEMENTED`.
+  //
+  // NOTE: the `name` binding allows API services to override the binding
+  // to use different resource name schemes, such as `users/*/operations`. To
+  // override the binding, API services can add a binding such as
+  // `"/v1/{name=users/*}/operations"` to their service configuration.
+  // For backwards compatibility, the default name includes the operations
+  // collection id, however overriding users must ensure the name binding
+  // is the parent resource, without the operations collection id.
+  rpc ListOperations(ListOperationsRequest) returns (ListOperationsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{name=operations}"
+    };
+    option (google.api.method_signature) = "name,filter";
+  }
+
+  // Gets the latest state of a long-running operation.  Clients can use this
+  // method to poll the operation result at intervals as recommended by the API
+  // service.
+  rpc GetOperation(GetOperationRequest) returns (Operation) {
+    option (google.api.http) = {
+      get: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Deletes a long-running operation. This method indicates that the client is
+  // no longer interested in the operation result. It does not cancel the
+  // operation. If the server doesn't support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  rpc DeleteOperation(DeleteOperationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Starts asynchronous cancellation on a long-running operation.  The server
+  // makes a best effort to cancel the operation, but success is not
+  // guaranteed.  If the server doesn't support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+  // [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+  // other methods to check whether the cancellation succeeded or whether the
+  // operation completed despite cancellation. On successful cancellation,
+  // the operation is not deleted; instead, it becomes an operation with
+  // an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+  // corresponding to `Code.CANCELLED`.
+  rpc CancelOperation(CancelOperationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1/{name=operations/**}:cancel"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Waits until the specified long-running operation is done or reaches at most
+  // a specified timeout, returning the latest state.  If the operation is
+  // already done, the latest state is immediately returned.  If the timeout
+  // specified is greater than the default HTTP/RPC timeout, the HTTP/RPC
+  // timeout is used.  If the server does not support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  // Note that this method is on a best-effort basis.  It may return the latest
+  // state before the specified timeout (including immediately), meaning even an
+  // immediate response is no guarantee that the operation is done.
+  rpc WaitOperation(WaitOperationRequest) returns (Operation) {
+  }
+}
+
+// This resource represents a long-running operation that is the result of a
+// network API call.
+message Operation {
+  // The server-assigned name, which is only unique within the same service that
+  // originally returns it. If you use the default HTTP mapping, the
+  // `name` should be a resource name ending with `operations/{unique_id}`.
+  string name = 1;
+
+  // Service-specific metadata associated with the operation.  It typically
+  // contains progress information and common metadata such as create time.
+  // Some services might not provide such metadata.  Any method that returns a
+  // long-running operation should document the metadata type, if any.
+  google.protobuf.Any metadata = 2;
+
+  // If the value is `false`, it means the operation is still in progress.
+  // If `true`, the operation is completed, and either `error` or `response` is
+  // available.
+  bool done = 3;
+
+  // The operation result, which can be either an `error` or a valid `response`.
+  // If `done` == `false`, neither `error` nor `response` is set.
+  // If `done` == `true`, exactly one of `error` or `response` is set.
+  oneof result {
+    // The error result of the operation in case of failure or cancellation.
+    google.rpc.Status error = 4;
+
+    // The normal response of the operation in case of success.  If the original
+    // method returns no data on success, such as `Delete`, the response is
+    // `google.protobuf.Empty`.  If the original method is standard
+    // `Get`/`Create`/`Update`, the response should be the resource.  For other
+    // methods, the response should have the type `XxxResponse`, where `Xxx`
+    // is the original method name.  For example, if the original method name
+    // is `TakeSnapshot()`, the inferred response type is
+    // `TakeSnapshotResponse`.
+    google.protobuf.Any response = 5;
+  }
+}
+
+// The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+message GetOperationRequest {
+  // The name of the operation resource.
+  string name = 1;
+}
+
+// The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+message ListOperationsRequest {
+  // The name of the operation's parent resource.
+  string name = 4;
+
+  // The standard list filter.
+  string filter = 1;
+
+  // The standard list page size.
+  int32 page_size = 2;
+
+  // The standard list page token.
+  string page_token = 3;
+}
+
+// The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+message ListOperationsResponse {
+  // A list of operations that matches the specified filter in the request.
+  repeated Operation operations = 1;
+
+  // The standard List next-page token.
+  string next_page_token = 2;
+}
+
+// The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+message CancelOperationRequest {
+  // The name of the operation resource to be cancelled.
+  string name = 1;
+}
+
+// The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+message DeleteOperationRequest {
+  // The name of the operation resource to be deleted.
+  string name = 1;
+}
+
+// The request message for [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
+message WaitOperationRequest {
+  // The name of the operation resource to wait on.
+  string name = 1;
+
+  // The maximum duration to wait before timing out. If left blank, the wait
+  // will be at most the time permitted by the underlying HTTP/RPC protocol.
+  // If RPC context deadline is also specified, the shorter one will be used.
+  google.protobuf.Duration timeout = 2;
+}
+
+// A message representing the message types used by a long-running operation.
+//
+// Example:
+//
+//   rpc LongRunningRecognize(LongRunningRecognizeRequest)
+//       returns (google.longrunning.Operation) {
+//     option (google.longrunning.operation_info) = {
+//       response_type: "LongRunningRecognizeResponse"
+//       metadata_type: "LongRunningRecognizeMetadata"
+//     };
+//   }
+message OperationInfo {
+  // Required. The message name of the primary return type for this
+  // long-running operation.
+  // This type will be used to deserialize the LRO's response.
+  //
+  // If the response is in a different package from the rpc, a fully-qualified
+  // message name must be used (e.g. `google.protobuf.Struct`).
+  //
+  // Note: Altering this value constitutes a breaking change.
+  string response_type = 1;
+
+  // Required. The message name of the metadata type for this long-running
+  // operation.
+  //
+  // If the response is in a different package from the rpc, a fully-qualified
+  // message name must be used (e.g. `google.protobuf.Struct`).
+  //
+  // Note: Altering this value constitutes a breaking change.
+  string metadata_type = 2;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/rpc/status.proto
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/google/rpc/status.proto
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The `Status` type defines a logical error model that is suitable for
+// different programming environments, including REST APIs and RPC APIs. It is
+// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+// three pieces of data: error code, error message, and error details.
+//
+// You can find out more about this error model and how to work with it in the
+// [API Design Guide](https://cloud.google.com/apis/design/errors).
+message Status {
+  // The status code, which should be an enum value of
+  // [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+  // by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There is a common set of
+  // message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}

--- a/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/info.yaml
+++ b/cmd/registry/cmd/compute/complexity/testdata/apigeeregistry/v1/protos/info.yaml
@@ -1,0 +1,12 @@
+apiVersion: apigeeregistry/v1
+kind: Spec
+metadata:
+  name: protos
+  parent: apis/apigeeregistry/versions/v1
+  annotations:
+    config: apigeeregistry_v1.yaml
+    directory: google/cloud/apigeeregistry/v1
+    host: apigeeregistry.googleapis.com
+data:
+  filename: protos.zip
+  mimeType: application/x.proto+zip


### PR DESCRIPTION
This verifies that the computation runs and computes something for the three formats.

testdata is identical to the testdata in the vocabulary package, these could be merged and pulled up a level if desired. 