### PR TITLE
Convert registry tool flags to variable-bound.

### DIFF
--- a/cmd/registry/cmd/compute/complexity/complexity.go
+++ b/cmd/registry/cmd/compute/complexity/complexity.go
@@ -36,6 +36,9 @@ import (
 )
 
 func Command() *cobra.Command {
+	var filter string
+	var jobs int
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "complexity SPEC_REVISION",
 		Short: "Compute complexity metrics of API specs",
@@ -48,24 +51,11 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			filter, err := cmd.Flags().GetString("filter")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
-			}
-			dryRun, err := cmd.Flags().GetBool("dry-run")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
-			}
-
 			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			// Initialize task queue.
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, jobs)
 			defer wait()
 
@@ -99,9 +89,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().String("filter", "", "Filter selected resources")
-	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().StringVar(&filter, "filter", "", "filter selected resources")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/compute.go
+++ b/cmd/registry/cmd/compute/compute.go
@@ -39,8 +39,5 @@ func Command() *cobra.Command {
 	cmd.AddCommand(scorecard.Command())
 	cmd.AddCommand(vocabulary.Command())
 
-	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
 	return cmd
 }

--- a/cmd/registry/cmd/compute/conformance/conformance.go
+++ b/cmd/registry/cmd/compute/conformance/conformance.go
@@ -34,6 +34,9 @@ import (
 var styleguideFilter = fmt.Sprintf("mime_type.contains('%s')", mime.MimeTypeForKind("StyleGuide"))
 
 func Command() *cobra.Command {
+	var filter string
+	var jobs int
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "conformance SPEC_REVISION",
 		Short: "Compute lint results for API specs",
@@ -45,19 +48,6 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
 			args[0] = c.FQName(args[0])
-
-			filter, err := cmd.Flags().GetString("filter")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
-			}
-			dryRun, err := cmd.Flags().GetBool("dry-run")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
-			}
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 
 			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
@@ -104,9 +94,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().String("filter", "", "Filter selected resources")
-	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().StringVar(&filter, "filter", "", "filter selected resources")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/lintstats/lintstats.go
+++ b/cmd/registry/cmd/compute/lintstats/lintstats.go
@@ -44,6 +44,8 @@ func lintStatsRelation(linter string) string {
 
 func Command() *cobra.Command {
 	var linter string
+	var filter string
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "lintstats RESOURCE",
 		Short: "Compute summaries of linter runs",
@@ -55,15 +57,6 @@ func Command() *cobra.Command {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get config")
 			}
 			args[0] = c.FQName(args[0])
-
-			filter, err := cmd.Flags().GetString("filter")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
-			}
-			dryRun, err := cmd.Flags().GetBool("dry-run")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
-			}
 
 			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
@@ -82,8 +75,10 @@ func Command() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
 	cmd.Flags().StringVar(&linter, "linter", "", "the name of the linter whose results will be used to compute stats (aip|spectral|gnostic)")
 	_ = cmd.MarkFlagRequired("linter")
+	cmd.Flags().StringVar(&filter, "filter", "", "filter selected resources")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/score/score.go
+++ b/cmd/registry/cmd/compute/score/score.go
@@ -29,6 +29,9 @@ import (
 )
 
 func Command() *cobra.Command {
+	var filter string
+	var jobs int
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "score PATTERN",
 		Short: "Compute scores for APIs and API specs",
@@ -41,15 +44,6 @@ func Command() *cobra.Command {
 			}
 			args[0] = c.FQName(args[0])
 
-			filter, err := cmd.Flags().GetString("filter")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
-			}
-			dryRun, err := cmd.Flags().GetBool("dry-run")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
-			}
-
 			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
@@ -57,10 +51,6 @@ func Command() *cobra.Command {
 
 			// Initialize task queue.
 			// Use the warnings queue to make sure that failure in one score calculation task doesn't abort the whole queue.
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, jobs)
 			defer wait()
 
@@ -105,9 +95,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().String("filter", "", "Filter selected resources")
-	cmd.Flags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.Flags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().StringVar(&filter, "filter", "", "filter selected resources")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/compute/vocabulary/vocabulary.go
+++ b/cmd/registry/cmd/compute/vocabulary/vocabulary.go
@@ -37,6 +37,9 @@ import (
 )
 
 func Command() *cobra.Command {
+	var filter string
+	var jobs int
+	var dryRun bool
 	cmd := &cobra.Command{
 		Use:   "vocabulary SPEC_REVISION",
 		Short: "Compute vocabularies of API specs",
@@ -49,24 +52,11 @@ func Command() *cobra.Command {
 			}
 			path := c.FQName(args[0])
 
-			filter, err := cmd.Flags().GetString("filter")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get filter from flags")
-			}
-			dryRun, err := cmd.Flags().GetBool("dry-run")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get dry-run from flags")
-			}
-
 			client, err := connection.NewRegistryClientWithSettings(ctx, c)
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Fatal("Failed to get client")
 			}
 			// Initialize task queue.
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, jobs)
 			defer wait()
 
@@ -100,9 +90,9 @@ func Command() *cobra.Command {
 			}
 		},
 	}
-	cmd.PersistentFlags().String("filter", "", "Filter selected resources")
-	cmd.PersistentFlags().Bool("dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
-	cmd.PersistentFlags().Int("jobs", 10, "Number of actions to perform concurrently")
+	cmd.Flags().StringVar(&filter, "filter", "", "filter selected resources")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "if set, computation results will only be printed and will not stored in the registry")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/csv.go
+++ b/cmd/registry/cmd/upload/csv.go
@@ -100,6 +100,8 @@ func csvCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&projectID, "project-id", "", "project ID to use for each upload (deprecated)")
+	cmd.Flags().StringVar(&parent, "parent", "", "parent for the upload (projects/PROJECT/locations/LOCATION)")
 	cmd.Flags().StringVar(&delimiter, "delimiter", ",", "field delimiter for the CSV file")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd

--- a/cmd/registry/cmd/upload/discovery.go
+++ b/cmd/registry/cmd/upload/discovery.go
@@ -49,6 +49,7 @@ func fetchDiscoveryList(service string) (*discovery.List, error) {
 
 func discoveryCommand() *cobra.Command {
 	var service string
+	var jobs int
 	cmd := &cobra.Command{
 		Use:   "discovery",
 		Args:  cobra.NoArgs,
@@ -67,10 +68,6 @@ func discoveryCommand() *cobra.Command {
 				return fmt.Errorf("parent does not exist (%s)", err)
 			}
 			// create a queue for upload tasks and wait for the workers to finish after filling it.
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, jobs)
 			defer wait()
 
@@ -93,8 +90,11 @@ func discoveryCommand() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&projectID, "project-id", "", "project ID to use for each upload (deprecated)")
+	cmd.Flags().StringVar(&parent, "parent", "", "parent for the upload (projects/PROJECT/locations/LOCATION)")
 	cmd.Flags().StringVar(&service, "service", "",
 		fmt.Sprintf("the API Discovery Service URL (default %s)", discovery.APIsListServiceURL))
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/openapi.go
+++ b/cmd/registry/cmd/upload/openapi.go
@@ -40,6 +40,7 @@ const openAPISpecID = "openapi"
 
 func openAPICommand() *cobra.Command {
 	var baseURI string
+	var jobs int
 	cmd := &cobra.Command{
 		Use:   "openapi DIRECTORY",
 		Short: "Upload OpenAPI descriptions from a directory of specs",
@@ -58,10 +59,6 @@ func openAPICommand() *cobra.Command {
 				return fmt.Errorf("parent does not exist (%s)", err)
 			}
 			// create a queue for upload tasks and wait for the workers to finish after filling it.
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, jobs)
 			defer wait()
 
@@ -76,7 +73,10 @@ func openAPICommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&projectID, "project-id", "", "project ID to use for each upload (deprecated)")
+	cmd.Flags().StringVar(&parent, "parent", "", "parent for the upload (projects/PROJECT/locations/LOCATION)")
 	cmd.Flags().StringVar(&baseURI, "base-uri", "", "prefix to use for the source_uri field of each spec upload")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/protos.go
+++ b/cmd/registry/cmd/upload/protos.go
@@ -57,6 +57,7 @@ type ServiceConfig struct {
 func protosCommand() *cobra.Command {
 	var baseURI string
 	var root string
+	var jobs int
 	cmd := &cobra.Command{
 		Use:   "protos DIRECTORY",
 		Short: "Upload Protocol Buffer descriptions from a directory of specs",
@@ -75,10 +76,6 @@ func protosCommand() *cobra.Command {
 				return fmt.Errorf("parent does not exist (%s)", err)
 			}
 			// create a queue for upload tasks and wait for the workers to finish after filling it.
-			jobs, err := cmd.Flags().GetInt("jobs")
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Fatal("Failed to get jobs from flags")
-			}
 			taskQueue, wait := tasks.WorkerPoolIgnoreError(ctx, jobs)
 			defer wait()
 
@@ -104,8 +101,11 @@ func protosCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&projectID, "project-id", "", "project ID to use for each upload (deprecated)")
+	cmd.Flags().StringVar(&parent, "parent", "", "parent for the upload (projects/PROJECT/locations/LOCATION)")
 	cmd.Flags().StringVar(&root, "protoc-root", "", "root directory to use for proto compilation, defaults to PATH")
 	cmd.Flags().StringVar(&baseURI, "base-uri", "", "prefix to use for the source_uri field of each proto upload")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 10, "number of actions to perform concurrently")
 	return cmd
 }
 

--- a/cmd/registry/cmd/upload/upload.go
+++ b/cmd/registry/cmd/upload/upload.go
@@ -33,25 +33,16 @@ func Command() *cobra.Command {
 	cmd.AddCommand(discoveryCommand())
 	cmd.AddCommand(openAPICommand())
 	cmd.AddCommand(protosCommand())
-
-	cmd.PersistentFlags().String("project-id", "", "project ID to use for each upload (deprecated)")
-	cmd.PersistentFlags().String("parent", "", "parent for the upload (projects/PROJECT/locations/LOCATION)")
-	cmd.PersistentFlags().IntP("jobs", "j", 10, "number of actions to perform concurrently")
-
 	return cmd
 }
+
+// shared among all subcommands
+var parent string
+var projectID string
 
 func getParent(cmd *cobra.Command) (string, error) {
 	ctx := cmd.Context()
 
-	parent, err := cmd.Flags().GetString("parent")
-	if err != nil {
-		return "", fmt.Errorf("failed to get parent from flags (%s)", err)
-	}
-	projectID, err := cmd.Flags().GetString("project-id")
-	if err != nil {
-		return "", fmt.Errorf("failed to get project-id from flags (%s)", err)
-	}
 	if projectID != "" && parent != "" {
 		return "", errors.New("--project-id cannot be used with --parent")
 	}

--- a/cmd/registry/cmd/upload/upload_test.go
+++ b/cmd/registry/cmd/upload/upload_test.go
@@ -54,7 +54,7 @@ func TestParentFromFlags(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			cmd := Command()
+			cmd := protosCommand()
 			cmd.SetContext(context.Background())
 			if err := cmd.ParseFlags(test.args); err != nil {
 				t.Fatalf("Failed to parse flags")


### PR DESCRIPTION
Fixes #1129.

This converts everything except flags in automatically-generated CLI methods and `pkg/config`.