### PR TITLE
show available plugins in registry cli

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -79,7 +79,7 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
 
 Available Plugins:
 {{- range Plugins}}
-  {{.}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{.}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -17,12 +17,20 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
 
 	"github.com/apigee/registry/cmd/registry/cmd"
 	"github.com/apigee/registry/pkg/log"
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
 )
+
+const pluginPrefix string = "registry-"
 
 func main() {
 	// Bind a logger instance to the local context with metadata for outbound requests.
@@ -32,10 +40,90 @@ func main() {
 	})
 
 	cmd := cmd.Command()
+	cmd.SetUsageTemplate(usageTemplate)
+	cobra.AddTemplateFunc("Plugins", plugins)
+
+	staySilent := cmd.SilenceErrors
+	cmd.SilenceErrors = true // don't print "unknown command" error
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		fmt.Println("----")
-		fmt.Println("Need more help?")
-		fmt.Println("https://github.com/apigee/registry/wiki")
+		if strings.HasPrefix(err.Error(), "unknown command") && contains(plugins(), os.Args[1]) {
+			exCmd, err := exec.LookPath(pluginPrefix + os.Args[1])
+			if err == nil {
+				if err := syscall.Exec(exCmd, append([]string{exCmd}, os.Args[2:]...), os.Environ()); err != nil {
+					fmt.Fprintf(os.Stderr, "Command finished with error: %v", err)
+					os.Exit(127)
+				}
+			}
+		}
+		if !staySilent {
+			cmd.PrintErrln("Error:", err.Error())
+			cmd.PrintErrf("Run '%v --help' for usage.\n", cmd.CommandPath())
+		}
 		os.Exit(1)
 	}
+}
+
+// adds `Available Plugins` and `Need more help?` sections to default
+const usageTemplate = `Usage:{{if .Runnable}}
+{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+{{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Available Plugins:
+{{- range Plugins}}
+  {{.}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+
+Need more help?
+https://github.com/apigee/registry/wiki
+`
+
+// list of executable files on path matching `registry-*
+func plugins() []string {
+	plugs := []string{}
+	paths := filepath.SplitList(os.Getenv("PATH"))
+	for _, path := range paths {
+		if files, err := ioutil.ReadDir(path); err == nil {
+			for _, file := range files {
+				if strings.HasPrefix(file.Name(), pluginPrefix) {
+					plug := strings.TrimPrefix(file.Name(), pluginPrefix)
+					if !contains(plugs, plug) {
+						if info, err := os.Stat(filepath.Join(path, file.Name())); err == nil {
+							if info.Mode()&0o111 != 0 {
+								plugs = append(plugs, plug)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return plugs
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #1154

Adds list of plugins to usage page and allows execution of these directly in registry command. Also moves `Need more help?` wiki link direclty into usage template. See below.

This is a very basic implementation in that it only looks for `registry-*` filenames on the path and doesn't have any information about the plugins. 

But give it a try and see what you think.

```
$ registry -h
A command-line tool for working with the API Registry

Usage:
registry [command]

Available Commands:
annotate    Annotate resources in the API Registry
apply       Apply YAML to the API Registry
auth        Manage authentication to the API Registry
check       Check entities in the API Registry
completion  Generate the autocompletion script for the specified shell
compute     Compute properties of resources in the API Registry
config      Maintain properties in the active configuration
delete      Delete resources from the API Registry
diff        Compare resources in the API Registry
export      Export resources from the API Registry
get         Get resources from the API Registry
help        Help about any command
label       Label resources in the API Registry
resolve     Resolve dependencies by performing actions in a specified manifest
rpc         Make direct calls to RPC methods
upload      Upload information to the API Registry

Available Plugins:
basenames
connect
decode-spec
encode-spec
experimental
graphql
lint-api-linter
lint-openapi-sample
lint-sample
lint-spectral
lint-test
server

Flags:
      --address string             the server and port of the Registry API (eg. localhost:8080)
  -c, --config string              name of a configuration profile or path to config file
  -h, --help                       help for registry
      --registry.address string    the server and port of the Registry API (eg. localhost:8080)
      --registry.insecure          if specified, client connects via http (not https)
      --registry.location string   the API Registry location
      --registry.project string    the API Registry project
      --registry.token string      the token to use for authorization to the API Registry
  -v, --version                    version for registry

Use "registry [command] --help" for more information about a command.

Need more help?
https://github.com/apigee/registry/wiki
```