### PR TITLE
Only print Available Plugins when the list is not empty.

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -90,7 +90,7 @@ Examples:
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if gt (len Plugins) 0}}
 
 Available Plugins:
 {{- range Plugins}}


### PR DESCRIPTION
Fixes #1179.