### PR TITLE
Pass "true" for continueOnError from WorkerPoolIgnoreError.

### DIFF
--- a/cmd/registry/tasks/tasks.go
+++ b/cmd/registry/tasks/tasks.go
@@ -86,7 +86,7 @@ func WorkerPool(ctx context.Context, n int, continueOnError bool) (chan<- Task, 
 // returns a wait function that captures and logs the error at Error level. This
 // is convenient for defer.
 func WorkerPoolIgnoreError(ctx context.Context, n int) (chan<- Task, func()) {
-	wp, w := WorkerPool(ctx, n, false)
+	wp, w := WorkerPool(ctx, n, true)
 	wait := func() {
 		if err := w(); err != nil {
 			log.FromContext(ctx).WithError(err).Errorf("unhandled WorkerPool error")


### PR DESCRIPTION
I think this got mixed up in the back-and-forth today. When I tried `main`, I noticed the worker pools were exiting on error, but fortunately, flipping this boolean got them to continue, and this also now matches the comment above it.