### PR TITLE
connection.ActiveConfig() should use config.Active() instead of reading configuration directly

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,7 +161,11 @@ func ReadValid(name string) (c Configuration, err error) {
 	var r io.Reader = &bytes.Buffer{}
 	if file != "" {
 		if dir == "" {
-			name = filepath.Join(Directory, file)
+			// If name refers to a local file, preferentially read the local file.
+			// Otherwise assume name refers to a file in the config directory.
+			if info, err := os.Stat(file); errors.Is(err, os.ErrNotExist) || info.IsDir() {
+				name = filepath.Join(Directory, file)
+			}
 		}
 		r, err = os.Open(name)
 		if err != nil {

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -514,4 +514,21 @@ func TestReadExternalFile(t *testing.T) {
 	if c3.Registry.Address != c.Registry.Address {
 		t.Errorf("want: %s, got: %s", c3.Registry.Address, c.Registry.Address)
 	}
+	// Repeat the above with config.ReadValid
+	// Verify that we can read a file using its full path name.
+	c4, err := config.ReadValid(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c4.Registry.Address != c.Registry.Address {
+		t.Errorf("want: %s, got: %s", c4.Registry.Address, c.Registry.Address)
+	}
+	// Verify that we can read a local file using its base name.
+	c5, err := config.ReadValid(filepath.Base(f.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c5.Registry.Address != c.Registry.Address {
+		t.Errorf("want: %s, got: %s", c5.Registry.Address, c.Registry.Address)
+	}
 }

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -46,12 +46,17 @@ func ActiveConfig() (Config, error) {
 		return *active, nil
 	}
 
-	name, err := config.ActiveName()
+	c, err := config.Active()
 	if err != nil {
 		return Config{}, err
 	}
-
-	return ReadConfig(name)
+	return Config{
+		Address:  c.Registry.Address,
+		Insecure: c.Registry.Insecure,
+		Location: c.Registry.Location,
+		Project:  c.Registry.Project,
+		Token:    c.Registry.Token,
+	}, nil
 }
 
 // Reads a Config from a file. If name is empty, no


### PR DESCRIPTION
Fixes #1231

`config.Active()` [supports the `--config` flag](https://github.com/timburks/registry/blob/d0fe7e5d450b2f71fbaf1e24d62cea244928cfba/pkg/config/config.go#L115) where the previous code for `connection.ActiveConfig()` does not.