### PR TITLE
Indent usage string, available commands, and available plugins

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -81,7 +81,7 @@ func main() {
 // adds `Available Plugins` and `Need more help?` sections to default
 const usageTemplate = `Usage:{{if .Runnable}}
 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
 {{.NameAndAliases}}{{end}}{{if .HasExample}}
@@ -90,11 +90,11 @@ Examples:
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if gt (len Plugins) 0}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if gt (len Plugins) 0}}
 
 Available Plugins:
 {{- range Plugins}}
-{{.}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{.}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}


### PR DESCRIPTION
Produces:
```
$ registry
A command-line tool for working with the API Registry

Usage:
  registry [command]

Available Commands:
  annotate    Annotate resources in the API Registry
  apply       Apply YAML to the API Registry
  auth        Manage authentication to the API Registry
  check       Check entities in the API Registry
  completion  Generate the autocompletion script for the specified shell
  compute     Compute properties of resources in the API Registry
  config      Maintain properties in the active configuration
  delete      Delete resources from the API Registry
  diff        Compare resources in the API Registry
  export      Export resources from the API Registry
  get         Get resources from the API Registry
  help        Help about any command
  label       Label resources in the API Registry
  resolve     Resolve dependencies by performing actions in a specified manifest
  rpc         Make direct calls to RPC methods
  upload      Upload information to the API Registry

Available Plugins:
  connect
  experimental
```