### PR TITLE
github action to install and setup the registry cli tool

### DIFF
--- a/.github/actions/setup-registry/action.yml
+++ b/.github/actions/setup-registry/action.yml
@@ -1,0 +1,54 @@
+name: Configure Registry
+description: Install and configure Apigee Registry CLI.
+author: Apigee Registry Authors
+branding:
+  color: red
+  icon: cloud-lightning
+inputs:
+  project:
+    description: The Registry project.
+    required: true
+  version:
+    description: The Registry version label to use.
+    required: false
+    default: latest
+  name:
+    description: The config name to create.
+    required: false
+    default: default
+  address:
+    description: The server and port of the Registry API.
+    required: true
+  insecure:
+    description: If true, client connects via http (not https).
+    required: false
+  location:
+    description: The Registry location.
+    required: false
+    default: global
+  token:
+    description: A token to use for authorization to the Registry.
+    required: false
+  token-source:
+    description: A shell command to use to generate an authorization token for the Registry.
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Install the Registry CLI
+      shell: bash
+      run: |
+        if ! command -v registry &> /dev/null; then
+          export REGISTRY_VERSION=${{ inputs.version }}
+          curl -L https://raw.githubusercontent.com/apigee/registry/main/downloadLatest.sh | sh -
+          echo "$HOME/.registry/bin" >> $GITHUB_PATH
+        fi
+    - name: Configure the Apigee Registry CLI
+      shell: bash
+      run: |
+        registry config configurations create '${{ inputs.name }}'
+        registry config set address '${{ inputs.address }}'
+        registry config set token-source '${{ inputs.token-source }}'
+        registry config set location '${{ inputs.location }}'
+        registry config set project '${{ inputs.project }}'
+        registry config set insecure '${{ inputs.insecure }}'


### PR DESCRIPTION
Fixes #1149

Example for a local registry:

``` yaml
    services:
      local-registry:
        image: ghcr.io/apigee/registry-server:main
        env:
          REGISTRY_LOGGING_LEVEL: debug
        ports:
          - 8080:8080
    steps:
    - name: Configure local Registry
      uses: apigee/registry/.github/actions/registry-config
      with:
        name: local
        address: localhost:8080
        insecure: true
        version: v0.6.10
        project: test
    - name: Create a project
      run: registry rpc admin create-project --project_id test
```

Example for a remote registry:

``` yaml
    - name: Set up Google Cloud auth
      uses: google-github-actions/auth@v1
      with:
        credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
    - name: Set up the Google Cloud SDK
      uses: google-github-actions/setup-gcloud@v1
      with:
        skip_install: true
    - name: Capture GOOGLE_CLOUD_PROJECT env var
      run: echo "GOOGLE_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT" >> $GITHUB_ENV
    - name: Verify the Google Cloud SDK installation
      run: gcloud info
    - uses: apigee/registry/.github/actions/registry-config
      with:
        name: cloud
        project: ${{ env.GOOGLE_CLOUD_PROJECT }}
        address: apigeeregistry.googleapis.com:443
        token-source: gcloud auth print-access-token
        insecure: false
```
