### PR TITLE
Automatically uncompress all spec data returned by the visitor package.

### DIFF
--- a/cmd/registry/cmd/compute/complexity/complexity.go
+++ b/cmd/registry/cmd/compute/complexity/complexity.go
@@ -17,9 +17,7 @@ package complexity
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/cmd/registry/tasks"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/pkg/log"
@@ -133,11 +131,6 @@ func (task *computeComplexityTask) Run(ctx context.Context) error {
 	relation := "complexity"
 	log.Debugf(ctx, "Computing %s/artifacts/%s", task.specName, relation)
 	contents := spec.GetContents()
-	if strings.Contains(spec.GetMimeType(), "+gzip") {
-		if contents, err = compress.GUnzippedBytes(contents); err != nil {
-			return err
-		}
-	}
 	var complexity *metrics.Complexity
 	if mime.IsOpenAPIv2(spec.GetMimeType()) {
 		document, err := oas2.ParseDocument(contents)

--- a/cmd/registry/cmd/diff/diff.go
+++ b/cmd/registry/cmd/diff/diff.go
@@ -23,7 +23,6 @@ import (
 	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/pkg/log"
-	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/pkg/names"
 	"github.com/apigee/registry/pkg/visitor"
 	"github.com/apigee/registry/rpc"
@@ -196,22 +195,7 @@ func printDiff(spec1, spec2 *rpc.ApiSpec) error {
 			}
 		}
 	} else {
-		var err error
-		contents1 := spec1.Contents
-		if mime.IsGZipCompressed(spec1.MimeType) {
-			contents1, err = compress.GUnzippedBytes(contents1)
-			if err != nil {
-				return err
-			}
-		}
-		contents2 := spec2.Contents
-		if mime.IsGZipCompressed(spec2.MimeType) {
-			contents2, err = compress.GUnzippedBytes(contents2)
-			if err != nil {
-				return err
-			}
-		}
-		diff := computeDiff(contents1, contents2, spec1.Name, spec2.Name)
+		diff := computeDiff(spec1.Contents, spec2.Contents, spec1.Name, spec2.Name)
 		if len(diff) > 0 {
 			fmt.Println(diff)
 		}

--- a/cmd/registry/cmd/get/get.go
+++ b/cmd/registry/cmd/get/get.go
@@ -19,9 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
-	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/cmd/registry/patch"
 	"github.com/apigee/registry/pkg/connection"
 	"github.com/apigee/registry/pkg/encoding"
@@ -221,11 +219,7 @@ func (v *getVisitor) SpecHandler() visitor.SpecHandler {
 			if err := visitor.FetchSpecContents(ctx, v.registryClient, message); err != nil {
 				return err
 			}
-			contents := message.GetContents()
-			if strings.Contains(message.GetMimeType(), "+gzip") {
-				contents, _ = compress.GUnzippedBytes(contents)
-			}
-			v.results = append(v.results, contents)
+			v.results = append(v.results, message.GetContents())
 			return nil
 		case "yaml":
 			spec, err := patch.NewApiSpec(ctx, v.registryClient, message, v.nested)

--- a/cmd/registry/conformance/conformance-task.go
+++ b/cmd/registry/conformance/conformance-task.go
@@ -94,7 +94,7 @@ func (task *ComputeConformanceTask) String() string {
 func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 	log.Debugf(ctx, "Computing conformance report %s/artifacts/%s", task.Spec.GetName(), conformanceReportId(task.StyleguideId))
 
-	data, err := visitor.GetBytesForSpec(ctx, task.Client, task.Spec)
+	err := visitor.FetchSpecContents(ctx, task.Client, task.Spec)
 	if err != nil {
 		return err
 	}
@@ -111,10 +111,10 @@ func (task *ComputeConformanceTask) Run(ctx context.Context) error {
 	defer os.RemoveAll(root)
 
 	if mime.IsZipArchive(task.Spec.GetMimeType()) {
-		_, err = compress.UnzipArchiveToPath(data, root)
+		_, err = compress.UnzipArchiveToPath(task.Spec.GetContents(), root)
 	} else {
 		// Write the file to the temporary directory.
-		err = os.WriteFile(filepath.Join(root, name), data, 0644)
+		err = os.WriteFile(filepath.Join(root, name), task.Spec.GetContents(), 0644)
 	}
 	if err != nil {
 		return err

--- a/pkg/mime/types.go
+++ b/pkg/mime/types.go
@@ -69,6 +69,11 @@ func IsGZipCompressed(mimeType string) bool {
 	return strings.Contains(mimeType, "+gzip")
 }
 
+// GUnzippedType returns an equivalent uncompressed MIME type for a compressed type.
+func GUnzippedType(mimeType string) string {
+	return strings.Replace(mimeType, "+gzip", "", 1)
+}
+
 // IsZipArchive returns true if a MIME type represents a type stored as a multifile Zip archive.
 func IsZipArchive(mimeType string) bool {
 	return strings.Contains(mimeType, "+zip")

--- a/pkg/mime/types_test.go
+++ b/pkg/mime/types_test.go
@@ -72,6 +72,12 @@ func TestOpenAPIMimeTypes(t *testing.T) {
 			if IsZipArchive(value) {
 				t.Errorf("%s is incorrectly recognized as a zip archive", value)
 			}
+			if IsGZipCompressed(value) {
+				unzipped := GUnzippedType(value)
+				if IsGZipCompressed(unzipped) {
+					t.Errorf("failed to remove compression from type %q", value)
+				}
+			}
 		})
 	}
 }

--- a/pkg/visitor/content.go
+++ b/pkg/visitor/content.go
@@ -41,8 +41,7 @@ func SetArtifact(ctx context.Context,
 	if code == codes.AlreadyExists {
 		request := &rpc.ReplaceArtifactRequest{}
 		request.Artifact = artifact
-		_, err := client.ReplaceArtifact(ctx, request)
-		return err
+		_, err = client.ReplaceArtifact(ctx, request)
 	}
 	return err
 }

--- a/pkg/visitor/content.go
+++ b/pkg/visitor/content.go
@@ -18,13 +18,9 @@ import (
 	"context"
 	"path"
 
-	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/gapic"
-	"github.com/apigee/registry/pkg/connection"
-	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -49,17 +45,4 @@ func SetArtifact(ctx context.Context,
 		return err
 	}
 	return err
-}
-
-func GetBytesForSpec(ctx context.Context, client connection.RegistryClient, spec *rpc.ApiSpec) ([]byte, error) {
-	request := &rpc.GetApiSpecContentsRequest{Name: spec.GetName()}
-	ctx = metadata.AppendToOutgoingContext(ctx, "accept-encoding", "gzip")
-	contents, err := client.GetApiSpecContents(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-	if mime.IsGZipCompressed(contents.ContentType) {
-		return compress.GUnzippedBytes(contents.Data)
-	}
-	return contents.Data, nil
 }

--- a/pkg/visitor/fetch.go
+++ b/pkg/visitor/fetch.go
@@ -41,9 +41,8 @@ func FetchSpecContents(ctx context.Context, client *gapic.RegistryClient, spec *
 	if mime.IsGZipCompressed(spec.MimeType) {
 		spec.MimeType = mime.GUnzippedType(spec.MimeType)
 		spec.Contents, err = compress.GUnzippedBytes(spec.Contents)
-		return err
 	}
-	return nil
+	return err
 }
 
 func FetchArtifactContents(ctx context.Context, client *gapic.RegistryClient, artifact *rpc.Artifact) error {

--- a/pkg/visitor/fetch.go
+++ b/pkg/visitor/fetch.go
@@ -17,7 +17,9 @@ package visitor
 import (
 	"context"
 
+	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/gapic"
+	"github.com/apigee/registry/pkg/mime"
 	"github.com/apigee/registry/rpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -34,8 +36,13 @@ func FetchSpecContents(ctx context.Context, client *gapic.RegistryClient, spec *
 	if err != nil {
 		return err
 	}
-	spec.Contents = contents.GetData()
 	spec.MimeType = contents.GetContentType()
+	spec.Contents = contents.GetData()
+	if mime.IsGZipCompressed(spec.MimeType) {
+		spec.MimeType = mime.GUnzippedType(spec.MimeType)
+		spec.Contents, err = compress.GUnzippedBytes(spec.Contents)
+		return err
+	}
 	return nil
 }
 

--- a/pkg/visitor/fetch_test.go
+++ b/pkg/visitor/fetch_test.go
@@ -30,8 +30,8 @@ func TestFetch(t *testing.T) {
 	project := names.Project{ProjectID: projectID}
 	parent := project.String() + "/locations/global"
 
-	specContents := "hello"
-	gzippedSpecContents, err := compress.GZippedBytes([]byte(specContents))
+	specContents := []byte("hello")
+	gzippedSpecContents, err := compress.GZippedBytes(specContents)
 	if err != nil {
 		t.Fatalf("Setup: Failed to compress test data: %s", err)
 	}
@@ -97,7 +97,7 @@ func TestFetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to fetch spec contents: %s", err)
 		}
-		if !bytes.Equal(spec.Contents, gzippedSpecContents) {
+		if !bytes.Equal(spec.Contents, specContents) {
 			t.Fatalf("Fetched unexpected spec contents: wanted %q got %q", specContents, spec.Contents)
 		}
 	})
@@ -117,7 +117,7 @@ func TestFetch(t *testing.T) {
 			t.Fatalf("Failed to parse spec name: %s", err)
 		}
 		err = GetSpec(ctx, registryClient, specName, true, func(ctx context.Context, spec *rpc.ApiSpec) error {
-			if !bytes.Equal(spec.Contents, gzippedSpecContents) {
+			if !bytes.Equal(spec.Contents, specContents) {
 				t.Fatalf("Fetched unexpected spec contents: wanted %q got %q", specContents, spec.Contents)
 			}
 			return nil
@@ -134,7 +134,7 @@ func TestFetch(t *testing.T) {
 		count := 0
 		err = ListSpecs(ctx, registryClient, specName, "", true, func(ctx context.Context, spec *rpc.ApiSpec) error {
 			count++
-			if string(spec.Contents) != specContents {
+			if !bytes.Equal(spec.Contents, specContents) {
 				t.Fatalf("Fetched unexpected spec contents: wanted %q got %q", specContents, spec.Contents)
 			}
 			return nil
@@ -152,7 +152,7 @@ func TestFetch(t *testing.T) {
 			t.Fatalf("Failed to parse spec revision name: %s", err)
 		}
 		err = GetSpecRevision(ctx, registryClient, specRevisionName, true, func(ctx context.Context, spec *rpc.ApiSpec) error {
-			if !bytes.Equal(spec.Contents, gzippedSpecContents) {
+			if !bytes.Equal(spec.Contents, specContents) {
 				t.Fatalf("Fetched unexpected spec contents: wanted %q got %q", specContents, spec.Contents)
 			}
 			return nil
@@ -169,7 +169,7 @@ func TestFetch(t *testing.T) {
 		count := 0
 		err = ListSpecRevisions(ctx, registryClient, specRevisionName, "", true, func(ctx context.Context, spec *rpc.ApiSpec) error {
 			count++
-			if string(spec.Contents) != specContents {
+			if !bytes.Equal(spec.Contents, specContents) {
 				t.Fatalf("Fetched unexpected spec contents: wanted %q got %q", specContents, spec.Contents)
 			}
 			return nil

--- a/pkg/visitor/list.go
+++ b/pkg/visitor/list.go
@@ -198,6 +198,7 @@ func ListSpecs(ctx context.Context,
 			}
 			r.Contents = resp.GetData()
 			if mime.IsGZipCompressed(resp.ContentType) {
+				r.MimeType = mime.GUnzippedType(r.MimeType)
 				r.Contents, err = compress.GUnzippedBytes(r.Contents)
 				if err != nil {
 					return err
@@ -236,6 +237,7 @@ func ListSpecRevisions(ctx context.Context,
 			}
 			r.Contents = resp.GetData()
 			if mime.IsGZipCompressed(resp.ContentType) {
+				r.MimeType = mime.GUnzippedType(r.MimeType)
 				r.Contents, err = compress.GUnzippedBytes(r.Contents)
 				if err != nil {
 					return err


### PR DESCRIPTION
This fixes #1123 by modifying `visitor.GetSpecs` (and the underlying  `visitor.FetchSpecContents`) to always return ungzipped specs. To avoid confusing downstream code, this also modifies the mime type of the returned specs to match the unzipped content (i.e. the "+gzip" is removed). This might be seen as misrepresenting the content stored on the server, but overall I think this is better because downstream code often switches on spec mime types, and this avoids accidental double-uncompression.

Moving this uncompression into the `visitor` package allows us to eliminate uncompression throughout the registry tool subcommands. Now any client code that uses `visitor` can safely expect gzipped specs to be uncompressed.

With a few other small changes, this eliminates `visitor.GetSpecBytes()`, replacing it with calls to `visitor.FetchSpecContents()`. `FetchSpecContents` is useful in situations where we are working on large numbers of specs and want to avoid loading all these specs into memory as we are putting them in task queues for processing. Instead we defer the "fetch" to when the specs are needed in the task handlers.

There's some untested code in `compute lint` that will be addressed in future PRs (#1121).