### PR TITLE
Add snyk scan workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Snyk
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # each Sunday at 12:00 AM UTC
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/golang@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Add workflow to run snyk scan following Snyk documentation: https://docs.snyk.io/integrations/snyk-ci-cd-integrations/github-actions-integration/snyk-golang-action.

This workflow can be run manually and will automatically run once a week Sunday night. For now, this is just configured to run `snyk test` - https://docs.snyk.io/snyk-cli/commands/test. This will scan the repo for vulnerability and license issues and the cli will exit with 1 if any are found.

An example run is here: https://github.com/hansatgoogle/registry/actions/runs/6123960183/job/16622986936. As you can see, this currently finds an issue with a MPL-2.0 license. I don't think that's a concern for us as we aren't likely to modify that library. To get this scan to pass, we could create a custom license policy in snyk (https://docs.snyk.io/manage-risk/policies/license-policies) or remove the dependency if it's not needed.

I've already added `SNYK_TOKEN` as a repository secret, so the action should work once merged.