### PR TITLE
Trim the "@-" suffix from resource names before calling the List*Revisions APIs.

### DIFF
--- a/pkg/visitor/list.go
+++ b/pkg/visitor/list.go
@@ -17,6 +17,7 @@ package visitor
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apigee/registry/cmd/registry/compress"
 	"github.com/apigee/registry/gapic"
@@ -132,7 +133,8 @@ func ListDeploymentRevisions(ctx context.Context,
 	filter string,
 	handler DeploymentHandler) error {
 	it := client.ListApiDeploymentRevisions(ctx, &rpc.ListApiDeploymentRevisionsRequest{
-		Name:     name.String(),
+		// "@-" indicates a collection of revisions, but we only want to send the resource name to the List RPC.
+		Name:     strings.TrimSuffix(name.String(), "@-"),
 		PageSize: pageSize,
 		Filter:   filter,
 	})
@@ -234,7 +236,8 @@ func ListSpecRevisions(ctx context.Context,
 	getContents bool,
 	handler SpecHandler) error {
 	it := client.ListApiSpecRevisions(ctx, &rpc.ListApiSpecRevisionsRequest{
-		Name:     name.String(),
+		// "@-" indicates a collection of revisions, but we only want to send the resource name to the List RPC.
+		Name:     strings.TrimSuffix(name.String(), "@-"),
 		PageSize: pageSize,
 		Filter:   filter,
 	})


### PR DESCRIPTION
This fixes a problem that @theganyo discovered in which calls to hosted versions of the `ListApiSpecRevisions` and `ListApiDeploymentRevisions` failed when `@-` was appended to the resource names. These suffixes were being included in the [name](https://github.com/apigee/registry/blob/bce42327880e246c3d71072ce3481084b43aa8f4/google/cloud/apigeeregistry/v1/registry_service.proto#L793) arguments, which is strictly expected to be a resource name (and not a pattern that matches collections). The core implementation accidentally supports these modified names, but hosted implementations may not, because it is out of spec, and agreeing with that, we trim the `@-` from these names before passing them as arguments.

This is a Postel's Law solution -- the `visitor` package is now conservative in the requests that it generates but the core server is liberal (permissive) in what it accepts. Should we create an issue to tighten that?