### PR TITLE
update actions/checkout version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         registry: ${{ env.REGISTRY }}
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         registry: ${{ env.REGISTRY }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
Addresses [build warning](https://github.com/apigee/registry/actions/runs/4692896484):

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```