### PR TITLE
Use "global" as the default location when location is unspecified (i.e. empty).

### DIFF
--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -84,6 +84,9 @@ func (c Config) FQName(name string) string {
 			name = path.Join("projects", c.Project, name)
 		} else if c.Location != "" {
 			name = path.Join("projects", c.Project, "locations", c.Location, name)
+		} else {
+			// Use "global" as the default location.
+			name = path.Join("projects", c.Project, "locations", "global", name)
 		}
 	}
 	return name

--- a/pkg/connection/config_test.go
+++ b/pkg/connection/config_test.go
@@ -44,6 +44,30 @@ func TestFQNamePartialConfig(t *testing.T) {
 	}
 }
 
+func TestFQNameUnspecifiedLocation(t *testing.T) {
+	data := []struct {
+		input string
+		want  string
+	}{
+		{"locations/foo", "projects/project1/locations/foo"},
+		{"/locations/foo", "projects/project1/locations/foo"},
+		{"apis/foo", "projects/project1/locations/global/apis/foo"},
+		{"/apis/foo", "projects/project1/locations/global/apis/foo"},
+	}
+
+	c := Config{
+		Project: "project1",
+	}
+	for _, d := range data {
+		t.Run(d.input, func(t *testing.T) {
+			got := c.FQName(d.input)
+			if d.want != got {
+				t.Errorf("want: %q, got: %q", d.want, got)
+			}
+		})
+	}
+}
+
 func TestFQNameFullConfig(t *testing.T) {
 	data := []struct {
 		input string


### PR DESCRIPTION
Fixes #1105.