### PR TITLE
migrate should run without --no-migrate flag

### DIFF
--- a/cmd/registry-server/main.go
+++ b/cmd/registry-server/main.go
@@ -157,7 +157,7 @@ func main() {
 		LogFormat: config.Logging.Format,
 		Notify:    config.Pubsub.Enable,
 		ProjectID: config.Pubsub.Project,
-		NoMigrate: !noMigrate,
+		NoMigrate: noMigrate,
 	})
 	if err != nil {
 		logger.WithError(err).Fatalf("Failed to create registry server")


### PR DESCRIPTION
Fixes an issue with https://github.com/apigee/registry/pull/1207 where --no-migrate flag meaning was reversed. 