### PR TITLE
Loosen test constraint (appropriately)

### DIFF
--- a/cmd/registry/tasks/tasks_test.go
+++ b/cmd/registry/tasks/tasks_test.go
@@ -64,8 +64,8 @@ func TestWorkerPoolStopOnError(t *testing.T) {
 	}()
 
 	got := counter.Load()
-	if got < int32(errorAt) || got >= int32(total) {
-		t.Errorf("want between %d and %d, got: %d", errorAt, total, got)
+	if got < int32(errorAt) || got > int32(total) {
+		t.Errorf("want from %d to %d, got: %d", errorAt, total, got)
 	}
 }
 


### PR DESCRIPTION
`TestWorkerPoolStopOnError` was intermittently failing with a count of 1000, which should be in the acceptable range.