### PR TITLE
Use correct mime type for lint artifacts.

### DIFF
--- a/cmd/registry/cmd/compute/lint/lint.go
+++ b/cmd/registry/cmd/compute/lint/lint.go
@@ -157,7 +157,7 @@ func (task *computeLintTask) Run(ctx context.Context) error {
 	messageData, _ := proto.Marshal(lint)
 	artifact := &rpc.Artifact{
 		Name:     subject + "/artifacts/" + relation,
-		MimeType: mime.MimeTypeForMessageType("google.cloud.apigeeregistry.applications.v1alpha1.Lint"),
+		MimeType: mime.MimeTypeForMessageType("google.cloud.apigeeregistry.v1.style.Lint"),
 		Contents: messageData,
 	}
 	return visitor.SetArtifact(ctx, task.client, artifact)


### PR DESCRIPTION
More is needed for `registry compute lint`, but this fixes a glaring problem in the mime type used to store lint artifacts, updating it to the correct current value.